### PR TITLE
Allow custom output filenames

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ npm install node-getopt mkdirp xml2js color-names
 **Typical use:** `./fixtures_convert.js -f qlcplus`  
 formats `fixtures.json` as *QLC+* and writes the resulting fixture definition `.qxf` files to `out/qlcplus/`
 
-**Import:** `./fixtures_convert.js -i UserLibrary.xml -f ecue`  
-imports `UserLibrary.xml` as *e:cue* format and writes the resulting JSON file to `out/ecue/import_YYYY-MM-DD_hh:mm:ss.json`
+**Import:** `./fixtures_convert.js -i UserLibrary.xml -f ecue -o out/%FORMAT%/%MANUFACTURER%.json`  
+imports `UserLibrary.xml` as *e:cue* format and writes the resulting JSON files (separated by manufacturer) to `out/ecue/%MANUFACTURER%.json`
 
 
 ## Contributing
@@ -69,15 +69,19 @@ Feel free to add your own output formats and / or fixtures. Just create a pull r
 
 ### New formats
 
-Each format may implement two functions:
+Each format module may look like this:
 
 ```js
 // required
 module.exports.defaultFileName = '%MANUFACTURER%-%FIXTURE%.xml';
 
-// both are optional
-module.exports.export = function(manufacturers, fixtures, localOutDir) { ... }
+// both functions are optional
+module.exports.export = function(manufacturers, fixtures, optionsOutput) {
+    // optionsOutput contains the -o command line parameter with %FORMAT% already replaced
+    ...
+}
 module.exports.import = function(str, filename) {
+    // str is the string to be parsed, filename is just for helpful error messages
     ...
     // use a promise to allow asynchronous return values
     return new Promise((resolve, reject) => {
@@ -85,6 +89,9 @@ module.exports.import = function(str, filename) {
         resolve(objectToConvertToJSON);
     });
 }
+
+// optional
+function privateHelperFunction() { ... }
 ```
 
 Those will get called from [fixtures_convert.js](fixtures_convert.js), so you won't have to bother with command line arguments.

--- a/README.md
+++ b/README.md
@@ -72,6 +72,10 @@ Feel free to add your own output formats and / or fixtures. Just create a pull r
 Each format may implement two functions:
 
 ```js
+// required
+module.exports.defaultFileName = '%MANUFACTURER%-%FIXTURE%.xml';
+
+// both are optional
 module.exports.export = function(manufacturers, fixtures, localOutDir) { ... }
 module.exports.import = function(str, filename) {
     ...

--- a/fixtures/imports/ecue-MainLibrary/5Star-Systems.json
+++ b/fixtures/imports/ecue-MainLibrary/5Star-Systems.json
@@ -1,0 +1,377 @@
+{
+    "manufacturers": {
+        "5Star Systems": {
+            "name": "5Star Systems",
+            "website": "www.5star-systems.com"
+        }
+    },
+    "fixtures": [
+        {
+            "manufacturer": "5Star Systems",
+            "name": "Spica 250M",
+            "shortName": "Spica250M",
+            "comment": "cd",
+            "physical": {
+                "dimensions": [400, 400, 494]
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "P/T Speed": {
+                    "type": "Speed",
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "track"
+                        },
+                        {
+                            "range": [1, 249],
+                            "name": "speed"
+                        },
+                        {
+                            "range": [250, 255],
+                            "name": "MIB"
+                        }
+                    ]
+                },
+                "Reset": {
+                    "type": "Beam",
+                    "defaultValue": 170,
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "fan speed"
+                        },
+                        {
+                            "range": [128, 139],
+                            "name": "lamp on"
+                        },
+                        {
+                            "range": [140, 179],
+                            "name": "idle"
+                        },
+                        {
+                            "range": [180, 189],
+                            "name": "reset"
+                        },
+                        {
+                            "range": [190, 229],
+                            "name": "idle"
+                        },
+                        {
+                            "range": [230, 239],
+                            "name": "lamp off"
+                        },
+                        {
+                            "range": [240, 255],
+                            "name": "idle"
+                        }
+                    ]
+                },
+                "Colours": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 13],
+                            "name": "open"
+                        },
+                        {
+                            "range": [14, 27],
+                            "name": "yellow",
+                            "color": "#ffff00"
+                        },
+                        {
+                            "range": [28, 41],
+                            "name": "orange",
+                            "color": "#ff7f00"
+                        },
+                        {
+                            "range": [42, 55],
+                            "name": "red",
+                            "color": "#ff0000"
+                        },
+                        {
+                            "range": [56, 69],
+                            "name": "blue",
+                            "color": "#0000ff"
+                        },
+                        {
+                            "range": [70, 83],
+                            "name": "green",
+                            "color": "#00ff00"
+                        },
+                        {
+                            "range": [84, 97],
+                            "name": "pink",
+                            "color": "#ffc0cb"
+                        },
+                        {
+                            "range": [98, 111],
+                            "name": "turquoise",
+                            "color": "#40e0d0"
+                        },
+                        {
+                            "range": [112, 127],
+                            "name": "deep purple"
+                        },
+                        {
+                            "range": [128, 189],
+                            "name": ">>"
+                        },
+                        {
+                            "range": [190, 193],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [194, 255],
+                            "name": "<<"
+                        }
+                    ]
+                },
+                "Prisma": {
+                    "type": "Prism",
+                    "capabilities": [
+                        {
+                            "range": [0, 95],
+                            "name": "open"
+                        },
+                        {
+                            "range": [96, 159],
+                            "name": "prisma"
+                        },
+                        {
+                            "range": [160, 167],
+                            "name": "macro1"
+                        },
+                        {
+                            "range": [168, 175],
+                            "name": "macro2"
+                        },
+                        {
+                            "range": [176, 183],
+                            "name": "macro3"
+                        },
+                        {
+                            "range": [184, 191],
+                            "name": "macro4"
+                        },
+                        {
+                            "range": [192, 199],
+                            "name": "macro5"
+                        },
+                        {
+                            "range": [200, 207],
+                            "name": "macro6"
+                        },
+                        {
+                            "range": [208, 215],
+                            "name": "macro7"
+                        },
+                        {
+                            "range": [216, 223],
+                            "name": "macro8"
+                        },
+                        {
+                            "range": [224, 231],
+                            "name": "macro9"
+                        },
+                        {
+                            "range": [232, 239],
+                            "name": "macro10"
+                        },
+                        {
+                            "range": [240, 247],
+                            "name": "macro11"
+                        },
+                        {
+                            "range": [248, 255],
+                            "name": "macro12"
+                        }
+                    ]
+                },
+                "Prism rot.": {
+                    "type": "Prism",
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [1, 126],
+                            "name": ">>"
+                        },
+                        {
+                            "range": [127, 128],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [129, 255],
+                            "name": "<<"
+                        }
+                    ]
+                },
+                "Gobo": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 31],
+                            "name": "open"
+                        },
+                        {
+                            "range": [32, 63],
+                            "name": "slot1"
+                        },
+                        {
+                            "range": [64, 95],
+                            "name": "slot2"
+                        },
+                        {
+                            "range": [96, 127],
+                            "name": "slot3"
+                        },
+                        {
+                            "range": [128, 159],
+                            "name": "slot4"
+                        },
+                        {
+                            "range": [160, 223],
+                            "name": "slot5"
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": ">>"
+                        }
+                    ]
+                },
+                "Gobo rot.": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "index"
+                        },
+                        {
+                            "range": [128, 190],
+                            "name": ">>"
+                        },
+                        {
+                            "range": [191, 192],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [193, 255],
+                            "name": "<<"
+                        }
+                    ]
+                },
+                "Focus": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Shutter": {
+                    "type": "Shutter",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 31],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [32, 63],
+                            "name": "idle"
+                        },
+                        {
+                            "range": [64, 95],
+                            "name": "strobe"
+                        },
+                        {
+                            "range": [96, 127],
+                            "name": "idle"
+                        },
+                        {
+                            "range": [128, 159],
+                            "name": "pulse"
+                        },
+                        {
+                            "range": [160, 191],
+                            "name": "idle"
+                        },
+                        {
+                            "range": [192, 223],
+                            "name": "random"
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "idle"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "16-channel Mode",
+                    "shortName": "16ch",
+                    "channels": [
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "P/T Speed",
+                        "Reset",
+                        "Colours",
+                        null,
+                        "Prisma",
+                        "Prism rot.",
+                        "Gobo",
+                        "Gobo rot.",
+                        null,
+                        "Focus",
+                        "Shutter",
+                        "Intensity"
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/fixtures/imports/ecue-MainLibrary/AO.json
+++ b/fixtures/imports/ecue-MainLibrary/AO.json
@@ -1,0 +1,540 @@
+{
+    "manufacturers": {
+        "AO": {
+            "name": "AO"
+        }
+    },
+    "fixtures": [
+        {
+            "manufacturer": "AO",
+            "name": "Beam Color",
+            "shortName": "BeamCol",
+            "comment": "cd",
+            "physical": {
+                "dimensions": [800, 800, 1600]
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Zoom": {
+                    "type": "Beam",
+                    "highlightValue": 128,
+                    "crossfade": true
+                },
+                "Control": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 26],
+                            "name": "idle"
+                        },
+                        {
+                            "range": [27, 77],
+                            "name": "lamp off"
+                        },
+                        {
+                            "range": [78, 127],
+                            "name": "lamp on"
+                        },
+                        {
+                            "range": [128, 199],
+                            "name": "reset"
+                        },
+                        {
+                            "range": [200, 255],
+                            "name": "fan"
+                        }
+                    ]
+                },
+                "Elec. Dimmer": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Strobe": {
+                    "type": "Strobe",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 20],
+                            "name": "open"
+                        },
+                        {
+                            "range": [21, 255],
+                            "name": "strobe"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Scroller": {
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "crossfade": true
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "12-channel Mode",
+                    "shortName": "12ch",
+                    "channels": [
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "Zoom",
+                        null,
+                        null,
+                        "Control",
+                        "Elec. Dimmer",
+                        "Strobe",
+                        "Intensity",
+                        "Scroller"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "AO",
+            "name": "Beam Flower",
+            "shortName": "BeamFlw",
+            "comment": "cd",
+            "physical": {
+                "dimensions": [800, 800, 1600]
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Flower rot.": {
+                    "type": "Beam",
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 100],
+                            "name": "<<"
+                        },
+                        {
+                            "range": [101, 155],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [156, 255],
+                            "name": ">>"
+                        }
+                    ]
+                },
+                "Control": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 26],
+                            "name": "idle"
+                        },
+                        {
+                            "range": [27, 77],
+                            "name": "lamp off"
+                        },
+                        {
+                            "range": [78, 127],
+                            "name": "lamp on"
+                        },
+                        {
+                            "range": [128, 199],
+                            "name": "reset"
+                        },
+                        {
+                            "range": [200, 255],
+                            "name": "fan"
+                        }
+                    ]
+                },
+                "Elec. Dimmer": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Strobe": {
+                    "type": "Strobe",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 20],
+                            "name": "open"
+                        },
+                        {
+                            "range": [21, 255],
+                            "name": "strobe"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Scroller": {
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "crossfade": true
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "12-channel Mode",
+                    "shortName": "12ch",
+                    "channels": [
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        null,
+                        "Flower rot.",
+                        null,
+                        "Control",
+                        "Elec. Dimmer",
+                        "Strobe",
+                        "Intensity",
+                        "Scroller"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "AO",
+            "name": "Falcon ARC Color",
+            "shortName": "ARC Col",
+            "comment": "cd",
+            "physical": {
+                "dimensions": [800, 800, 1600]
+            },
+            "availableChannels": {
+                "Cyan": {
+                    "type": "SingleColor",
+                    "color": "Cyan",
+                    "crossfade": true
+                },
+                "Yellow": {
+                    "type": "SingleColor",
+                    "color": "Yellow",
+                    "crossfade": true
+                },
+                "Magenta": {
+                    "type": "SingleColor",
+                    "color": "Magenta",
+                    "crossfade": true
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Control": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 26],
+                            "name": "idle"
+                        },
+                        {
+                            "range": [27, 50],
+                            "name": "lamp off"
+                        },
+                        {
+                            "range": [78, 100],
+                            "name": "lamp on"
+                        },
+                        {
+                            "range": [128, 150],
+                            "name": "Reset"
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "5-channel Mode",
+                    "shortName": "5ch",
+                    "channels": [
+                        "Cyan",
+                        "Yellow",
+                        "Magenta",
+                        "Intensity",
+                        "Control"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "AO",
+            "name": "Falcon LED",
+            "shortName": "Falcon LED",
+            "comment": "cd",
+            "physical": {
+                "dimensions": [400, 400, 300]
+            },
+            "availableChannels": {
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "White": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                }
+            },
+            "modes": [
+                {
+                    "name": "4-channel Mode",
+                    "shortName": "4ch",
+                    "channels": [
+                        "Red",
+                        "Green",
+                        "Blue",
+                        "White"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "AO",
+            "name": "Sperber mini",
+            "shortName": "Sperber",
+            "comment": "cd",
+            "physical": {
+                "dimensions": [400, 400, 900]
+            },
+            "availableChannels": {
+                "Rotation": {
+                    "type": "Beam",
+                    "highlightValue": 125,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 100],
+                            "name": "<<"
+                        },
+                        {
+                            "range": [101, 155],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [156, 255],
+                            "name": ">>"
+                        }
+                    ]
+                },
+                "Control": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 20],
+                            "name": "idle"
+                        },
+                        {
+                            "range": [27, 50],
+                            "name": "lamp off"
+                        },
+                        {
+                            "range": [51, 77],
+                            "name": "idle"
+                        },
+                        {
+                            "range": [78, 100],
+                            "name": "lamp on"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Strobe": {
+                    "type": "Strobe",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 20],
+                            "name": "open"
+                        },
+                        {
+                            "range": [21, 255],
+                            "name": "strobe"
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "4-channel Mode",
+                    "shortName": "4ch",
+                    "channels": [
+                        "Rotation",
+                        "Control",
+                        "Intensity",
+                        "Strobe"
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/fixtures/imports/ecue-MainLibrary/American-DJ.json
+++ b/fixtures/imports/ecue-MainLibrary/American-DJ.json
@@ -1,0 +1,301 @@
+{
+    "manufacturers": {
+        "American DJ": {
+            "name": "American DJ"
+        }
+    },
+    "fixtures": [
+        {
+            "manufacturer": "American DJ",
+            "name": "Focus Spot 250",
+            "shortName": "Focus Spot 250",
+            "physical": {
+                "dimensions": [450, 450, 560],
+                "weight": 23
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "highlightValue": null
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 0,
+                    "crossfade": true,
+                    "highlightValue": null
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "highlightValue": null
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 0,
+                    "crossfade": true,
+                    "highlightValue": null
+                },
+                "Color": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 13],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [14, 27],
+                            "name": "Red",
+                            "color": "#ff0000"
+                        },
+                        {
+                            "range": [28, 41],
+                            "name": "Blue",
+                            "color": "#0000ff"
+                        },
+                        {
+                            "range": [42, 55],
+                            "name": "Green",
+                            "color": "#00ff00"
+                        },
+                        {
+                            "range": [56, 69],
+                            "name": "Yellow",
+                            "color": "#ffff00"
+                        },
+                        {
+                            "range": [70, 83],
+                            "name": "Magenta",
+                            "color": "#ca1f7b"
+                        },
+                        {
+                            "range": [84, 97],
+                            "name": "Orange",
+                            "color": "#ff7f00"
+                        },
+                        {
+                            "range": [98, 111],
+                            "name": "UV"
+                        },
+                        {
+                            "range": [128, 187],
+                            "name": "Clr Roll CW"
+                        },
+                        {
+                            "range": [188, 193],
+                            "name": "No Func",
+                            "center": true
+                        },
+                        {
+                            "range": [194, 255],
+                            "name": "Clr Roll CCW"
+                        }
+                    ]
+                },
+                "Gobo": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 9],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [10, 19],
+                            "name": "Gobo 1"
+                        },
+                        {
+                            "range": [20, 29],
+                            "name": "Gobo 2"
+                        },
+                        {
+                            "range": [30, 39],
+                            "name": "Gobo 3"
+                        },
+                        {
+                            "range": [40, 49],
+                            "name": "Gobo 4"
+                        },
+                        {
+                            "range": [50, 59],
+                            "name": "Gobo 5"
+                        },
+                        {
+                            "range": [60, 69],
+                            "name": "Gobo 6"
+                        },
+                        {
+                            "range": [70, 189],
+                            "name": "Gobo Shake"
+                        },
+                        {
+                            "range": [190, 255],
+                            "name": "Gobo Roll"
+                        }
+                    ]
+                },
+                "Gobo Rot": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "Index"
+                        },
+                        {
+                            "range": [128, 187],
+                            "name": "Rot Fwd"
+                        },
+                        {
+                            "range": [188, 193],
+                            "name": "No Func",
+                            "center": true
+                        },
+                        {
+                            "range": [194, 255],
+                            "name": "Rot Back"
+                        }
+                    ]
+                },
+                "Shutter": {
+                    "type": "Shutter",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 31],
+                            "name": "Closed",
+                            "center": true
+                        },
+                        {
+                            "range": [32, 63],
+                            "name": "Dimmer"
+                        },
+                        {
+                            "range": [64, 95],
+                            "name": "Strobe"
+                        },
+                        {
+                            "range": [96, 127],
+                            "name": "No Func",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 159],
+                            "name": "Pulse"
+                        },
+                        {
+                            "range": [160, 191],
+                            "name": "No Func",
+                            "center": true
+                        },
+                        {
+                            "range": [192, 223],
+                            "name": "Random Strb"
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "No Func",
+                            "center": true
+                        }
+                    ]
+                },
+                "Control": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 19],
+                            "name": "Clr Normal",
+                            "center": true
+                        },
+                        {
+                            "range": [20, 39],
+                            "name": "Clr to Any",
+                            "center": true
+                        },
+                        {
+                            "range": [40, 59],
+                            "name": "Lamp ON",
+                            "center": true
+                        },
+                        {
+                            "range": [60, 79],
+                            "name": "Lamp OFF",
+                            "center": true
+                        },
+                        {
+                            "range": [80, 99],
+                            "name": "Mtr Reset",
+                            "center": true
+                        },
+                        {
+                            "range": [100, 255],
+                            "name": "Programs"
+                        }
+                    ]
+                },
+                "Speed": {
+                    "type": "Speed",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 225],
+                            "name": "Speed"
+                        },
+                        {
+                            "range": [226, 235],
+                            "name": "Blk Move",
+                            "center": true
+                        },
+                        {
+                            "range": [236, 245],
+                            "name": "Blk Wheels",
+                            "center": true
+                        },
+                        {
+                            "range": [246, 255],
+                            "name": "No Func",
+                            "center": true
+                        }
+                    ]
+                },
+                "Focus": {
+                    "type": "Beam",
+                    "crossfade": true
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "11-channel Mode",
+                    "shortName": "11ch",
+                    "channels": [
+                        "Pan",
+                        "Tilt",
+                        "Color",
+                        "Gobo",
+                        "Gobo Rot",
+                        "Shutter",
+                        "Control",
+                        "Speed",
+                        "Focus",
+                        "Pan fine",
+                        "Tilt fine"
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/fixtures/imports/ecue-MainLibrary/Amptown.json
+++ b/fixtures/imports/ecue-MainLibrary/Amptown.json
@@ -1,0 +1,1769 @@
+{
+    "manufacturers": {
+        "Amptown": {
+            "name": "Amptown",
+            "website": "www.amptown-lichttechnik.de"
+        }
+    },
+    "fixtures": [
+        {
+            "manufacturer": "Amptown",
+            "name": "AmpMount",
+            "shortName": "AmpMount",
+            "physical": {
+                "dimensions": [100, 100, 100],
+                "weight": 15,
+                "power": 50
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 0,
+                    "highlightValue": 0,
+                    "crossfade": true
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 0,
+                    "highlightValue": 0,
+                    "crossfade": true
+                },
+                "Reset": {
+                    "type": "Beam",
+                    "crossfade": true
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "5-channel Mode",
+                    "shortName": "5ch",
+                    "channels": [
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "Reset"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Amptown",
+            "name": "Controlite PML zoom",
+            "shortName": "PMLzoom",
+            "physical": {
+                "dimensions": [100, 100, 100]
+            },
+            "availableChannels": {
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Shutter": {
+                    "type": "Shutter",
+                    "defaultValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 10],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [11, 210],
+                            "name": "strobe"
+                        },
+                        {
+                            "range": [211, 240],
+                            "name": "random"
+                        },
+                        {
+                            "range": [241, 255],
+                            "name": "open"
+                        }
+                    ]
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Yellow": {
+                    "type": "SingleColor",
+                    "color": "Yellow",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Magenta": {
+                    "type": "SingleColor",
+                    "color": "Magenta",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Cyan": {
+                    "type": "SingleColor",
+                    "color": "Cyan",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "CTO": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "600k"
+                        },
+                        {
+                            "range": [220, 220],
+                            "name": "3400k"
+                        }
+                    ]
+                },
+                "Color": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 43],
+                            "name": "open"
+                        },
+                        {
+                            "range": [44, 87],
+                            "name": "color 1"
+                        },
+                        {
+                            "range": [88, 131],
+                            "name": "color 2"
+                        },
+                        {
+                            "range": [132, 176],
+                            "name": "color 3"
+                        },
+                        {
+                            "range": [177, 219],
+                            "name": "color 4"
+                        },
+                        {
+                            "range": [220, 255],
+                            "name": "open"
+                        }
+                    ]
+                },
+                "Gobo 1": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 10],
+                            "name": "gobo 0-0"
+                        },
+                        {
+                            "range": [11, 19],
+                            "name": "gobo 0-90"
+                        },
+                        {
+                            "range": [20, 28],
+                            "name": "gobo 0-180"
+                        },
+                        {
+                            "range": [29, 37],
+                            "name": "gobo 0-270"
+                        },
+                        {
+                            "range": [38, 46],
+                            "name": "gobo 1-0"
+                        },
+                        {
+                            "range": [47, 55],
+                            "name": "gobo 1-90"
+                        },
+                        {
+                            "range": [56, 64],
+                            "name": "gobo 1-180"
+                        },
+                        {
+                            "range": [65, 73],
+                            "name": "gobo 1-270"
+                        },
+                        {
+                            "range": [74, 82],
+                            "name": "gobo 2-0"
+                        },
+                        {
+                            "range": [83, 91],
+                            "name": "gobo 2-90"
+                        },
+                        {
+                            "range": [92, 100],
+                            "name": "gobo 2-180"
+                        },
+                        {
+                            "range": [101, 109],
+                            "name": "gobo 2-270"
+                        },
+                        {
+                            "range": [110, 118],
+                            "name": "gobo 3-0"
+                        },
+                        {
+                            "range": [119, 127],
+                            "name": "gobo 3-90"
+                        },
+                        {
+                            "range": [128, 136],
+                            "name": "gobo 3-180"
+                        },
+                        {
+                            "range": [137, 145],
+                            "name": "gobo 3-270"
+                        },
+                        {
+                            "range": [146, 154],
+                            "name": "gobo 4-0"
+                        },
+                        {
+                            "range": [155, 163],
+                            "name": "gobo 4-90"
+                        },
+                        {
+                            "range": [164, 172],
+                            "name": "gobo 4-180"
+                        },
+                        {
+                            "range": [173, 181],
+                            "name": "gobo 4-270"
+                        },
+                        {
+                            "range": [182, 190],
+                            "name": "gobo 5-0"
+                        },
+                        {
+                            "range": [191, 199],
+                            "name": "gobo 5-90"
+                        },
+                        {
+                            "range": [200, 208],
+                            "name": "gobo 5-180"
+                        },
+                        {
+                            "range": [209, 217],
+                            "name": "gobo 5-270"
+                        },
+                        {
+                            "range": [218, 226],
+                            "name": "gobo 6-0"
+                        },
+                        {
+                            "range": [227, 235],
+                            "name": "gobo 6-90"
+                        },
+                        {
+                            "range": [236, 244],
+                            "name": "gobo 6-180"
+                        },
+                        {
+                            "range": [245, 255],
+                            "name": "gobo 6-270"
+                        }
+                    ]
+                },
+                "GIndex 1": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Gobo 2": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 10],
+                            "name": "gobo 0-0"
+                        },
+                        {
+                            "range": [11, 19],
+                            "name": "gobo 0-90"
+                        },
+                        {
+                            "range": [20, 28],
+                            "name": "gobo 0-180"
+                        },
+                        {
+                            "range": [29, 37],
+                            "name": "gobo 0-270"
+                        },
+                        {
+                            "range": [38, 46],
+                            "name": "gobo 1-0"
+                        },
+                        {
+                            "range": [47, 55],
+                            "name": "gobo 1-90"
+                        },
+                        {
+                            "range": [56, 64],
+                            "name": "gobo 1-180"
+                        },
+                        {
+                            "range": [65, 73],
+                            "name": "gobo 1-270"
+                        },
+                        {
+                            "range": [74, 82],
+                            "name": "gobo 2-0"
+                        },
+                        {
+                            "range": [83, 91],
+                            "name": "gobo 2-90"
+                        },
+                        {
+                            "range": [92, 100],
+                            "name": "gobo 2-180"
+                        },
+                        {
+                            "range": [101, 109],
+                            "name": "gobo 2-270"
+                        },
+                        {
+                            "range": [110, 118],
+                            "name": "gobo 3-0"
+                        },
+                        {
+                            "range": [119, 127],
+                            "name": "gobo 3-90"
+                        },
+                        {
+                            "range": [128, 136],
+                            "name": "gobo 3-180"
+                        },
+                        {
+                            "range": [137, 145],
+                            "name": "gobo 3-270"
+                        },
+                        {
+                            "range": [146, 154],
+                            "name": "gobo 4-0"
+                        },
+                        {
+                            "range": [155, 163],
+                            "name": "gobo 4-90"
+                        },
+                        {
+                            "range": [164, 172],
+                            "name": "gobo 4-180"
+                        },
+                        {
+                            "range": [173, 181],
+                            "name": "gobo 4-270"
+                        },
+                        {
+                            "range": [182, 190],
+                            "name": "gobo 5-0"
+                        },
+                        {
+                            "range": [191, 199],
+                            "name": "gobo 5-90"
+                        },
+                        {
+                            "range": [200, 208],
+                            "name": "gobo 5-180"
+                        },
+                        {
+                            "range": [209, 217],
+                            "name": "gobo 5-270"
+                        },
+                        {
+                            "range": [218, 226],
+                            "name": "gobo 6-0"
+                        },
+                        {
+                            "range": [227, 235],
+                            "name": "gobo 6-90"
+                        },
+                        {
+                            "range": [236, 244],
+                            "name": "gobo 6-180"
+                        },
+                        {
+                            "range": [245, 255],
+                            "name": "gobo 6-270"
+                        }
+                    ]
+                },
+                "GIndex 2": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Beam": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Prism": {
+                    "type": "Prism",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 19],
+                            "name": "prism 0-0"
+                        },
+                        {
+                            "range": [20, 31],
+                            "name": "prism 0-90"
+                        },
+                        {
+                            "range": [32, 43],
+                            "name": "prism 0-180"
+                        },
+                        {
+                            "range": [44, 55],
+                            "name": "prism 0-270"
+                        },
+                        {
+                            "range": [56, 67],
+                            "name": "prism 1-0"
+                        },
+                        {
+                            "range": [68, 79],
+                            "name": "prism 1-90"
+                        },
+                        {
+                            "range": [80, 91],
+                            "name": "prism 1-180"
+                        },
+                        {
+                            "range": [92, 103],
+                            "name": "prism 1-270"
+                        },
+                        {
+                            "range": [104, 115],
+                            "name": "prism 2-0"
+                        },
+                        {
+                            "range": [116, 127],
+                            "name": "prism 2-90"
+                        },
+                        {
+                            "range": [128, 139],
+                            "name": "prism 2-180"
+                        },
+                        {
+                            "range": [140, 151],
+                            "name": "prism 2-270"
+                        },
+                        {
+                            "range": [152, 163],
+                            "name": "prism 3-0"
+                        },
+                        {
+                            "range": [164, 175],
+                            "name": "prism 3-90"
+                        },
+                        {
+                            "range": [176, 187],
+                            "name": "prism 3-180"
+                        },
+                        {
+                            "range": [188, 199],
+                            "name": "prism 3-270"
+                        },
+                        {
+                            "range": [200, 211],
+                            "name": "prism 4-0"
+                        },
+                        {
+                            "range": [212, 223],
+                            "name": "prism 4-90"
+                        },
+                        {
+                            "range": [224, 235],
+                            "name": "prism 4-180"
+                        },
+                        {
+                            "range": [236, 255],
+                            "name": "prism 4-270"
+                        }
+                    ]
+                },
+                "PIndex": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Frost": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Picture": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 8],
+                            "name": "%"
+                        },
+                        {
+                            "range": [9, 84],
+                            "name": "Iris",
+                            "color": "#5a4fcf"
+                        },
+                        {
+                            "range": [85, 124],
+                            "name": "Gobo 1"
+                        },
+                        {
+                            "range": [125, 254],
+                            "name": "Gobo 2"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "Wash"
+                        }
+                    ]
+                },
+                "Zoom": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Focus": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Control": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [51, 100],
+                            "name": "Lamp on"
+                        },
+                        {
+                            "range": [101, 150],
+                            "name": "Lamp off"
+                        },
+                        {
+                            "range": [151, 175],
+                            "name": "Display on"
+                        },
+                        {
+                            "range": [176, 200],
+                            "name": "Display off"
+                        },
+                        {
+                            "range": [202, 202],
+                            "name": "reset servo"
+                        },
+                        {
+                            "range": [203, 203],
+                            "name": "reset servo-ste"
+                        },
+                        {
+                            "range": [204, 204],
+                            "name": "reset stepper"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "23-channel Mode",
+                    "shortName": "23ch",
+                    "channels": [
+                        "Intensity",
+                        "Shutter",
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "Yellow",
+                        "Magenta",
+                        "Cyan",
+                        "CTO",
+                        "Color",
+                        "Gobo 1",
+                        "GIndex 1",
+                        "Gobo 2",
+                        "GIndex 2",
+                        "Beam",
+                        "Prism",
+                        "PIndex",
+                        "Frost",
+                        "Picture",
+                        "Zoom",
+                        "Focus",
+                        "Control"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Amptown",
+            "name": "ControLite Washlight HP Squarcle",
+            "shortName": "CntroLWashHPsq",
+            "physical": {
+                "dimensions": [100, 100, 100],
+                "weight": 25,
+                "power": 900
+            },
+            "availableChannels": {
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Shutter": {
+                    "type": "Shutter",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 14],
+                            "name": "Closed"
+                        },
+                        {
+                            "range": [15, 84],
+                            "name": "Speed"
+                        },
+                        {
+                            "range": [85, 164],
+                            "name": "Strobe(soft)"
+                        },
+                        {
+                            "range": [165, 254],
+                            "name": "Strobe(hard)"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "Open"
+                        }
+                    ]
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 0,
+                    "highlightValue": 0,
+                    "crossfade": true
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 0,
+                    "highlightValue": 0,
+                    "crossfade": true
+                },
+                "Yellow": {
+                    "type": "SingleColor",
+                    "color": "Yellow",
+                    "crossfade": true
+                },
+                "Magenta": {
+                    "type": "SingleColor",
+                    "color": "Magenta",
+                    "crossfade": true
+                },
+                "Cyan": {
+                    "type": "SingleColor",
+                    "color": "Cyan",
+                    "crossfade": true
+                },
+                "CTO": {
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "crossfade": true
+                },
+                "Focus": {
+                    "type": "Beam",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true
+                },
+                "Lamp Ctrl": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 31],
+                            "name": "On"
+                        },
+                        {
+                            "range": [32, 201],
+                            "name": "Off"
+                        },
+                        {
+                            "range": [202, 204],
+                            "name": "Reset"
+                        },
+                        {
+                            "range": [205, 255],
+                            "name": "Boost"
+                        }
+                    ]
+                },
+                "Barn door rot.": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "B. door 1/2": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Barn door 3": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Barn door 4": {
+                    "type": "Beam",
+                    "crossfade": true
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "16-channel Mode",
+                    "shortName": "16ch",
+                    "channels": [
+                        "Intensity",
+                        "Shutter",
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "Yellow",
+                        "Magenta",
+                        "Cyan",
+                        "CTO",
+                        "Focus",
+                        "Lamp Ctrl",
+                        "Barn door rot.",
+                        "B. door 1/2",
+                        "Barn door 3",
+                        "Barn door 4"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Amptown",
+            "name": "Light Mover",
+            "shortName": "LightMover",
+            "physical": {
+                "dimensions": [100, 100, 100]
+            },
+            "availableChannels": {
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Fokus": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 0,
+                    "highlightValue": 0,
+                    "crossfade": true
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 0,
+                    "highlightValue": 0,
+                    "crossfade": true
+                },
+                "Barn door rot.": {
+                    "type": "Beam",
+                    "defaultValue": 180,
+                    "highlightValue": 180,
+                    "crossfade": true
+                },
+                "Barn door 1": {
+                    "type": "Beam",
+                    "defaultValue": 1,
+                    "highlightValue": 1,
+                    "crossfade": true
+                },
+                "Barn door 2": {
+                    "type": "Beam",
+                    "defaultValue": 1,
+                    "highlightValue": 1,
+                    "crossfade": true
+                },
+                "Barn door 3": {
+                    "type": "Beam",
+                    "defaultValue": 1,
+                    "highlightValue": 1,
+                    "crossfade": true
+                },
+                "Barn door 4": {
+                    "type": "Beam",
+                    "defaultValue": 1,
+                    "highlightValue": 1,
+                    "crossfade": true
+                },
+                "Control": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 201],
+                            "name": "idle"
+                        },
+                        {
+                            "range": [202, 202],
+                            "name": "reset servo",
+                            "center": true
+                        },
+                        {
+                            "range": [203, 203],
+                            "name": "reset all",
+                            "center": true
+                        },
+                        {
+                            "range": [204, 204],
+                            "name": "reset stepper",
+                            "center": true
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "12-channel Mode",
+                    "shortName": "12ch",
+                    "channels": [
+                        "Intensity",
+                        "Fokus",
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "Barn door rot.",
+                        "Barn door 1",
+                        "Barn door 2",
+                        "Barn door 3",
+                        "Barn door 4",
+                        "Control"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Amptown",
+            "name": "Moving 4-Lite",
+            "shortName": "4-Lite",
+            "physical": {
+                "dimensions": [100, 100, 100]
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "crossfade": true
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "crossfade": true
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Scroller": {
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "crossfade": true
+                }
+            },
+            "modes": [
+                {
+                    "name": "4-channel Mode",
+                    "shortName": "4ch",
+                    "channels": [
+                        "Pan",
+                        "Tilt",
+                        "Intensity",
+                        "Scroller"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Amptown",
+            "name": "Moving Yoke",
+            "shortName": "MovingYoke",
+            "physical": {
+                "dimensions": [100, 100, 100]
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 0,
+                    "highlightValue": 0,
+                    "crossfade": true
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 0,
+                    "highlightValue": 0,
+                    "crossfade": true
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "4-channel Mode",
+                    "shortName": "4ch",
+                    "channels": [
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Amptown",
+            "name": "Posi Fan",
+            "shortName": "PosiFan",
+            "physical": {
+                "dimensions": [100, 100, 100]
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Fan": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "3-channel Mode",
+                    "shortName": "3ch",
+                    "channels": [
+                        "Pan",
+                        "Tilt",
+                        "Fan"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Amptown",
+            "name": "Posi Fog",
+            "shortName": "PosiFog",
+            "physical": {
+                "dimensions": [100, 100, 100]
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Fog": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "3-channel Mode",
+                    "shortName": "3ch",
+                    "channels": [
+                        "Pan",
+                        "Tilt",
+                        "Fog"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Amptown",
+            "name": "Washlight HP Squarcle",
+            "shortName": "WashHPsq",
+            "physical": {
+                "dimensions": [400, 400, 600],
+                "weight": 25,
+                "power": 900
+            },
+            "availableChannels": {
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Shutter": {
+                    "type": "Shutter",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 14],
+                            "name": "Closed"
+                        },
+                        {
+                            "range": [15, 84],
+                            "name": "Speed"
+                        },
+                        {
+                            "range": [85, 164],
+                            "name": "Strobe(soft)"
+                        },
+                        {
+                            "range": [165, 254],
+                            "name": "Strobe(hard)"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "Open"
+                        }
+                    ]
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 0,
+                    "highlightValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 0,
+                    "highlightValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Yellow": {
+                    "type": "SingleColor",
+                    "color": "Yellow",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Magenta": {
+                    "type": "SingleColor",
+                    "color": "Magenta",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Cyan": {
+                    "type": "SingleColor",
+                    "color": "Cyan",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "CTO": {
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Focus": {
+                    "type": "Beam",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "Distance"
+                        }
+                    ]
+                },
+                "Lamp Ctrl": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 31],
+                            "name": "On"
+                        },
+                        {
+                            "range": [32, 201],
+                            "name": "Off"
+                        },
+                        {
+                            "range": [202, 204],
+                            "name": "Reset"
+                        },
+                        {
+                            "range": [205, 255],
+                            "name": "Boost"
+                        }
+                    ]
+                },
+                "Barn door rot.": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "Rotation"
+                        }
+                    ]
+                },
+                "Barn door 1/2": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 254],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "Closed"
+                        }
+                    ]
+                },
+                "Barn door 3": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 254],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "Closed"
+                        }
+                    ]
+                },
+                "Barn door 4": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 254],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "Closed"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "16-channel Mode",
+                    "shortName": "16ch",
+                    "channels": [
+                        "Intensity",
+                        "Shutter",
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "Yellow",
+                        "Magenta",
+                        "Cyan",
+                        "CTO",
+                        "Focus",
+                        "Lamp Ctrl",
+                        "Barn door rot.",
+                        "Barn door 1/2",
+                        "Barn door 3",
+                        "Barn door 4"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Amptown",
+            "name": "Washlight HX Squarcle",
+            "shortName": "WashHXsq",
+            "physical": {
+                "dimensions": [400, 400, 600],
+                "weight": 25,
+                "power": 900
+            },
+            "availableChannels": {
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Focus": {
+                    "type": "Beam",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "Distance"
+                        }
+                    ]
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 0,
+                    "highlightValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 0,
+                    "highlightValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Yellow": {
+                    "type": "SingleColor",
+                    "color": "Yellow",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Magenta": {
+                    "type": "SingleColor",
+                    "color": "Magenta",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Cyan": {
+                    "type": "SingleColor",
+                    "color": "Cyan",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "CTO": {
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Lamp Ctrl": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 31],
+                            "name": "On"
+                        },
+                        {
+                            "range": [32, 201],
+                            "name": "Off"
+                        },
+                        {
+                            "range": [202, 204],
+                            "name": "Reset"
+                        },
+                        {
+                            "range": [205, 255],
+                            "name": "Boost"
+                        }
+                    ]
+                },
+                "Barn door rot.": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "Rotation"
+                        }
+                    ]
+                },
+                "Barn door 1": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 254],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "Closed"
+                        }
+                    ]
+                },
+                "Barn door 2": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 254],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "Closed"
+                        }
+                    ]
+                },
+                "Barn door 3": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 254],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "Closed"
+                        }
+                    ]
+                },
+                "Barn door 4": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 254],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "Closed"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "16-channel Mode",
+                    "shortName": "16ch",
+                    "channels": [
+                        "Intensity",
+                        "Focus",
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "Yellow",
+                        "Magenta",
+                        "Cyan",
+                        "CTO",
+                        "Lamp Ctrl",
+                        "Barn door rot.",
+                        "Barn door 1",
+                        "Barn door 2",
+                        "Barn door 3",
+                        "Barn door 4"
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/fixtures/imports/ecue-MainLibrary/Anolis.json
+++ b/fixtures/imports/ecue-MainLibrary/Anolis.json
@@ -1,0 +1,7548 @@
+{
+    "manufacturers": {
+        "Anolis": {
+            "name": "Anolis"
+        }
+    },
+    "fixtures": [
+        {
+            "manufacturer": "Anolis",
+            "name": "ArcPower 144 Mode 1",
+            "shortName": "APower 144 M1",
+            "comment": "Mode 1 - RGB 4 Zones",
+            "physical": {
+                "dimensions": [100, 100, 100],
+                "weight": 2,
+                "power": 240
+            },
+            "availableChannels": {
+                "Red 1": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green 1": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue 1": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Red 2": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green 2": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue 2": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Red 3": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green 3": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue 3": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Red 4": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green 4": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue 4": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                }
+            },
+            "modes": [
+                {
+                    "name": "12-channel Mode",
+                    "shortName": "12ch",
+                    "channels": [
+                        "Red 1",
+                        "Green 1",
+                        "Blue 1",
+                        "Red 2",
+                        "Green 2",
+                        "Blue 2",
+                        "Red 3",
+                        "Green 3",
+                        "Blue 3",
+                        "Red 4",
+                        "Green 4",
+                        "Blue 4"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Anolis",
+            "name": "ArcPower 144 Mode 2",
+            "shortName": "APower 144 M2",
+            "comment": "Mode 2 - RGBW 4 Zones",
+            "physical": {
+                "dimensions": [100, 100, 100],
+                "weight": 2,
+                "power": 240
+            },
+            "availableChannels": {
+                "Red 1": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green 1": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue 1": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "White 1": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Red 2": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green 2": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue 2": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "White 2": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Red 3": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green 3": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue 3": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "White 3": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Red 4": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green 4": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue 4": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "White 4": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                }
+            },
+            "modes": [
+                {
+                    "name": "16-channel Mode",
+                    "shortName": "16ch",
+                    "channels": [
+                        "Red 1",
+                        "Green 1",
+                        "Blue 1",
+                        "White 1",
+                        "Red 2",
+                        "Green 2",
+                        "Blue 2",
+                        "White 2",
+                        "Red 3",
+                        "Green 3",
+                        "Blue 3",
+                        "White 3",
+                        "Red 4",
+                        "Green 4",
+                        "Blue 4",
+                        "White 4"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Anolis",
+            "name": "ArcPower 144 Mode 3",
+            "shortName": "APower 144 M3",
+            "comment": "Mode 3 - RGBW 4 Zones + Macro + Shutter + Dimmer",
+            "physical": {
+                "dimensions": [100, 100, 100],
+                "weight": 2,
+                "power": 240
+            },
+            "availableChannels": {
+                "Red 1": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green 1": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue 1": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "White 1": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Red 2": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green 2": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue 2": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "White 2": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Red 3": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green 3": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue 3": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "White 3": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Red 4": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green 4": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue 4": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "White 4": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Macro": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 7],
+                            "name": "No Function",
+                            "center": true
+                        },
+                        {
+                            "range": [8, 15],
+                            "name": "Macro 1",
+                            "center": true
+                        },
+                        {
+                            "range": [16, 23],
+                            "name": "Macro 2",
+                            "center": true
+                        },
+                        {
+                            "range": [24, 31],
+                            "name": "Macro 3",
+                            "center": true
+                        },
+                        {
+                            "range": [32, 39],
+                            "name": "Macro 4",
+                            "center": true
+                        },
+                        {
+                            "range": [40, 47],
+                            "name": "Macro 5",
+                            "center": true
+                        },
+                        {
+                            "range": [48, 55],
+                            "name": "Macro 6",
+                            "center": true
+                        },
+                        {
+                            "range": [56, 63],
+                            "name": "Macro 7",
+                            "center": true
+                        },
+                        {
+                            "range": [64, 71],
+                            "name": "Macro 8",
+                            "center": true
+                        },
+                        {
+                            "range": [72, 79],
+                            "name": "Macro 9",
+                            "center": true
+                        },
+                        {
+                            "range": [80, 87],
+                            "name": "Macro 10",
+                            "center": true
+                        },
+                        {
+                            "range": [88, 95],
+                            "name": "Macro 11",
+                            "center": true
+                        },
+                        {
+                            "range": [96, 103],
+                            "name": "Macro 12",
+                            "center": true
+                        },
+                        {
+                            "range": [104, 111],
+                            "name": "Macro 13",
+                            "center": true
+                        },
+                        {
+                            "range": [112, 119],
+                            "name": "Macro 14",
+                            "center": true
+                        },
+                        {
+                            "range": [120, 127],
+                            "name": "Macro 15",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 135],
+                            "name": "Macro 16",
+                            "center": true
+                        },
+                        {
+                            "range": [136, 143],
+                            "name": "Macro 17",
+                            "center": true
+                        },
+                        {
+                            "range": [144, 151],
+                            "name": "Macro 18",
+                            "center": true
+                        },
+                        {
+                            "range": [152, 159],
+                            "name": "Macro 19",
+                            "center": true
+                        },
+                        {
+                            "range": [160, 167],
+                            "name": "Macro 20",
+                            "center": true
+                        },
+                        {
+                            "range": [168, 175],
+                            "name": "Macro 21",
+                            "center": true
+                        },
+                        {
+                            "range": [176, 183],
+                            "name": "Macro 22",
+                            "center": true
+                        },
+                        {
+                            "range": [184, 191],
+                            "name": "Macro 23",
+                            "center": true
+                        },
+                        {
+                            "range": [192, 199],
+                            "name": "Macro 24",
+                            "center": true
+                        },
+                        {
+                            "range": [200, 207],
+                            "name": "Macro 25",
+                            "center": true
+                        },
+                        {
+                            "range": [208, 215],
+                            "name": "Macro 26",
+                            "center": true
+                        },
+                        {
+                            "range": [216, 223],
+                            "name": "Macro 27",
+                            "center": true
+                        },
+                        {
+                            "range": [224, 231],
+                            "name": "Macro 28",
+                            "center": true
+                        },
+                        {
+                            "range": [232, 239],
+                            "name": "Macro 29",
+                            "center": true
+                        },
+                        {
+                            "range": [240, 247],
+                            "name": "Macro 30",
+                            "center": true
+                        },
+                        {
+                            "range": [248, 255],
+                            "name": "Macro 31",
+                            "center": true
+                        }
+                    ]
+                },
+                "Shutter": {
+                    "type": "Shutter",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 31],
+                            "name": "Closed",
+                            "center": true
+                        },
+                        {
+                            "range": [32, 63],
+                            "name": "Open",
+                            "center": true
+                        },
+                        {
+                            "range": [64, 95],
+                            "name": "Strobe S-F"
+                        },
+                        {
+                            "range": [96, 127],
+                            "name": "Open",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 143],
+                            "name": "Pulse Open"
+                        },
+                        {
+                            "range": [144, 159],
+                            "name": "Pulse Close"
+                        },
+                        {
+                            "range": [160, 191],
+                            "name": "Open",
+                            "center": true
+                        },
+                        {
+                            "range": [192, 223],
+                            "name": "Random S-F"
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "Open",
+                            "center": true
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                }
+            },
+            "modes": [
+                {
+                    "name": "19-channel Mode",
+                    "shortName": "19ch",
+                    "channels": [
+                        "Red 1",
+                        "Green 1",
+                        "Blue 1",
+                        "White 1",
+                        "Red 2",
+                        "Green 2",
+                        "Blue 2",
+                        "White 2",
+                        "Red 3",
+                        "Green 3",
+                        "Blue 3",
+                        "White 3",
+                        "Red 4",
+                        "Green 4",
+                        "Blue 4",
+                        "White 4",
+                        "Macro",
+                        "Shutter",
+                        "Intensity"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Anolis",
+            "name": "ArcPower 144 Mode 4",
+            "shortName": "APower 144 M4",
+            "comment": "Mode 4 - RGB 1 Zone",
+            "physical": {
+                "dimensions": [100, 100, 100],
+                "weight": 2,
+                "power": 240
+            },
+            "availableChannels": {
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                }
+            },
+            "modes": [
+                {
+                    "name": "3-channel Mode",
+                    "shortName": "3ch",
+                    "channels": [
+                        "Red",
+                        "Green",
+                        "Blue"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Anolis",
+            "name": "ArcPower 144 SW Mode 1",
+            "shortName": "APower 144 SW M1",
+            "comment": "Mode 1 - SW 4 Zones",
+            "physical": {
+                "dimensions": [100, 100, 100],
+                "weight": 2,
+                "power": 240
+            },
+            "availableChannels": {
+                "WarmWhite 1": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "ColdWhite 1": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "WarmWhite 2": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "WarmWhite 3": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "ColdWhite 3": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "WarmWhite 4": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "ColdWhite 4": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "ColdWhite 2": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                }
+            },
+            "modes": [
+                {
+                    "name": "12-channel Mode",
+                    "shortName": "12ch",
+                    "channels": [
+                        "WarmWhite 1",
+                        "ColdWhite 1",
+                        "WarmWhite 2",
+                        null,
+                        "WarmWhite 3",
+                        "ColdWhite 3",
+                        "WarmWhite 4",
+                        "ColdWhite 4",
+                        null,
+                        null,
+                        null,
+                        "ColdWhite 2"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Anolis",
+            "name": "ArcPower 144 SW Mode 2",
+            "shortName": "APower 144 SW M2",
+            "comment": "Mode 2 - All LEDs Saturation",
+            "physical": {
+                "dimensions": [100, 100, 100],
+                "weight": 2,
+                "power": 240
+            },
+            "availableChannels": {
+                "Intensity All L": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                }
+            },
+            "modes": [
+                {
+                    "name": "1-channel Mode",
+                    "shortName": "1ch",
+                    "channels": [
+                        "Intensity All L"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Anolis",
+            "name": "ArcPower 144 SW Mode 3",
+            "shortName": "APower 144 SW M3",
+            "comment": "Mode 3 - Ratio 4 Zones + Dimmer",
+            "physical": {
+                "dimensions": [100, 100, 100],
+                "weight": 2,
+                "power": 240
+            },
+            "availableChannels": {
+                "Ratio Control 1": {
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Ratio Control 2": {
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Ratio Control 3": {
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Ratio Control 4": {
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                }
+            },
+            "modes": [
+                {
+                    "name": "5-channel Mode",
+                    "shortName": "5ch",
+                    "channels": [
+                        "Ratio Control 1",
+                        "Ratio Control 2",
+                        "Ratio Control 3",
+                        "Ratio Control 4",
+                        "Intensity"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Anolis",
+            "name": "ArcPower 144 SW Mode 4",
+            "shortName": "APower 144 SW M4",
+            "comment": "Mode 4 - SW 4 Zones + Shutter + Dimmer",
+            "physical": {
+                "dimensions": [100, 100, 100],
+                "weight": 2,
+                "power": 240
+            },
+            "availableChannels": {
+                "WarmWhite 1": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "ColdWhite 1": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "WarmWhite 2": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "WarmWhite 3": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "ColdWhite 3": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "WarmWhite 4": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "ColdWhite 4": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Shutter": {
+                    "type": "Shutter",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "ColdWhite 2": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                }
+            },
+            "modes": [
+                {
+                    "name": "12-channel Mode",
+                    "shortName": "12ch",
+                    "channels": [
+                        "WarmWhite 1",
+                        "ColdWhite 1",
+                        "WarmWhite 2",
+                        null,
+                        "WarmWhite 3",
+                        "ColdWhite 3",
+                        "WarmWhite 4",
+                        "ColdWhite 4",
+                        "Shutter",
+                        "Intensity",
+                        null,
+                        "ColdWhite 2"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Anolis",
+            "name": "ArcPower 144 SW Mode 5",
+            "shortName": "APower 144 SW M5",
+            "comment": "Mode 5 - SW 1 Zone + Dimmer",
+            "physical": {
+                "dimensions": [100, 100, 100],
+                "weight": 2,
+                "power": 240
+            },
+            "availableChannels": {
+                "WarmWhite": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "ColdWhite": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                }
+            },
+            "modes": [
+                {
+                    "name": "3-channel Mode",
+                    "shortName": "3ch",
+                    "channels": [
+                        "WarmWhite",
+                        "ColdWhite",
+                        "Intensity"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Anolis",
+            "name": "ArcPower 144 SW Mode 6",
+            "shortName": "APower 144 SW M6",
+            "comment": "Mode 6 - SW 4 Zones + 4 Dimmers",
+            "physical": {
+                "dimensions": [100, 100, 100],
+                "weight": 2,
+                "power": 240
+            },
+            "availableChannels": {
+                "WarmWhite 1": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "ColdWhite 1": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Intensity 1": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "WarmWhite 2": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "ColdWhite 2": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Intensity 2": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "WarmWhite 3": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "ColdWhite 3": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Intensity 3": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "WarmWhite 4": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "ColdWhite 4": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                }
+            },
+            "modes": [
+                {
+                    "name": "12-channel Mode",
+                    "shortName": "12ch",
+                    "channels": [
+                        "WarmWhite 1",
+                        "ColdWhite 1",
+                        "Intensity 1",
+                        "WarmWhite 2",
+                        "ColdWhite 2",
+                        "Intensity 2",
+                        "WarmWhite 3",
+                        "ColdWhite 3",
+                        "Intensity 3",
+                        "WarmWhite 4",
+                        "ColdWhite 4",
+                        "Intensity"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Anolis",
+            "name": "ArcPower 16x6 Mode 1",
+            "shortName": "APower 16x6 M1",
+            "comment": "Mode 1 - RGB 16 Zones",
+            "physical": {
+                "dimensions": [100, 100, 100],
+                "weight": 2,
+                "power": 170
+            },
+            "availableChannels": {
+                "Red 1": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green 1": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue 1": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Red 2": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green 2": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue 2": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Red 3": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green 3": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue 3": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Red 4": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green 4": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue 4": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Red 5": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green 5": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue 5": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Red 6": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green 6": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue 6": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Red 7": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green 7": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue 7": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Red 8": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green 8": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue 8": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Red 9": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green 9": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue 9": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Red 10": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green 10": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue 10": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Red 11": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green 11": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue 11": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Red 12": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green 12": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue 12": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Red 13": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green 13": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue 13": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Red 14": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green 14": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue 14": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Red 15": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green 15": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue 15": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Red 16": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green 16": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue 16": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                }
+            },
+            "modes": [
+                {
+                    "name": "48-channel Mode",
+                    "shortName": "48ch",
+                    "channels": [
+                        "Red 1",
+                        "Green 1",
+                        "Blue 1",
+                        "Red 2",
+                        "Green 2",
+                        "Blue 2",
+                        "Red 3",
+                        "Green 3",
+                        "Blue 3",
+                        "Red 4",
+                        "Green 4",
+                        "Blue 4",
+                        "Red 5",
+                        "Green 5",
+                        "Blue 5",
+                        "Red 6",
+                        "Green 6",
+                        "Blue 6",
+                        "Red 7",
+                        "Green 7",
+                        "Blue 7",
+                        "Red 8",
+                        "Green 8",
+                        "Blue 8",
+                        "Red 9",
+                        "Green 9",
+                        "Blue 9",
+                        "Red 10",
+                        "Green 10",
+                        "Blue 10",
+                        "Red 11",
+                        "Green 11",
+                        "Blue 11",
+                        "Red 12",
+                        "Green 12",
+                        "Blue 12",
+                        "Red 13",
+                        "Green 13",
+                        "Blue 13",
+                        "Red 14",
+                        "Green 14",
+                        "Blue 14",
+                        "Red 15",
+                        "Green 15",
+                        "Blue 15",
+                        "Red 16",
+                        "Green 16",
+                        "Blue 16"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Anolis",
+            "name": "ArcPower 16x6 Mode 2",
+            "shortName": "APower 16x6 M2",
+            "comment": "Mode 2 - RGB 16 Zones + Shutter + Dimmer",
+            "physical": {
+                "dimensions": [100, 100, 100],
+                "weight": 2,
+                "power": 170
+            },
+            "availableChannels": {
+                "Red 1": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green 1": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue 1": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Red 2": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green 2": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue 2": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Red 3": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green 3": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue 3": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Red 4": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green 4": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue 4": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Red 5": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green 5": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue 5": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Red 6": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green 6": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue 6": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Red 7": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green 7": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue 7": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Red 8": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green 8": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue 8": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Red 9": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green 9": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue 9": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Red 10": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green 10": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue 10": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Red 11": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green 11": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue 11": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Red 12": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green 12": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue 12": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Red 13": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green 13": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue 13": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Red 14": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green 14": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue 14": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Red 15": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green 15": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue 15": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Red 16": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green 16": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue 16": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Shutter": {
+                    "type": "Shutter",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                }
+            },
+            "modes": [
+                {
+                    "name": "50-channel Mode",
+                    "shortName": "50ch",
+                    "channels": [
+                        "Red 1",
+                        "Green 1",
+                        "Blue 1",
+                        "Red 2",
+                        "Green 2",
+                        "Blue 2",
+                        "Red 3",
+                        "Green 3",
+                        "Blue 3",
+                        "Red 4",
+                        "Green 4",
+                        "Blue 4",
+                        "Red 5",
+                        "Green 5",
+                        "Blue 5",
+                        "Red 6",
+                        "Green 6",
+                        "Blue 6",
+                        "Red 7",
+                        "Green 7",
+                        "Blue 7",
+                        "Red 8",
+                        "Green 8",
+                        "Blue 8",
+                        "Red 9",
+                        "Green 9",
+                        "Blue 9",
+                        "Red 10",
+                        "Green 10",
+                        "Blue 10",
+                        "Red 11",
+                        "Green 11",
+                        "Blue 11",
+                        "Red 12",
+                        "Green 12",
+                        "Blue 12",
+                        "Red 13",
+                        "Green 13",
+                        "Blue 13",
+                        "Red 14",
+                        "Green 14",
+                        "Blue 14",
+                        "Red 15",
+                        "Green 15",
+                        "Blue 15",
+                        "Red 16",
+                        "Green 16",
+                        "Blue 16",
+                        "Shutter",
+                        "Intensity"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Anolis",
+            "name": "ArcPower 36 Mode 1",
+            "shortName": "APower 36 M1",
+            "comment": "Mode 1 - RGB",
+            "physical": {
+                "dimensions": [100, 100, 100],
+                "weight": 1,
+                "power": 60
+            },
+            "availableChannels": {
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                }
+            },
+            "modes": [
+                {
+                    "name": "3-channel Mode",
+                    "shortName": "3ch",
+                    "channels": [
+                        "Red",
+                        "Green",
+                        "Blue"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Anolis",
+            "name": "ArcPower 36 Mode 2",
+            "shortName": "APower 36 M2",
+            "comment": "Mode 2 - RGBW",
+            "physical": {
+                "dimensions": [100, 100, 100],
+                "weight": 1,
+                "power": 60
+            },
+            "availableChannels": {
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "White": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                }
+            },
+            "modes": [
+                {
+                    "name": "4-channel Mode",
+                    "shortName": "4ch",
+                    "channels": [
+                        "Red",
+                        "Green",
+                        "Blue",
+                        "White"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Anolis",
+            "name": "ArcPower 36 Mode 3",
+            "shortName": "APower 36 M3",
+            "comment": "Mode 3 - RGB + Macro + Shutter + Dimmer",
+            "physical": {
+                "dimensions": [100, 100, 100],
+                "weight": 1,
+                "power": 60
+            },
+            "availableChannels": {
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Macro": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 7],
+                            "name": "No Function",
+                            "center": true
+                        },
+                        {
+                            "range": [8, 15],
+                            "name": "Macro 1",
+                            "center": true
+                        },
+                        {
+                            "range": [16, 23],
+                            "name": "Macro 2",
+                            "center": true
+                        },
+                        {
+                            "range": [24, 31],
+                            "name": "Macro 3",
+                            "center": true
+                        },
+                        {
+                            "range": [32, 39],
+                            "name": "Macro 4",
+                            "center": true
+                        },
+                        {
+                            "range": [40, 47],
+                            "name": "Macro 5",
+                            "center": true
+                        },
+                        {
+                            "range": [48, 55],
+                            "name": "Macro 6",
+                            "center": true
+                        },
+                        {
+                            "range": [56, 63],
+                            "name": "Macro 7",
+                            "center": true
+                        },
+                        {
+                            "range": [64, 71],
+                            "name": "Macro 8",
+                            "center": true
+                        },
+                        {
+                            "range": [72, 79],
+                            "name": "Macro 9",
+                            "center": true
+                        },
+                        {
+                            "range": [80, 87],
+                            "name": "Macro 10",
+                            "center": true
+                        },
+                        {
+                            "range": [88, 95],
+                            "name": "Macro 11",
+                            "center": true
+                        },
+                        {
+                            "range": [96, 103],
+                            "name": "Macro 12",
+                            "center": true
+                        },
+                        {
+                            "range": [104, 111],
+                            "name": "Macro 13",
+                            "center": true
+                        },
+                        {
+                            "range": [112, 119],
+                            "name": "Macro 14",
+                            "center": true
+                        },
+                        {
+                            "range": [120, 127],
+                            "name": "Macro 15",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 135],
+                            "name": "Macro 16",
+                            "center": true
+                        },
+                        {
+                            "range": [136, 143],
+                            "name": "Macro 17",
+                            "center": true
+                        },
+                        {
+                            "range": [144, 151],
+                            "name": "Macro 18",
+                            "center": true
+                        },
+                        {
+                            "range": [152, 159],
+                            "name": "Macro 19",
+                            "center": true
+                        },
+                        {
+                            "range": [160, 167],
+                            "name": "Macro 20",
+                            "center": true
+                        },
+                        {
+                            "range": [168, 175],
+                            "name": "Macro 21",
+                            "center": true
+                        },
+                        {
+                            "range": [176, 183],
+                            "name": "Macro 22",
+                            "center": true
+                        },
+                        {
+                            "range": [184, 191],
+                            "name": "Macro 23",
+                            "center": true
+                        },
+                        {
+                            "range": [192, 199],
+                            "name": "Macro 24",
+                            "center": true
+                        },
+                        {
+                            "range": [200, 207],
+                            "name": "Macro 25",
+                            "center": true
+                        },
+                        {
+                            "range": [208, 215],
+                            "name": "Macro 26",
+                            "center": true
+                        },
+                        {
+                            "range": [216, 223],
+                            "name": "Macro 27",
+                            "center": true
+                        },
+                        {
+                            "range": [224, 231],
+                            "name": "Macro 28",
+                            "center": true
+                        },
+                        {
+                            "range": [232, 239],
+                            "name": "Macro 29",
+                            "center": true
+                        },
+                        {
+                            "range": [240, 247],
+                            "name": "Macro 30",
+                            "center": true
+                        },
+                        {
+                            "range": [248, 255],
+                            "name": "Macro 31",
+                            "center": true
+                        }
+                    ]
+                },
+                "Shutter": {
+                    "type": "Shutter",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 31],
+                            "name": "Closed",
+                            "center": true
+                        },
+                        {
+                            "range": [32, 63],
+                            "name": "Open",
+                            "center": true
+                        },
+                        {
+                            "range": [64, 95],
+                            "name": "Strobe S-F"
+                        },
+                        {
+                            "range": [96, 127],
+                            "name": "Open",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 143],
+                            "name": "Pulse Open"
+                        },
+                        {
+                            "range": [144, 159],
+                            "name": "Pulse Close"
+                        },
+                        {
+                            "range": [160, 191],
+                            "name": "Open",
+                            "center": true
+                        },
+                        {
+                            "range": [192, 223],
+                            "name": "Random S-F"
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "Open",
+                            "center": true
+                        }
+                    ]
+                },
+                "Dimmer": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                }
+            },
+            "modes": [
+                {
+                    "name": "6-channel Mode",
+                    "shortName": "6ch",
+                    "channels": [
+                        "Red",
+                        "Green",
+                        "Blue",
+                        "Macro",
+                        "Shutter",
+                        "Dimmer"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Anolis",
+            "name": "ArcPower 36 Mode 4",
+            "shortName": "APower 36 M4",
+            "comment": "Mode 4 - RGBW + Macro + Shutter + Dimmer",
+            "physical": {
+                "dimensions": [100, 100, 100],
+                "weight": 1,
+                "power": 60
+            },
+            "availableChannels": {
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "White": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Macro": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 7],
+                            "name": "No Function",
+                            "center": true
+                        },
+                        {
+                            "range": [8, 15],
+                            "name": "Macro 1",
+                            "center": true
+                        },
+                        {
+                            "range": [16, 23],
+                            "name": "Macro 2",
+                            "center": true
+                        },
+                        {
+                            "range": [24, 31],
+                            "name": "Macro 3",
+                            "center": true
+                        },
+                        {
+                            "range": [32, 39],
+                            "name": "Macro 4",
+                            "center": true
+                        },
+                        {
+                            "range": [40, 47],
+                            "name": "Macro 5",
+                            "center": true
+                        },
+                        {
+                            "range": [48, 55],
+                            "name": "Macro 6",
+                            "center": true
+                        },
+                        {
+                            "range": [56, 63],
+                            "name": "Macro 7",
+                            "center": true
+                        },
+                        {
+                            "range": [64, 71],
+                            "name": "Macro 8",
+                            "center": true
+                        },
+                        {
+                            "range": [72, 79],
+                            "name": "Macro 9",
+                            "center": true
+                        },
+                        {
+                            "range": [80, 87],
+                            "name": "Macro 10",
+                            "center": true
+                        },
+                        {
+                            "range": [88, 95],
+                            "name": "Macro 11",
+                            "center": true
+                        },
+                        {
+                            "range": [96, 103],
+                            "name": "Macro 12",
+                            "center": true
+                        },
+                        {
+                            "range": [104, 111],
+                            "name": "Macro 13",
+                            "center": true
+                        },
+                        {
+                            "range": [112, 119],
+                            "name": "Macro 14",
+                            "center": true
+                        },
+                        {
+                            "range": [120, 127],
+                            "name": "Macro 15",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 135],
+                            "name": "Macro 16",
+                            "center": true
+                        },
+                        {
+                            "range": [136, 143],
+                            "name": "Macro 17",
+                            "center": true
+                        },
+                        {
+                            "range": [144, 151],
+                            "name": "Macro 18",
+                            "center": true
+                        },
+                        {
+                            "range": [152, 159],
+                            "name": "Macro 19",
+                            "center": true
+                        },
+                        {
+                            "range": [160, 167],
+                            "name": "Macro 20",
+                            "center": true
+                        },
+                        {
+                            "range": [168, 175],
+                            "name": "Macro 21",
+                            "center": true
+                        },
+                        {
+                            "range": [176, 183],
+                            "name": "Macro 22",
+                            "center": true
+                        },
+                        {
+                            "range": [184, 191],
+                            "name": "Macro 23",
+                            "center": true
+                        },
+                        {
+                            "range": [192, 199],
+                            "name": "Macro 24",
+                            "center": true
+                        },
+                        {
+                            "range": [200, 207],
+                            "name": "Macro 25",
+                            "center": true
+                        },
+                        {
+                            "range": [208, 215],
+                            "name": "Macro 26",
+                            "center": true
+                        },
+                        {
+                            "range": [216, 223],
+                            "name": "Macro 27",
+                            "center": true
+                        },
+                        {
+                            "range": [224, 231],
+                            "name": "Macro 28",
+                            "center": true
+                        },
+                        {
+                            "range": [232, 239],
+                            "name": "Macro 29",
+                            "center": true
+                        },
+                        {
+                            "range": [240, 247],
+                            "name": "Macro 30",
+                            "center": true
+                        },
+                        {
+                            "range": [248, 255],
+                            "name": "Macro 31",
+                            "center": true
+                        }
+                    ]
+                },
+                "Shutter": {
+                    "type": "Shutter",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 31],
+                            "name": "Closed",
+                            "center": true
+                        },
+                        {
+                            "range": [32, 63],
+                            "name": "Open",
+                            "center": true
+                        },
+                        {
+                            "range": [64, 95],
+                            "name": "Strobe S-F"
+                        },
+                        {
+                            "range": [96, 127],
+                            "name": "Open",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 143],
+                            "name": "Pulse Open"
+                        },
+                        {
+                            "range": [144, 159],
+                            "name": "Pulse Close"
+                        },
+                        {
+                            "range": [160, 191],
+                            "name": "Open",
+                            "center": true
+                        },
+                        {
+                            "range": [192, 223],
+                            "name": "Random S-F"
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "Open",
+                            "center": true
+                        }
+                    ]
+                },
+                "Dimmer": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                }
+            },
+            "modes": [
+                {
+                    "name": "7-channel Mode",
+                    "shortName": "7ch",
+                    "channels": [
+                        "Red",
+                        "Green",
+                        "Blue",
+                        "White",
+                        "Macro",
+                        "Shutter",
+                        "Dimmer"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Anolis",
+            "name": "ArcPower 36 Mode 5",
+            "shortName": "APower 36 M5",
+            "comment": "Mode 5 - RGB + Dimmer",
+            "physical": {
+                "dimensions": [100, 100, 100],
+                "weight": 1,
+                "power": 60
+            },
+            "availableChannels": {
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Dimmer": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                }
+            },
+            "modes": [
+                {
+                    "name": "4-channel Mode",
+                    "shortName": "4ch",
+                    "channels": [
+                        "Red",
+                        "Green",
+                        "Blue",
+                        "Dimmer"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Anolis",
+            "name": "ArcPower 36 SW Mode 1",
+            "shortName": "APower 36 SW M1",
+            "comment": "Mode 1 - SW",
+            "physical": {
+                "dimensions": [100, 100, 100],
+                "weight": 1,
+                "power": 60
+            },
+            "availableChannels": {
+                "WarmWhite 1": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "ColdWhite 1": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                }
+            },
+            "modes": [
+                {
+                    "name": "2-channel Mode",
+                    "shortName": "2ch",
+                    "channels": [
+                        "WarmWhite 1",
+                        "ColdWhite 1"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Anolis",
+            "name": "ArcPower 36 SW Mode 2",
+            "shortName": "APower 36 SW M2",
+            "comment": "Mode 2 - All LEDs Saturation",
+            "physical": {
+                "dimensions": [100, 100, 100],
+                "weight": 1,
+                "power": 60
+            },
+            "availableChannels": {
+                "Intensity All L": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                }
+            },
+            "modes": [
+                {
+                    "name": "1-channel Mode",
+                    "shortName": "1ch",
+                    "channels": [
+                        "Intensity All L"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Anolis",
+            "name": "ArcPower 36 SW Mode 3",
+            "shortName": "APower 36 SW M3",
+            "comment": "Mode 3 - Ratio + Dimmer",
+            "physical": {
+                "dimensions": [100, 100, 100],
+                "weight": 1,
+                "power": 60
+            },
+            "availableChannels": {
+                "Ratio Control 1": {
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                }
+            },
+            "modes": [
+                {
+                    "name": "2-channel Mode",
+                    "shortName": "2ch",
+                    "channels": [
+                        "Ratio Control 1",
+                        "Intensity"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Anolis",
+            "name": "ArcPower 36 SW Mode 4",
+            "shortName": "APower 36 SW M4",
+            "comment": "Mode 4 - SW + Shutter + Dimmer",
+            "physical": {
+                "dimensions": [100, 100, 100],
+                "weight": 1,
+                "power": 60
+            },
+            "availableChannels": {
+                "WarmWhite 1": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "ColdWhite 1": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Shutter": {
+                    "type": "Shutter",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 31],
+                            "name": "Closed",
+                            "center": true
+                        },
+                        {
+                            "range": [32, 63],
+                            "name": "Open",
+                            "center": true
+                        },
+                        {
+                            "range": [64, 95],
+                            "name": "Strobe S-F"
+                        },
+                        {
+                            "range": [96, 127],
+                            "name": "Open",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 143],
+                            "name": "Pulse Open"
+                        },
+                        {
+                            "range": [144, 159],
+                            "name": "Pulse Close"
+                        },
+                        {
+                            "range": [160, 191],
+                            "name": "Open",
+                            "center": true
+                        },
+                        {
+                            "range": [192, 223],
+                            "name": "Random S-F"
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "Open",
+                            "center": true
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                }
+            },
+            "modes": [
+                {
+                    "name": "4-channel Mode",
+                    "shortName": "4ch",
+                    "channels": [
+                        "WarmWhite 1",
+                        "ColdWhite 1",
+                        "Shutter",
+                        "Intensity"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Anolis",
+            "name": "ArcPower 36 SW Mode 5",
+            "shortName": "APower 36 SW M5",
+            "comment": "Mode 5 - SW + Dimmer",
+            "physical": {
+                "dimensions": [100, 100, 100],
+                "weight": 1,
+                "power": 60
+            },
+            "availableChannels": {
+                "WarmWhite": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "ColdWhite": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                }
+            },
+            "modes": [
+                {
+                    "name": "3-channel Mode",
+                    "shortName": "3ch",
+                    "channels": [
+                        "WarmWhite",
+                        "ColdWhite",
+                        "Intensity"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Anolis",
+            "name": "ArcPower 360 Mode 1",
+            "shortName": "APower 360 M1",
+            "comment": "Mode 1 - RGB 10 Zones",
+            "physical": {
+                "dimensions": [100, 100, 100],
+                "weight": 6,
+                "power": 600
+            },
+            "availableChannels": {
+                "Red 1": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green 1": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue 1": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Red 2": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green 2": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue 2": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Red 3": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green 3": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue 3": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Red 4": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green 4": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue 4": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Red 5": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green 5": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue 5": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Red 6": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green 6": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue 6": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Red 7": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green 7": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue 7": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Red 8": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green 8": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue 8": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Red 9": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green 9": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue 9": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Red 10": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green 10": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue 10": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                }
+            },
+            "modes": [
+                {
+                    "name": "30-channel Mode",
+                    "shortName": "30ch",
+                    "channels": [
+                        "Red 1",
+                        "Green 1",
+                        "Blue 1",
+                        "Red 2",
+                        "Green 2",
+                        "Blue 2",
+                        "Red 3",
+                        "Green 3",
+                        "Blue 3",
+                        "Red 4",
+                        "Green 4",
+                        "Blue 4",
+                        "Red 5",
+                        "Green 5",
+                        "Blue 5",
+                        "Red 6",
+                        "Green 6",
+                        "Blue 6",
+                        "Red 7",
+                        "Green 7",
+                        "Blue 7",
+                        "Red 8",
+                        "Green 8",
+                        "Blue 8",
+                        "Red 9",
+                        "Green 9",
+                        "Blue 9",
+                        "Red 10",
+                        "Green 10",
+                        "Blue 10"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Anolis",
+            "name": "ArcPower 360 Mode 2",
+            "shortName": "APower 360 M2",
+            "comment": "Mode 2 - RGBW 10 Zones",
+            "physical": {
+                "dimensions": [100, 100, 100],
+                "weight": 6,
+                "power": 600
+            },
+            "availableChannels": {
+                "Red 1": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green 1": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue 1": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "White 1": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Red 2": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green 2": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue 2": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "White 2": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Red 3": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green 3": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue 3": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "White 3": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Red 4": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green 4": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue 4": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "White 4": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Red 5": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green 5": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue 5": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "White 5": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Red 6": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green 6": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue 6": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "White 6": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Red 7": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green 7": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue 7": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "White 7": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Red 8": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green 8": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue 8": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "White 8": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Red 9": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green 9": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue 9": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "White 9": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Red 10": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green 10": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue 10": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "White 10": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                }
+            },
+            "modes": [
+                {
+                    "name": "40-channel Mode",
+                    "shortName": "40ch",
+                    "channels": [
+                        "Red 1",
+                        "Green 1",
+                        "Blue 1",
+                        "White 1",
+                        "Red 2",
+                        "Green 2",
+                        "Blue 2",
+                        "White 2",
+                        "Red 3",
+                        "Green 3",
+                        "Blue 3",
+                        "White 3",
+                        "Red 4",
+                        "Green 4",
+                        "Blue 4",
+                        "White 4",
+                        "Red 5",
+                        "Green 5",
+                        "Blue 5",
+                        "White 5",
+                        "Red 6",
+                        "Green 6",
+                        "Blue 6",
+                        "White 6",
+                        "Red 7",
+                        "Green 7",
+                        "Blue 7",
+                        "White 7",
+                        "Red 8",
+                        "Green 8",
+                        "Blue 8",
+                        "White 8",
+                        "Red 9",
+                        "Green 9",
+                        "Blue 9",
+                        "White 9",
+                        "Red 10",
+                        "Green 10",
+                        "Blue 10",
+                        "White 10"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Anolis",
+            "name": "ArcPower 360 Mode 3",
+            "shortName": "APower 360 M3",
+            "comment": "Mode 3 - RGBW 10 Zones + Macro + Shutter + Dimmer",
+            "physical": {
+                "dimensions": [100, 100, 100],
+                "weight": 6,
+                "power": 600
+            },
+            "availableChannels": {
+                "Red 1": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green 1": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue 1": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "White 1": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Red 2": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green 2": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue 2": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "White 2": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Red 3": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green 3": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue 3": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "White 3": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Red 4": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green 4": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue 4": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "White 4": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Red 5": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green 5": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue 5": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "White 5": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Red 6": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green 6": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue 6": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "White 6": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Red 7": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green 7": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue 7": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "White 7": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Red 8": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green 8": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue 8": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "White 8": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Red 9": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green 9": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue 9": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "White 9": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Red 10": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green 10": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue 10": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "White 10": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Macro": {
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Shutter": {
+                    "type": "Shutter",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                }
+            },
+            "modes": [
+                {
+                    "name": "43-channel Mode",
+                    "shortName": "43ch",
+                    "channels": [
+                        "Red 1",
+                        "Green 1",
+                        "Blue 1",
+                        "White 1",
+                        "Red 2",
+                        "Green 2",
+                        "Blue 2",
+                        "White 2",
+                        "Red 3",
+                        "Green 3",
+                        "Blue 3",
+                        "White 3",
+                        "Red 4",
+                        "Green 4",
+                        "Blue 4",
+                        "White 4",
+                        "Red 5",
+                        "Green 5",
+                        "Blue 5",
+                        "White 5",
+                        "Red 6",
+                        "Green 6",
+                        "Blue 6",
+                        "White 6",
+                        "Red 7",
+                        "Green 7",
+                        "Blue 7",
+                        "White 7",
+                        "Red 8",
+                        "Green 8",
+                        "Blue 8",
+                        "White 8",
+                        "Red 9",
+                        "Green 9",
+                        "Blue 9",
+                        "White 9",
+                        "Red 10",
+                        "Green 10",
+                        "Blue 10",
+                        "White 10",
+                        "Macro",
+                        "Shutter",
+                        "Intensity"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Anolis",
+            "name": "ArcPower 360 Mode 4",
+            "shortName": "APower 360 M4",
+            "comment": "Mode 4 - RGB + Dimmer",
+            "physical": {
+                "dimensions": [100, 100, 100],
+                "weight": 6,
+                "power": 600
+            },
+            "availableChannels": {
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                }
+            },
+            "modes": [
+                {
+                    "name": "4-channel Mode",
+                    "shortName": "4ch",
+                    "channels": [
+                        "Red",
+                        "Green",
+                        "Blue",
+                        "Intensity"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Anolis",
+            "name": "ArcPower 360 Mode 5",
+            "shortName": "APower 360 M5",
+            "comment": "Mode 5 - RGBW + Dimmer",
+            "physical": {
+                "dimensions": [100, 100, 100],
+                "weight": 6,
+                "power": 600
+            },
+            "availableChannels": {
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "White": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                }
+            },
+            "modes": [
+                {
+                    "name": "5-channel Mode",
+                    "shortName": "5ch",
+                    "channels": [
+                        "Red",
+                        "Green",
+                        "Blue",
+                        "White",
+                        "Intensity"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Anolis",
+            "name": "ArcPower 36K2 Mode 1",
+            "shortName": "APower 36_K2 M1",
+            "comment": "Mode 1 - RGB",
+            "physical": {
+                "dimensions": [100, 100, 100],
+                "weight": 1,
+                "power": 120
+            },
+            "availableChannels": {
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                }
+            },
+            "modes": [
+                {
+                    "name": "3-channel Mode",
+                    "shortName": "3ch",
+                    "channels": [
+                        "Red",
+                        "Green",
+                        "Blue"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Anolis",
+            "name": "ArcPower 36K2 Mode 2",
+            "shortName": "APower 36_K2 M2",
+            "comment": "Mode 2 - RGBW",
+            "physical": {
+                "dimensions": [100, 100, 100],
+                "weight": 1,
+                "power": 120
+            },
+            "availableChannels": {
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "White": {
+                    "type": "MultiColor",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 7],
+                            "name": "No Function",
+                            "center": true
+                        },
+                        {
+                            "range": [8, 15],
+                            "name": "Macro 1",
+                            "center": true
+                        },
+                        {
+                            "range": [16, 23],
+                            "name": "Macro 2",
+                            "center": true
+                        },
+                        {
+                            "range": [24, 31],
+                            "name": "Macro 3",
+                            "center": true
+                        },
+                        {
+                            "range": [32, 39],
+                            "name": "Macro 4",
+                            "center": true
+                        },
+                        {
+                            "range": [40, 47],
+                            "name": "Macro 5",
+                            "center": true
+                        },
+                        {
+                            "range": [48, 55],
+                            "name": "Macro 6",
+                            "center": true
+                        },
+                        {
+                            "range": [56, 63],
+                            "name": "Macro 7",
+                            "center": true
+                        },
+                        {
+                            "range": [64, 71],
+                            "name": "Macro 8",
+                            "center": true
+                        },
+                        {
+                            "range": [72, 79],
+                            "name": "Macro 9",
+                            "center": true
+                        },
+                        {
+                            "range": [80, 87],
+                            "name": "Macro 10",
+                            "center": true
+                        },
+                        {
+                            "range": [88, 95],
+                            "name": "Macro 11",
+                            "center": true
+                        },
+                        {
+                            "range": [96, 103],
+                            "name": "Macro 12",
+                            "center": true
+                        },
+                        {
+                            "range": [104, 111],
+                            "name": "Macro 13",
+                            "center": true
+                        },
+                        {
+                            "range": [112, 119],
+                            "name": "Macro 14",
+                            "center": true
+                        },
+                        {
+                            "range": [120, 127],
+                            "name": "Macro 15",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 135],
+                            "name": "Macro 16",
+                            "center": true
+                        },
+                        {
+                            "range": [136, 143],
+                            "name": "Macro 17",
+                            "center": true
+                        },
+                        {
+                            "range": [144, 151],
+                            "name": "Macro 18",
+                            "center": true
+                        },
+                        {
+                            "range": [152, 159],
+                            "name": "Macro 19",
+                            "center": true
+                        },
+                        {
+                            "range": [160, 167],
+                            "name": "Macro 20",
+                            "center": true
+                        },
+                        {
+                            "range": [168, 175],
+                            "name": "Macro 21",
+                            "center": true
+                        },
+                        {
+                            "range": [176, 183],
+                            "name": "Macro 22",
+                            "center": true
+                        },
+                        {
+                            "range": [184, 191],
+                            "name": "Macro 23",
+                            "center": true
+                        },
+                        {
+                            "range": [192, 199],
+                            "name": "Macro 24",
+                            "center": true
+                        },
+                        {
+                            "range": [200, 207],
+                            "name": "Macro 25",
+                            "center": true
+                        },
+                        {
+                            "range": [208, 215],
+                            "name": "Macro 26",
+                            "center": true
+                        },
+                        {
+                            "range": [216, 223],
+                            "name": "Macro 27",
+                            "center": true
+                        },
+                        {
+                            "range": [224, 231],
+                            "name": "Macro 28",
+                            "center": true
+                        },
+                        {
+                            "range": [232, 239],
+                            "name": "Macro 29",
+                            "center": true
+                        },
+                        {
+                            "range": [240, 247],
+                            "name": "Macro 30",
+                            "center": true
+                        },
+                        {
+                            "range": [248, 255],
+                            "name": "Macro 31",
+                            "center": true
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "4-channel Mode",
+                    "shortName": "4ch",
+                    "channels": [
+                        "Red",
+                        "Green",
+                        "Blue",
+                        "White"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Anolis",
+            "name": "ArcPower 36K2 Mode 3",
+            "shortName": "APower 36_K2 M3",
+            "comment": "Mode 3 - RGB + Macro + Shutter + Dimmer",
+            "physical": {
+                "dimensions": [100, 100, 100],
+                "weight": 1,
+                "power": 120
+            },
+            "availableChannels": {
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Macro": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 7],
+                            "name": "No Function",
+                            "center": true
+                        },
+                        {
+                            "range": [8, 15],
+                            "name": "Macro 1",
+                            "center": true
+                        },
+                        {
+                            "range": [16, 23],
+                            "name": "Macro 2",
+                            "center": true
+                        },
+                        {
+                            "range": [24, 31],
+                            "name": "Macro 3",
+                            "center": true
+                        },
+                        {
+                            "range": [32, 39],
+                            "name": "Macro 4",
+                            "center": true
+                        },
+                        {
+                            "range": [40, 47],
+                            "name": "Macro 5",
+                            "center": true
+                        },
+                        {
+                            "range": [48, 55],
+                            "name": "Macro 6",
+                            "center": true
+                        },
+                        {
+                            "range": [56, 63],
+                            "name": "Macro 7",
+                            "center": true
+                        },
+                        {
+                            "range": [64, 71],
+                            "name": "Macro 8",
+                            "center": true
+                        },
+                        {
+                            "range": [72, 79],
+                            "name": "Macro 9",
+                            "center": true
+                        },
+                        {
+                            "range": [80, 87],
+                            "name": "Macro 10",
+                            "center": true
+                        },
+                        {
+                            "range": [88, 95],
+                            "name": "Macro 11",
+                            "center": true
+                        },
+                        {
+                            "range": [96, 103],
+                            "name": "Macro 12",
+                            "center": true
+                        },
+                        {
+                            "range": [104, 111],
+                            "name": "Macro 13",
+                            "center": true
+                        },
+                        {
+                            "range": [112, 119],
+                            "name": "Macro 14",
+                            "center": true
+                        },
+                        {
+                            "range": [120, 127],
+                            "name": "Macro 15",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 135],
+                            "name": "Macro 16",
+                            "center": true
+                        },
+                        {
+                            "range": [136, 143],
+                            "name": "Macro 17",
+                            "center": true
+                        },
+                        {
+                            "range": [144, 151],
+                            "name": "Macro 18",
+                            "center": true
+                        },
+                        {
+                            "range": [152, 159],
+                            "name": "Macro 19",
+                            "center": true
+                        },
+                        {
+                            "range": [160, 167],
+                            "name": "Macro 20",
+                            "center": true
+                        },
+                        {
+                            "range": [168, 175],
+                            "name": "Macro 21",
+                            "center": true
+                        },
+                        {
+                            "range": [176, 183],
+                            "name": "Macro 22",
+                            "center": true
+                        },
+                        {
+                            "range": [184, 191],
+                            "name": "Macro 23",
+                            "center": true
+                        },
+                        {
+                            "range": [192, 199],
+                            "name": "Macro 24",
+                            "center": true
+                        },
+                        {
+                            "range": [200, 207],
+                            "name": "Macro 25",
+                            "center": true
+                        },
+                        {
+                            "range": [208, 215],
+                            "name": "Macro 26",
+                            "center": true
+                        },
+                        {
+                            "range": [216, 223],
+                            "name": "Macro 27",
+                            "center": true
+                        },
+                        {
+                            "range": [224, 231],
+                            "name": "Macro 28",
+                            "center": true
+                        },
+                        {
+                            "range": [232, 239],
+                            "name": "Macro 29",
+                            "center": true
+                        },
+                        {
+                            "range": [240, 247],
+                            "name": "Macro 30",
+                            "center": true
+                        },
+                        {
+                            "range": [248, 255],
+                            "name": "Macro 31",
+                            "center": true
+                        }
+                    ]
+                },
+                "Shutter": {
+                    "type": "Shutter",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 31],
+                            "name": "Closed",
+                            "center": true
+                        },
+                        {
+                            "range": [32, 63],
+                            "name": "Open",
+                            "center": true
+                        },
+                        {
+                            "range": [64, 95],
+                            "name": "Strobe S-F"
+                        },
+                        {
+                            "range": [96, 127],
+                            "name": "Open",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 143],
+                            "name": "Pulse Open"
+                        },
+                        {
+                            "range": [144, 159],
+                            "name": "Pulse Close"
+                        },
+                        {
+                            "range": [160, 191],
+                            "name": "Open",
+                            "center": true
+                        },
+                        {
+                            "range": [192, 223],
+                            "name": "Random S-F"
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "Open",
+                            "center": true
+                        }
+                    ]
+                },
+                "Dimmer": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                }
+            },
+            "modes": [
+                {
+                    "name": "6-channel Mode",
+                    "shortName": "6ch",
+                    "channels": [
+                        "Red",
+                        "Green",
+                        "Blue",
+                        "Macro",
+                        "Shutter",
+                        "Dimmer"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Anolis",
+            "name": "ArcPower 36K2 Mode 4",
+            "shortName": "APower 36_K2 M4",
+            "comment": "Mode 4 - RGBW + Macro + Shutter + Dimmer",
+            "physical": {
+                "dimensions": [100, 100, 100],
+                "weight": 1,
+                "power": 120
+            },
+            "availableChannels": {
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "White": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Macro": {
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Shutter": {
+                    "type": "Shutter",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                }
+            },
+            "modes": [
+                {
+                    "name": "7-channel Mode",
+                    "shortName": "7ch",
+                    "channels": [
+                        "Red",
+                        "Green",
+                        "Blue",
+                        "White",
+                        "Macro",
+                        "Shutter",
+                        "Intensity"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Anolis",
+            "name": "ArcPower 36K2 Mode 5",
+            "shortName": "APower 36_K2 M5",
+            "comment": "Mode 5 - RGB + Dimmer",
+            "physical": {
+                "dimensions": [100, 100, 100],
+                "weight": 1,
+                "power": 120
+            },
+            "availableChannels": {
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Dimmer": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                }
+            },
+            "modes": [
+                {
+                    "name": "4-channel Mode",
+                    "shortName": "4ch",
+                    "channels": [
+                        "Red",
+                        "Green",
+                        "Blue",
+                        "Dimmer"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Anolis",
+            "name": "ArcPower 48 Mode 1",
+            "shortName": "APower 48 M1",
+            "comment": "Mode 1 - RGB",
+            "physical": {
+                "dimensions": [100, 100, 100],
+                "weight": 1,
+                "power": 60
+            },
+            "availableChannels": {
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                }
+            },
+            "modes": [
+                {
+                    "name": "3-channel Mode",
+                    "shortName": "3ch",
+                    "channels": [
+                        "Red",
+                        "Green",
+                        "Blue"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Anolis",
+            "name": "ArcPower 48 Mode 2",
+            "shortName": "APower 48 M2",
+            "comment": "Mode 2 - RGBW",
+            "physical": {
+                "dimensions": [100, 100, 100],
+                "weight": 1,
+                "power": 60
+            },
+            "availableChannels": {
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "White": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                }
+            },
+            "modes": [
+                {
+                    "name": "4-channel Mode",
+                    "shortName": "4ch",
+                    "channels": [
+                        "Red",
+                        "Green",
+                        "Blue",
+                        "White"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Anolis",
+            "name": "ArcPower 48 Mode 3",
+            "shortName": "APower 48 M3",
+            "comment": "Mode 3 - RGB + Macro + Shutter + Dimmer",
+            "physical": {
+                "dimensions": [100, 100, 100],
+                "weight": 1,
+                "power": 60
+            },
+            "availableChannels": {
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Macro": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 7],
+                            "name": "No Function",
+                            "center": true
+                        },
+                        {
+                            "range": [8, 15],
+                            "name": "Macro 1",
+                            "center": true
+                        },
+                        {
+                            "range": [16, 23],
+                            "name": "Macro 2",
+                            "center": true
+                        },
+                        {
+                            "range": [24, 31],
+                            "name": "Macro 3",
+                            "center": true
+                        },
+                        {
+                            "range": [32, 39],
+                            "name": "Macro 4",
+                            "center": true
+                        },
+                        {
+                            "range": [40, 47],
+                            "name": "Macro 5",
+                            "center": true
+                        },
+                        {
+                            "range": [48, 55],
+                            "name": "Macro 6",
+                            "center": true
+                        },
+                        {
+                            "range": [56, 63],
+                            "name": "Macro 7",
+                            "center": true
+                        },
+                        {
+                            "range": [64, 71],
+                            "name": "Macro 8",
+                            "center": true
+                        },
+                        {
+                            "range": [72, 79],
+                            "name": "Macro 9",
+                            "center": true
+                        },
+                        {
+                            "range": [80, 87],
+                            "name": "Macro 10",
+                            "center": true
+                        },
+                        {
+                            "range": [88, 95],
+                            "name": "Macro 11",
+                            "center": true
+                        },
+                        {
+                            "range": [96, 103],
+                            "name": "Macro 12",
+                            "center": true
+                        },
+                        {
+                            "range": [104, 111],
+                            "name": "Macro 13",
+                            "center": true
+                        },
+                        {
+                            "range": [112, 119],
+                            "name": "Macro 14",
+                            "center": true
+                        },
+                        {
+                            "range": [120, 127],
+                            "name": "Macro 15",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 135],
+                            "name": "Macro 16",
+                            "center": true
+                        },
+                        {
+                            "range": [136, 143],
+                            "name": "Macro 17",
+                            "center": true
+                        },
+                        {
+                            "range": [144, 151],
+                            "name": "Macro 18",
+                            "center": true
+                        },
+                        {
+                            "range": [152, 159],
+                            "name": "Macro 19",
+                            "center": true
+                        },
+                        {
+                            "range": [160, 167],
+                            "name": "Macro 20",
+                            "center": true
+                        },
+                        {
+                            "range": [168, 175],
+                            "name": "Macro 21",
+                            "center": true
+                        },
+                        {
+                            "range": [176, 183],
+                            "name": "Macro 22",
+                            "center": true
+                        },
+                        {
+                            "range": [184, 191],
+                            "name": "Macro 23",
+                            "center": true
+                        },
+                        {
+                            "range": [192, 199],
+                            "name": "Macro 24",
+                            "center": true
+                        },
+                        {
+                            "range": [200, 207],
+                            "name": "Macro 25",
+                            "center": true
+                        },
+                        {
+                            "range": [208, 215],
+                            "name": "Macro 26",
+                            "center": true
+                        },
+                        {
+                            "range": [216, 223],
+                            "name": "Macro 27",
+                            "center": true
+                        },
+                        {
+                            "range": [224, 231],
+                            "name": "Macro 28",
+                            "center": true
+                        },
+                        {
+                            "range": [232, 239],
+                            "name": "Macro 29",
+                            "center": true
+                        },
+                        {
+                            "range": [240, 247],
+                            "name": "Macro 30",
+                            "center": true
+                        },
+                        {
+                            "range": [248, 255],
+                            "name": "Macro 31",
+                            "center": true
+                        }
+                    ]
+                },
+                "Shutter": {
+                    "type": "Shutter",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 31],
+                            "name": "Closed",
+                            "center": true
+                        },
+                        {
+                            "range": [32, 63],
+                            "name": "Open",
+                            "center": true
+                        },
+                        {
+                            "range": [64, 95],
+                            "name": "Strobe S-F"
+                        },
+                        {
+                            "range": [96, 127],
+                            "name": "Open",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 143],
+                            "name": "Pulse Open"
+                        },
+                        {
+                            "range": [144, 159],
+                            "name": "Pulse Close"
+                        },
+                        {
+                            "range": [160, 191],
+                            "name": "Open",
+                            "center": true
+                        },
+                        {
+                            "range": [192, 223],
+                            "name": "Random S-F"
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "Open",
+                            "center": true
+                        }
+                    ]
+                },
+                "Dimmer": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                }
+            },
+            "modes": [
+                {
+                    "name": "6-channel Mode",
+                    "shortName": "6ch",
+                    "channels": [
+                        "Red",
+                        "Green",
+                        "Blue",
+                        "Macro",
+                        "Shutter",
+                        "Dimmer"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Anolis",
+            "name": "ArcPower 48 Mode 4",
+            "shortName": "APower 48 M4",
+            "comment": "Mode 4 - RGBW + Macro + Shutter + Dimmer",
+            "physical": {
+                "dimensions": [100, 100, 100],
+                "weight": 1,
+                "power": 60
+            },
+            "availableChannels": {
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "White": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Macro": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 7],
+                            "name": "No Function",
+                            "center": true
+                        },
+                        {
+                            "range": [8, 15],
+                            "name": "Macro 1",
+                            "center": true
+                        },
+                        {
+                            "range": [16, 23],
+                            "name": "Macro 2",
+                            "center": true
+                        },
+                        {
+                            "range": [24, 31],
+                            "name": "Macro 3",
+                            "center": true
+                        },
+                        {
+                            "range": [32, 39],
+                            "name": "Macro 4",
+                            "center": true
+                        },
+                        {
+                            "range": [40, 47],
+                            "name": "Macro 5",
+                            "center": true
+                        },
+                        {
+                            "range": [48, 55],
+                            "name": "Macro 6",
+                            "center": true
+                        },
+                        {
+                            "range": [56, 63],
+                            "name": "Macro 7",
+                            "center": true
+                        },
+                        {
+                            "range": [64, 71],
+                            "name": "Macro 8",
+                            "center": true
+                        },
+                        {
+                            "range": [72, 79],
+                            "name": "Macro 9",
+                            "center": true
+                        },
+                        {
+                            "range": [80, 87],
+                            "name": "Macro 10",
+                            "center": true
+                        },
+                        {
+                            "range": [88, 95],
+                            "name": "Macro 11",
+                            "center": true
+                        },
+                        {
+                            "range": [96, 103],
+                            "name": "Macro 12",
+                            "center": true
+                        },
+                        {
+                            "range": [104, 111],
+                            "name": "Macro 13",
+                            "center": true
+                        },
+                        {
+                            "range": [112, 119],
+                            "name": "Macro 14",
+                            "center": true
+                        },
+                        {
+                            "range": [120, 127],
+                            "name": "Macro 15",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 135],
+                            "name": "Macro 16",
+                            "center": true
+                        },
+                        {
+                            "range": [136, 143],
+                            "name": "Macro 17",
+                            "center": true
+                        },
+                        {
+                            "range": [144, 151],
+                            "name": "Macro 18",
+                            "center": true
+                        },
+                        {
+                            "range": [152, 159],
+                            "name": "Macro 19",
+                            "center": true
+                        },
+                        {
+                            "range": [160, 167],
+                            "name": "Macro 20",
+                            "center": true
+                        },
+                        {
+                            "range": [168, 175],
+                            "name": "Macro 21",
+                            "center": true
+                        },
+                        {
+                            "range": [176, 183],
+                            "name": "Macro 22",
+                            "center": true
+                        },
+                        {
+                            "range": [184, 191],
+                            "name": "Macro 23",
+                            "center": true
+                        },
+                        {
+                            "range": [192, 199],
+                            "name": "Macro 24",
+                            "center": true
+                        },
+                        {
+                            "range": [200, 207],
+                            "name": "Macro 25",
+                            "center": true
+                        },
+                        {
+                            "range": [208, 215],
+                            "name": "Macro 26",
+                            "center": true
+                        },
+                        {
+                            "range": [216, 223],
+                            "name": "Macro 27",
+                            "center": true
+                        },
+                        {
+                            "range": [224, 231],
+                            "name": "Macro 28",
+                            "center": true
+                        },
+                        {
+                            "range": [232, 239],
+                            "name": "Macro 29",
+                            "center": true
+                        },
+                        {
+                            "range": [240, 247],
+                            "name": "Macro 30",
+                            "center": true
+                        },
+                        {
+                            "range": [248, 255],
+                            "name": "Macro 31",
+                            "center": true
+                        }
+                    ]
+                },
+                "Shutter": {
+                    "type": "Shutter",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 31],
+                            "name": "Closed",
+                            "center": true
+                        },
+                        {
+                            "range": [32, 63],
+                            "name": "Open",
+                            "center": true
+                        },
+                        {
+                            "range": [64, 95],
+                            "name": "Strobe S-F"
+                        },
+                        {
+                            "range": [96, 127],
+                            "name": "Open",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 143],
+                            "name": "Pulse Open"
+                        },
+                        {
+                            "range": [144, 159],
+                            "name": "Pulse Close"
+                        },
+                        {
+                            "range": [160, 191],
+                            "name": "Open",
+                            "center": true
+                        },
+                        {
+                            "range": [192, 223],
+                            "name": "Random S-F"
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "Open",
+                            "center": true
+                        }
+                    ]
+                },
+                "Dimmer": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                }
+            },
+            "modes": [
+                {
+                    "name": "7-channel Mode",
+                    "shortName": "7ch",
+                    "channels": [
+                        "Red",
+                        "Green",
+                        "Blue",
+                        "White",
+                        "Macro",
+                        "Shutter",
+                        "Dimmer"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Anolis",
+            "name": "ArcPower 48 Mode 5",
+            "shortName": "APower 48 M5",
+            "comment": "Mode 5 - RGB + Dimmer",
+            "physical": {
+                "dimensions": [100, 100, 100],
+                "weight": 1,
+                "power": 60
+            },
+            "availableChannels": {
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Dimmer": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                }
+            },
+            "modes": [
+                {
+                    "name": "4-channel Mode",
+                    "shortName": "4ch",
+                    "channels": [
+                        "Red",
+                        "Green",
+                        "Blue",
+                        "Dimmer"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Anolis",
+            "name": "ArcPower 72 Mode 1",
+            "shortName": "APower 72 M1",
+            "comment": "Mode 1 - RGB 2 Zones",
+            "physical": {
+                "dimensions": [100, 100, 100],
+                "weight": 1,
+                "power": 120
+            },
+            "availableChannels": {
+                "Red 1": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green 1": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue 1": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Red 2": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green 2": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue 2": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                }
+            },
+            "modes": [
+                {
+                    "name": "4-channel Mode",
+                    "shortName": "4ch",
+                    "channels": [
+                        "Red 1",
+                        "Green 1",
+                        "Blue 1",
+                        "Blue 2"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Anolis",
+            "name": "ArcPower 72 Mode 2",
+            "shortName": "APower 72 M2",
+            "comment": "Mode 2 - RGBW 2 Zones",
+            "physical": {
+                "dimensions": [100, 100, 100],
+                "weight": 1,
+                "power": 120
+            },
+            "availableChannels": {
+                "Red 1": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green 1": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue 1": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "White 1": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Red 2": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green 2": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue 2": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "White 2": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                }
+            },
+            "modes": [
+                {
+                    "name": "8-channel Mode",
+                    "shortName": "8ch",
+                    "channels": [
+                        "Red 1",
+                        "Green 1",
+                        "Blue 1",
+                        "White 1",
+                        "Red 2",
+                        "Green 2",
+                        "Blue 2",
+                        "White 2"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Anolis",
+            "name": "ArcPower 72 Mode 3",
+            "shortName": "APower 72 M3",
+            "comment": "Mode 3 - RGBW 2 Zones + Macro + Shutter + Dimmer",
+            "physical": {
+                "dimensions": [100, 100, 100],
+                "weight": 1,
+                "power": 120
+            },
+            "availableChannels": {
+                "Red 1": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green 1": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue 1": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "White 1": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Red 2": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green 2": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue 2": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "White 2": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Macro": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 7],
+                            "name": "No Function",
+                            "center": true
+                        },
+                        {
+                            "range": [8, 15],
+                            "name": "Macro 1",
+                            "center": true
+                        },
+                        {
+                            "range": [16, 23],
+                            "name": "Macro 2",
+                            "center": true
+                        },
+                        {
+                            "range": [24, 31],
+                            "name": "Macro 3",
+                            "center": true
+                        },
+                        {
+                            "range": [32, 39],
+                            "name": "Macro 4",
+                            "center": true
+                        },
+                        {
+                            "range": [40, 47],
+                            "name": "Macro 5",
+                            "center": true
+                        },
+                        {
+                            "range": [48, 55],
+                            "name": "Macro 6",
+                            "center": true
+                        },
+                        {
+                            "range": [56, 63],
+                            "name": "Macro 7",
+                            "center": true
+                        },
+                        {
+                            "range": [64, 71],
+                            "name": "Macro 8",
+                            "center": true
+                        },
+                        {
+                            "range": [72, 79],
+                            "name": "Macro 9",
+                            "center": true
+                        },
+                        {
+                            "range": [80, 87],
+                            "name": "Macro 10",
+                            "center": true
+                        },
+                        {
+                            "range": [88, 95],
+                            "name": "Macro 11",
+                            "center": true
+                        },
+                        {
+                            "range": [96, 103],
+                            "name": "Macro 12",
+                            "center": true
+                        },
+                        {
+                            "range": [104, 111],
+                            "name": "Macro 13",
+                            "center": true
+                        },
+                        {
+                            "range": [112, 119],
+                            "name": "Macro 14",
+                            "center": true
+                        },
+                        {
+                            "range": [120, 127],
+                            "name": "Macro 15",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 135],
+                            "name": "Macro 16",
+                            "center": true
+                        },
+                        {
+                            "range": [136, 143],
+                            "name": "Macro 17",
+                            "center": true
+                        },
+                        {
+                            "range": [144, 151],
+                            "name": "Macro 18",
+                            "center": true
+                        },
+                        {
+                            "range": [152, 159],
+                            "name": "Macro 19",
+                            "center": true
+                        },
+                        {
+                            "range": [160, 167],
+                            "name": "Macro 20",
+                            "center": true
+                        },
+                        {
+                            "range": [168, 175],
+                            "name": "Macro 21",
+                            "center": true
+                        },
+                        {
+                            "range": [176, 183],
+                            "name": "Macro 22",
+                            "center": true
+                        },
+                        {
+                            "range": [184, 191],
+                            "name": "Macro 23",
+                            "center": true
+                        },
+                        {
+                            "range": [192, 199],
+                            "name": "Macro 24",
+                            "center": true
+                        },
+                        {
+                            "range": [200, 207],
+                            "name": "Macro 25",
+                            "center": true
+                        },
+                        {
+                            "range": [208, 215],
+                            "name": "Macro 26",
+                            "center": true
+                        },
+                        {
+                            "range": [216, 223],
+                            "name": "Macro 27",
+                            "center": true
+                        },
+                        {
+                            "range": [224, 231],
+                            "name": "Macro 28",
+                            "center": true
+                        },
+                        {
+                            "range": [232, 239],
+                            "name": "Macro 29",
+                            "center": true
+                        },
+                        {
+                            "range": [240, 247],
+                            "name": "Macro 30",
+                            "center": true
+                        },
+                        {
+                            "range": [248, 255],
+                            "name": "Macro 31",
+                            "center": true
+                        }
+                    ]
+                },
+                "Shutter": {
+                    "type": "Shutter",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 31],
+                            "name": "Closed",
+                            "center": true
+                        },
+                        {
+                            "range": [32, 63],
+                            "name": "Open",
+                            "center": true
+                        },
+                        {
+                            "range": [64, 95],
+                            "name": "Strobe S-F"
+                        },
+                        {
+                            "range": [96, 127],
+                            "name": "Open",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 143],
+                            "name": "Pulse Open"
+                        },
+                        {
+                            "range": [144, 159],
+                            "name": "Pulse Close"
+                        },
+                        {
+                            "range": [160, 191],
+                            "name": "Open",
+                            "center": true
+                        },
+                        {
+                            "range": [192, 223],
+                            "name": "Random S-F"
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "Open",
+                            "center": true
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                }
+            },
+            "modes": [
+                {
+                    "name": "11-channel Mode",
+                    "shortName": "11ch",
+                    "channels": [
+                        "Red 1",
+                        "Green 1",
+                        "Blue 1",
+                        "White 1",
+                        "Red 2",
+                        "Green 2",
+                        "Blue 2",
+                        "White 2",
+                        "Macro",
+                        "Shutter",
+                        "Intensity"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Anolis",
+            "name": "ArcPower 72 Mode 4",
+            "shortName": "APower 72 M4",
+            "comment": "Mode 4 - RGB 1 Zone",
+            "physical": {
+                "dimensions": [100, 100, 100],
+                "weight": 1,
+                "power": 120
+            },
+            "availableChannels": {
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                }
+            },
+            "modes": [
+                {
+                    "name": "3-channel Mode",
+                    "shortName": "3ch",
+                    "channels": [
+                        "Red",
+                        "Green",
+                        "Blue"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Anolis",
+            "name": "ArcPower 72 SW Mode 1",
+            "shortName": "APower 72 SW M1",
+            "comment": "Mode 1 - SW 2 Zones",
+            "physical": {
+                "dimensions": [100, 100, 100],
+                "weight": 1,
+                "power": 120
+            },
+            "availableChannels": {
+                "WarmWhite 1": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "ColdWhite 1": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "WarmWhite 2": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "ColdWhite 2": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                }
+            },
+            "modes": [
+                {
+                    "name": "12-channel Mode",
+                    "shortName": "12ch",
+                    "channels": [
+                        "WarmWhite 1",
+                        "ColdWhite 1",
+                        "WarmWhite 2",
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        "ColdWhite 2"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Anolis",
+            "name": "ArcPower 72 SW Mode 2",
+            "shortName": "APower 72 SW M2",
+            "comment": "Mode 2 - All LEDs Saturation",
+            "physical": {
+                "dimensions": [100, 100, 100],
+                "weight": 1,
+                "power": 120
+            },
+            "availableChannels": {
+                "Intensity All L": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                }
+            },
+            "modes": [
+                {
+                    "name": "1-channel Mode",
+                    "shortName": "1ch",
+                    "channels": [
+                        "Intensity All L"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Anolis",
+            "name": "ArcPower 72 SW Mode 3",
+            "shortName": "APower 72 SW M3",
+            "comment": "Mode 3 - Ratio 2 Zones + Dimmer",
+            "physical": {
+                "dimensions": [100, 100, 100],
+                "weight": 1,
+                "power": 120
+            },
+            "availableChannels": {
+                "Ratio Control 1": {
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Ratio Control 2": {
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                }
+            },
+            "modes": [
+                {
+                    "name": "3-channel Mode",
+                    "shortName": "3ch",
+                    "channels": [
+                        "Ratio Control 1",
+                        "Ratio Control 2",
+                        "Intensity"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Anolis",
+            "name": "ArcPower 72 SW Mode 4",
+            "shortName": "APower 72 SW M4",
+            "comment": "Mode 4 - SW 2 Zones + Shutter + Dimmer",
+            "physical": {
+                "dimensions": [100, 100, 100],
+                "weight": 1,
+                "power": 120
+            },
+            "availableChannels": {
+                "WarmWhite 1": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "ColdWhite 1": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "WarmWhite 2": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Shutter": {
+                    "type": "Shutter",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 31],
+                            "name": "Closed",
+                            "center": true
+                        },
+                        {
+                            "range": [32, 63],
+                            "name": "Open",
+                            "center": true
+                        },
+                        {
+                            "range": [64, 95],
+                            "name": "Strobe S-F"
+                        },
+                        {
+                            "range": [96, 127],
+                            "name": "Open",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 143],
+                            "name": "Pulse Open"
+                        },
+                        {
+                            "range": [144, 159],
+                            "name": "Pulse Close"
+                        },
+                        {
+                            "range": [160, 191],
+                            "name": "Open",
+                            "center": true
+                        },
+                        {
+                            "range": [192, 223],
+                            "name": "Random S-F"
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "Open",
+                            "center": true
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "ColdWhite 2": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                }
+            },
+            "modes": [
+                {
+                    "name": "12-channel Mode",
+                    "shortName": "12ch",
+                    "channels": [
+                        "WarmWhite 1",
+                        "ColdWhite 1",
+                        "WarmWhite 2",
+                        null,
+                        "Shutter",
+                        "Intensity",
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        "ColdWhite 2"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Anolis",
+            "name": "ArcPower 72 SW Mode 5",
+            "shortName": "APower 72 SW M5",
+            "comment": "Mode 5 - SW 1 Zone + Dimmer",
+            "physical": {
+                "dimensions": [100, 100, 100],
+                "weight": 1,
+                "power": 120
+            },
+            "availableChannels": {
+                "WarmWhite": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "ColdWhite": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                }
+            },
+            "modes": [
+                {
+                    "name": "3-channel Mode",
+                    "shortName": "3ch",
+                    "channels": [
+                        "WarmWhite",
+                        "ColdWhite",
+                        "Intensity"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Anolis",
+            "name": "ArcPower 72 SW Mode 6",
+            "shortName": "APower 72 SW M6",
+            "comment": "Mode 6 - SW 2 Zones + 2 Dimmers",
+            "physical": {
+                "dimensions": [100, 100, 100],
+                "weight": 1,
+                "power": 120
+            },
+            "availableChannels": {
+                "WarmWhite 1": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "ColdWhite 1": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Intensity 1": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "WarmWhite 2": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "ColdWhite 2": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Intensity 2": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                }
+            },
+            "modes": [
+                {
+                    "name": "6-channel Mode",
+                    "shortName": "6ch",
+                    "channels": [
+                        "WarmWhite 1",
+                        "ColdWhite 1",
+                        "Intensity 1",
+                        "WarmWhite 2",
+                        "ColdWhite 2",
+                        "Intensity 2"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Anolis",
+            "name": "ArcPower 72K2 Mode 1",
+            "shortName": "APower 72_K2 M1",
+            "comment": "Mode 1 - RGB 2 Zones",
+            "physical": {
+                "dimensions": [100, 100, 100],
+                "weight": 2,
+                "power": 240
+            },
+            "availableChannels": {
+                "Red 1": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green 1": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue 1": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Red 2": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green 2": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue 2": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                }
+            },
+            "modes": [
+                {
+                    "name": "6-channel Mode",
+                    "shortName": "6ch",
+                    "channels": [
+                        "Red 1",
+                        "Green 1",
+                        "Blue 1",
+                        "Red 2",
+                        "Green 2",
+                        "Blue 2"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Anolis",
+            "name": "ArcPower 72K2 Mode 2",
+            "shortName": "APower 72_K2 M2",
+            "comment": "Mode 2 - RGBW 2 Zones",
+            "physical": {
+                "dimensions": [100, 100, 100],
+                "weight": 2,
+                "power": 240
+            },
+            "availableChannels": {
+                "Red 1": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green 1": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue 1": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "White 1": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Red 2": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green 2": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue 2": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "White 2": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                }
+            },
+            "modes": [
+                {
+                    "name": "8-channel Mode",
+                    "shortName": "8ch",
+                    "channels": [
+                        "Red 1",
+                        "Green 1",
+                        "Blue 1",
+                        "White 1",
+                        "Red 2",
+                        "Green 2",
+                        "Blue 2",
+                        "White 2"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Anolis",
+            "name": "ArcPower 72K2 Mode 3",
+            "shortName": "APower 72_K2 M3",
+            "comment": "Mode 3 - RGBW 2 Zones + Macro + Shutter + Dimmer",
+            "physical": {
+                "dimensions": [100, 100, 100],
+                "weight": 2,
+                "power": 240
+            },
+            "availableChannels": {
+                "Red 1": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green 1": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue 1": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "White 1": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Red 2": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green 2": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue 2": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "White 2": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Macro": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 7],
+                            "name": "No Function",
+                            "center": true
+                        },
+                        {
+                            "range": [8, 15],
+                            "name": "Macro 1",
+                            "center": true
+                        },
+                        {
+                            "range": [16, 23],
+                            "name": "Macro 2",
+                            "center": true
+                        },
+                        {
+                            "range": [24, 31],
+                            "name": "Macro 3",
+                            "center": true
+                        },
+                        {
+                            "range": [32, 39],
+                            "name": "Macro 4",
+                            "center": true
+                        },
+                        {
+                            "range": [40, 47],
+                            "name": "Macro 5",
+                            "center": true
+                        },
+                        {
+                            "range": [48, 55],
+                            "name": "Macro 6",
+                            "center": true
+                        },
+                        {
+                            "range": [56, 63],
+                            "name": "Macro 7",
+                            "center": true
+                        },
+                        {
+                            "range": [64, 71],
+                            "name": "Macro 8",
+                            "center": true
+                        },
+                        {
+                            "range": [72, 79],
+                            "name": "Macro 9",
+                            "center": true
+                        },
+                        {
+                            "range": [80, 87],
+                            "name": "Macro 10",
+                            "center": true
+                        },
+                        {
+                            "range": [88, 95],
+                            "name": "Macro 11",
+                            "center": true
+                        },
+                        {
+                            "range": [96, 103],
+                            "name": "Macro 12",
+                            "center": true
+                        },
+                        {
+                            "range": [104, 111],
+                            "name": "Macro 13",
+                            "center": true
+                        },
+                        {
+                            "range": [112, 119],
+                            "name": "Macro 14",
+                            "center": true
+                        },
+                        {
+                            "range": [120, 127],
+                            "name": "Macro 15",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 135],
+                            "name": "Macro 16",
+                            "center": true
+                        },
+                        {
+                            "range": [136, 143],
+                            "name": "Macro 17",
+                            "center": true
+                        },
+                        {
+                            "range": [144, 151],
+                            "name": "Macro 18",
+                            "center": true
+                        },
+                        {
+                            "range": [152, 159],
+                            "name": "Macro 19",
+                            "center": true
+                        },
+                        {
+                            "range": [160, 167],
+                            "name": "Macro 20",
+                            "center": true
+                        },
+                        {
+                            "range": [168, 175],
+                            "name": "Macro 21",
+                            "center": true
+                        },
+                        {
+                            "range": [176, 183],
+                            "name": "Macro 22",
+                            "center": true
+                        },
+                        {
+                            "range": [184, 191],
+                            "name": "Macro 23",
+                            "center": true
+                        },
+                        {
+                            "range": [192, 199],
+                            "name": "Macro 24",
+                            "center": true
+                        },
+                        {
+                            "range": [200, 207],
+                            "name": "Macro 25",
+                            "center": true
+                        },
+                        {
+                            "range": [208, 215],
+                            "name": "Macro 26",
+                            "center": true
+                        },
+                        {
+                            "range": [216, 223],
+                            "name": "Macro 27",
+                            "center": true
+                        },
+                        {
+                            "range": [224, 231],
+                            "name": "Macro 28",
+                            "center": true
+                        },
+                        {
+                            "range": [232, 239],
+                            "name": "Macro 29",
+                            "center": true
+                        },
+                        {
+                            "range": [240, 247],
+                            "name": "Macro 30",
+                            "center": true
+                        },
+                        {
+                            "range": [248, 255],
+                            "name": "Macro 31",
+                            "center": true
+                        }
+                    ]
+                },
+                "Shutter": {
+                    "type": "Shutter",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 31],
+                            "name": "Closed",
+                            "center": true
+                        },
+                        {
+                            "range": [32, 63],
+                            "name": "Open",
+                            "center": true
+                        },
+                        {
+                            "range": [64, 95],
+                            "name": "Strobe S-F"
+                        },
+                        {
+                            "range": [96, 127],
+                            "name": "Open",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 143],
+                            "name": "Pulse Open"
+                        },
+                        {
+                            "range": [144, 159],
+                            "name": "Pulse Close"
+                        },
+                        {
+                            "range": [160, 191],
+                            "name": "Open",
+                            "center": true
+                        },
+                        {
+                            "range": [192, 223],
+                            "name": "Random S-F"
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "Open",
+                            "center": true
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                }
+            },
+            "modes": [
+                {
+                    "name": "11-channel Mode",
+                    "shortName": "11ch",
+                    "channels": [
+                        "Red 1",
+                        "Green 1",
+                        "Blue 1",
+                        "White 1",
+                        "Red 2",
+                        "Green 2",
+                        "Blue 2",
+                        "White 2",
+                        "Macro",
+                        "Shutter",
+                        "Intensity"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Anolis",
+            "name": "ArcPower 72K2 Mode 4",
+            "shortName": "APower 72_K2 M4",
+            "comment": "Mode 4 - RGB 1 Zone + Dimmer",
+            "physical": {
+                "dimensions": [100, 100, 100],
+                "weight": 2,
+                "power": 240
+            },
+            "availableChannels": {
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                }
+            },
+            "modes": [
+                {
+                    "name": "4-channel Mode",
+                    "shortName": "4ch",
+                    "channels": [
+                        "Red",
+                        "Green",
+                        "Blue",
+                        "Intensity"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Anolis",
+            "name": "PowerArc 144 Mode 1",
+            "shortName": "PArc 144 M1",
+            "comment": "out of date!",
+            "physical": {
+                "dimensions": [100, 100, 100],
+                "weight": 2,
+                "power": 2
+            },
+            "availableChannels": {
+                "Red 1": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green 1": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue 1": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "White 1": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Red 2": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green 2": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue 2": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "White 2": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Red 3": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green 3": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue 3": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "White 3": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Red 4": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green 4": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue 4": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "White 4": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Makro": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 7],
+                            "name": "No Function",
+                            "center": true
+                        },
+                        {
+                            "range": [8, 15],
+                            "name": "Macro 1",
+                            "center": true
+                        },
+                        {
+                            "range": [16, 23],
+                            "name": "Macro 2",
+                            "center": true
+                        },
+                        {
+                            "range": [24, 31],
+                            "name": "Macro 3",
+                            "center": true
+                        },
+                        {
+                            "range": [32, 39],
+                            "name": "Macro 4",
+                            "center": true
+                        },
+                        {
+                            "range": [40, 47],
+                            "name": "Macro 5",
+                            "center": true
+                        },
+                        {
+                            "range": [48, 55],
+                            "name": "Macro 6",
+                            "center": true
+                        },
+                        {
+                            "range": [56, 63],
+                            "name": "Macro 7",
+                            "center": true
+                        },
+                        {
+                            "range": [64, 71],
+                            "name": "Macro 8",
+                            "center": true
+                        },
+                        {
+                            "range": [72, 79],
+                            "name": "Macro 9",
+                            "center": true
+                        },
+                        {
+                            "range": [80, 87],
+                            "name": "Macro 10",
+                            "center": true
+                        },
+                        {
+                            "range": [88, 95],
+                            "name": "Macro 11",
+                            "center": true
+                        },
+                        {
+                            "range": [96, 103],
+                            "name": "Macro 12",
+                            "center": true
+                        },
+                        {
+                            "range": [104, 111],
+                            "name": "Macro 13",
+                            "center": true
+                        },
+                        {
+                            "range": [112, 119],
+                            "name": "Macro 14",
+                            "center": true
+                        },
+                        {
+                            "range": [120, 127],
+                            "name": "Macro 15",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 135],
+                            "name": "Macro 16",
+                            "center": true
+                        },
+                        {
+                            "range": [136, 143],
+                            "name": "Macro 17",
+                            "center": true
+                        },
+                        {
+                            "range": [144, 151],
+                            "name": "Macro 18",
+                            "center": true
+                        },
+                        {
+                            "range": [152, 159],
+                            "name": "Macro 19",
+                            "center": true
+                        },
+                        {
+                            "range": [160, 167],
+                            "name": "Macro 20",
+                            "center": true
+                        },
+                        {
+                            "range": [168, 175],
+                            "name": "Macro 21",
+                            "center": true
+                        },
+                        {
+                            "range": [176, 183],
+                            "name": "Macro 22",
+                            "center": true
+                        },
+                        {
+                            "range": [184, 191],
+                            "name": "Macro 23",
+                            "center": true
+                        },
+                        {
+                            "range": [192, 199],
+                            "name": "Macro 24",
+                            "center": true
+                        },
+                        {
+                            "range": [200, 207],
+                            "name": "Macro 25",
+                            "center": true
+                        },
+                        {
+                            "range": [208, 215],
+                            "name": "Macro 26",
+                            "center": true
+                        },
+                        {
+                            "range": [216, 223],
+                            "name": "Macro 27",
+                            "center": true
+                        },
+                        {
+                            "range": [224, 231],
+                            "name": "Macro 28",
+                            "center": true
+                        },
+                        {
+                            "range": [232, 239],
+                            "name": "Macro 29",
+                            "center": true
+                        },
+                        {
+                            "range": [240, 247],
+                            "name": "Macro 30",
+                            "center": true
+                        },
+                        {
+                            "range": [248, 255],
+                            "name": "Macro 31",
+                            "center": true
+                        }
+                    ]
+                },
+                "Shutter": {
+                    "type": "Shutter",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 31],
+                            "name": "Closed",
+                            "center": true
+                        },
+                        {
+                            "range": [32, 63],
+                            "name": "Open",
+                            "center": true
+                        },
+                        {
+                            "range": [64, 95],
+                            "name": "Strobe S-F"
+                        },
+                        {
+                            "range": [96, 127],
+                            "name": "Open",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 143],
+                            "name": "Pulse Open"
+                        },
+                        {
+                            "range": [144, 159],
+                            "name": "Pulse Close"
+                        },
+                        {
+                            "range": [160, 191],
+                            "name": "Open",
+                            "center": true
+                        },
+                        {
+                            "range": [192, 223],
+                            "name": "Random S-F"
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "Open",
+                            "center": true
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                }
+            },
+            "modes": [
+                {
+                    "name": "19-channel Mode",
+                    "shortName": "19ch",
+                    "channels": [
+                        "Red 1",
+                        "Green 1",
+                        "Blue 1",
+                        "White 1",
+                        "Red 2",
+                        "Green 2",
+                        "Blue 2",
+                        "White 2",
+                        "Red 3",
+                        "Green 3",
+                        "Blue 3",
+                        "White 3",
+                        "Red 4",
+                        "Green 4",
+                        "Blue 4",
+                        "White 4",
+                        "Makro",
+                        "Shutter",
+                        "Intensity"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Anolis",
+            "name": "PowerArc 144 Mode 2",
+            "shortName": "PArc 144 M2",
+            "comment": "out of date!",
+            "physical": {
+                "dimensions": [100, 100, 100],
+                "weight": 2,
+                "power": 2
+            },
+            "availableChannels": {
+                "Red 1": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green 1": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue 1": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Red 2": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green 2": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue 2": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Red 3": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green 3": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue 3": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Red 4": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green 4": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue 4": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                }
+            },
+            "modes": [
+                {
+                    "name": "12-channel Mode",
+                    "shortName": "12ch",
+                    "channels": [
+                        "Red 1",
+                        "Green 1",
+                        "Blue 1",
+                        "Red 2",
+                        "Green 2",
+                        "Blue 2",
+                        "Red 3",
+                        "Green 3",
+                        "Blue 3",
+                        "Red 4",
+                        "Green 4",
+                        "Blue 4"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Anolis",
+            "name": "PowerArc 36 Mode 1",
+            "shortName": "PArc 36 M1",
+            "comment": "out of date!",
+            "physical": {
+                "dimensions": [100, 100, 100],
+                "weight": 1
+            },
+            "availableChannels": {
+                "Red 1": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green 1": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue 1": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "White 1": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Color Makro": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 7],
+                            "name": "No Function",
+                            "center": true
+                        },
+                        {
+                            "range": [8, 15],
+                            "name": "Macro 1",
+                            "center": true
+                        },
+                        {
+                            "range": [16, 23],
+                            "name": "Macro 2",
+                            "center": true
+                        },
+                        {
+                            "range": [24, 31],
+                            "name": "Macro 3",
+                            "center": true
+                        },
+                        {
+                            "range": [32, 39],
+                            "name": "Macro 4",
+                            "center": true
+                        },
+                        {
+                            "range": [40, 47],
+                            "name": "Macro 5",
+                            "center": true
+                        },
+                        {
+                            "range": [48, 55],
+                            "name": "Macro 6",
+                            "center": true
+                        },
+                        {
+                            "range": [56, 63],
+                            "name": "Macro 7",
+                            "center": true
+                        },
+                        {
+                            "range": [64, 71],
+                            "name": "Macro 8",
+                            "center": true
+                        },
+                        {
+                            "range": [72, 79],
+                            "name": "Macro 9",
+                            "center": true
+                        },
+                        {
+                            "range": [80, 87],
+                            "name": "Macro 10",
+                            "center": true
+                        },
+                        {
+                            "range": [88, 95],
+                            "name": "Macro 11",
+                            "center": true
+                        },
+                        {
+                            "range": [96, 103],
+                            "name": "Macro 12",
+                            "center": true
+                        },
+                        {
+                            "range": [104, 111],
+                            "name": "Macro 13",
+                            "center": true
+                        },
+                        {
+                            "range": [112, 119],
+                            "name": "Macro 14",
+                            "center": true
+                        },
+                        {
+                            "range": [120, 127],
+                            "name": "Macro 15",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 135],
+                            "name": "Macro 16",
+                            "center": true
+                        },
+                        {
+                            "range": [136, 143],
+                            "name": "Macro 17",
+                            "center": true
+                        },
+                        {
+                            "range": [144, 151],
+                            "name": "Macro 18",
+                            "center": true
+                        },
+                        {
+                            "range": [152, 159],
+                            "name": "Macro 19",
+                            "center": true
+                        },
+                        {
+                            "range": [160, 167],
+                            "name": "Macro 20",
+                            "center": true
+                        },
+                        {
+                            "range": [168, 175],
+                            "name": "Macro 21",
+                            "center": true
+                        },
+                        {
+                            "range": [176, 183],
+                            "name": "Macro 22",
+                            "center": true
+                        },
+                        {
+                            "range": [184, 191],
+                            "name": "Macro 23",
+                            "center": true
+                        },
+                        {
+                            "range": [192, 199],
+                            "name": "Macro 24",
+                            "center": true
+                        },
+                        {
+                            "range": [200, 207],
+                            "name": "Macro 25",
+                            "center": true
+                        },
+                        {
+                            "range": [208, 215],
+                            "name": "Macro 26",
+                            "center": true
+                        },
+                        {
+                            "range": [216, 223],
+                            "name": "Macro 27",
+                            "center": true
+                        },
+                        {
+                            "range": [224, 231],
+                            "name": "Macro 28",
+                            "center": true
+                        },
+                        {
+                            "range": [232, 239],
+                            "name": "Macro 29",
+                            "center": true
+                        },
+                        {
+                            "range": [240, 247],
+                            "name": "Macro 30",
+                            "center": true
+                        },
+                        {
+                            "range": [248, 255],
+                            "name": "Macro 31",
+                            "center": true
+                        }
+                    ]
+                },
+                "Shutter": {
+                    "type": "Shutter",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 31],
+                            "name": "Closed",
+                            "center": true
+                        },
+                        {
+                            "range": [32, 63],
+                            "name": "Open",
+                            "center": true
+                        },
+                        {
+                            "range": [64, 95],
+                            "name": "Strobe S-F"
+                        },
+                        {
+                            "range": [96, 127],
+                            "name": "Open",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 143],
+                            "name": "Pulse Open"
+                        },
+                        {
+                            "range": [144, 159],
+                            "name": "Pulse Close"
+                        },
+                        {
+                            "range": [160, 191],
+                            "name": "Open",
+                            "center": true
+                        },
+                        {
+                            "range": [192, 223],
+                            "name": "Random S-F"
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "Open",
+                            "center": true
+                        }
+                    ]
+                },
+                "Dimmer": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                }
+            },
+            "modes": [
+                {
+                    "name": "7-channel Mode",
+                    "shortName": "7ch",
+                    "channels": [
+                        "Red 1",
+                        "Green 1",
+                        "Blue 1",
+                        "White 1",
+                        "Color Makro",
+                        "Shutter",
+                        "Dimmer"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Anolis",
+            "name": "PowerArc 36 Mode 2",
+            "shortName": "PArc 36 M2",
+            "comment": "out of date!",
+            "physical": {
+                "dimensions": [100, 100, 100],
+                "weight": 1
+            },
+            "availableChannels": {
+                "Red 1": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green 1": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue 1": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                }
+            },
+            "modes": [
+                {
+                    "name": "3-channel Mode",
+                    "shortName": "3ch",
+                    "channels": [
+                        "Red 1",
+                        "Green 1",
+                        "Blue 1"
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/fixtures/imports/ecue-MainLibrary/Antari.json
+++ b/fixtures/imports/ecue-MainLibrary/Antari.json
@@ -1,0 +1,57 @@
+{
+    "manufacturers": {
+        "Antari": {
+            "name": "Antari",
+            "website": "www.antari.com"
+        }
+    },
+    "fixtures": [
+        {
+            "manufacturer": "Antari",
+            "name": "X-20II",
+            "shortName": "X-20II",
+            "physical": {
+                "dimensions": [500, 250, 200]
+            },
+            "availableChannels": {
+                "Fog": {
+                    "type": "Beam",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 5],
+                            "name": "off"
+                        },
+                        {
+                            "range": [6, 74],
+                            "name": "volume"
+                        },
+                        {
+                            "range": [75, 75],
+                            "name": "continous"
+                        },
+                        {
+                            "range": [76, 248],
+                            "name": "volume"
+                        },
+                        {
+                            "range": [249, 255],
+                            "name": "maximum"
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "1-channel Mode",
+                    "shortName": "1ch",
+                    "channels": [
+                        "Fog"
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/fixtures/imports/ecue-MainLibrary/ArKaos.json
+++ b/fixtures/imports/ecue-MainLibrary/ArKaos.json
@@ -1,0 +1,1200 @@
+{
+    "manufacturers": {
+        "ArKaos": {
+            "name": "ArKaos",
+            "website": "www.arkaos.net"
+        }
+    },
+    "fixtures": [
+        {
+            "manufacturer": "ArKaos",
+            "name": "ArKaos Full",
+            "shortName": "ArKaos Full",
+            "comment": "43ch - LoopMode select on StartLoop and EndLoop       cd",
+            "physical": {
+                "dimensions": [100, 100, 100]
+            },
+            "availableChannels": {
+                "Dimmer": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "VisType": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 31],
+                            "name": "pict"
+                        },
+                        {
+                            "range": [32, 63],
+                            "name": "movie"
+                        },
+                        {
+                            "range": [64, 95],
+                            "name": "cam"
+                        },
+                        {
+                            "range": [96, 127],
+                            "name": "flash"
+                        }
+                    ]
+                },
+                "VisIndex": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "visual"
+                        }
+                    ]
+                },
+                "FxType": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 31],
+                            "name": "3D Fx"
+                        },
+                        {
+                            "range": [32, 63],
+                            "name": "video"
+                        },
+                        {
+                            "range": [64, 95],
+                            "name": "trans"
+                        },
+                        {
+                            "range": [96, 127],
+                            "name": "artis"
+                        },
+                        {
+                            "range": [128, 159],
+                            "name": "freeFr"
+                        }
+                    ]
+                },
+                "FxIndex": {
+                    "type": "Beam",
+                    "defaultValue": 1,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "Fx"
+                        }
+                    ]
+                },
+                "CopyMode": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 31],
+                            "name": "trans"
+                        },
+                        {
+                            "range": [32, 63],
+                            "name": "addition"
+                        },
+                        {
+                            "range": [64, 95],
+                            "name": "substraction"
+                        },
+                        {
+                            "range": [96, 127],
+                            "name": "multiplication"
+                        },
+                        {
+                            "range": [128, 159],
+                            "name": "minimum"
+                        },
+                        {
+                            "range": [160, 191],
+                            "name": "maximum"
+                        }
+                    ]
+                },
+                "MaskMode": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 31],
+                            "name": "none"
+                        },
+                        {
+                            "range": [32, 63],
+                            "name": "lum reject"
+                        },
+                        {
+                            "range": [64, 95],
+                            "name": "lum pass"
+                        },
+                        {
+                            "range": [96, 127],
+                            "name": "chr reject"
+                        },
+                        {
+                            "range": [128, 159],
+                            "name": "chr pass"
+                        },
+                        {
+                            "range": [160, 191],
+                            "name": "alpha"
+                        }
+                    ]
+                },
+                "L/C Center": {
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "cent"
+                        }
+                    ]
+                },
+                "L/C Width": {
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "defaultValue": 50,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "width"
+                        }
+                    ]
+                },
+                "L/C Smooth": {
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "defaultValue": 50,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "Smooth"
+                        }
+                    ]
+                },
+                "MovieSpeed": {
+                    "type": "Speed",
+                    "defaultValue": 64,
+                    "crossfade": true
+                },
+                "Speed/Loop": {
+                    "type": "Speed",
+                    "capabilities": [
+                        {
+                            "range": [0, 31],
+                            "name": "speed"
+                        },
+                        {
+                            "range": [32, 63],
+                            "name": "for/back"
+                        },
+                        {
+                            "range": [64, 65],
+                            "name": "ping/pong"
+                        }
+                    ]
+                },
+                "LoopMode": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 31],
+                            "name": "play all"
+                        },
+                        {
+                            "range": [32, 63],
+                            "name": "select"
+                        },
+                        {
+                            "range": [64, 95],
+                            "name": "random1"
+                        },
+                        {
+                            "range": [96, 127],
+                            "name": "random2"
+                        }
+                    ]
+                },
+                "StartLoop": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "image",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "StartLoop fine": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "image",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "EndLoop": {
+                    "type": "Beam",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "image",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "EndLoop fine": {
+                    "type": "Beam",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "image",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Pos X": {
+                    "type": "Intensity",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 32767],
+                            "name": "left",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [32768, 32768],
+                            "name": "32768",
+                            "warning": "Out of range!",
+                            "center": true
+                        },
+                        {
+                            "range": [32769, 65535],
+                            "name": "right",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Pos X fine": {
+                    "type": "Intensity",
+                    "defaultValue": 0,
+                    "highlightValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 32767],
+                            "name": "left",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [32768, 32768],
+                            "name": "32768",
+                            "warning": "Out of range!",
+                            "center": true
+                        },
+                        {
+                            "range": [32769, 65535],
+                            "name": "right",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Pos Y": {
+                    "type": "Intensity",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 32767],
+                            "name": "top",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [32768, 32768],
+                            "name": "32768",
+                            "warning": "Out of range!",
+                            "center": true
+                        },
+                        {
+                            "range": [32769, 65535],
+                            "name": "bottom",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Pos Y fine": {
+                    "type": "Intensity",
+                    "defaultValue": 0,
+                    "highlightValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 32767],
+                            "name": "top",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [32768, 32768],
+                            "name": "32768",
+                            "warning": "Out of range!",
+                            "center": true
+                        },
+                        {
+                            "range": [32769, 65535],
+                            "name": "bottom",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Pos Z": {
+                    "type": "Intensity",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 32767],
+                            "name": "near",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [32768, 32768],
+                            "name": "32768",
+                            "warning": "Out of range!",
+                            "center": true
+                        },
+                        {
+                            "range": [32769, 65535],
+                            "name": "fare",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Pos Z fine": {
+                    "type": "Intensity",
+                    "defaultValue": 0,
+                    "highlightValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 32767],
+                            "name": "near",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [32768, 32768],
+                            "name": "32768",
+                            "warning": "Out of range!",
+                            "center": true
+                        },
+                        {
+                            "range": [32769, 65535],
+                            "name": "fare",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "HorzSize": {
+                    "type": "Intensity",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "HorzSize fine": {
+                    "type": "Intensity",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "VertSize": {
+                    "type": "Intensity",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "VertSize fine": {
+                    "type": "Intensity",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Rot X HW": {
+                    "type": "Intensity",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Rot X HW fine": {
+                    "type": "Intensity",
+                    "defaultValue": 0,
+                    "highlightValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Rot Y HW": {
+                    "type": "Intensity",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Rot Y HW fine": {
+                    "type": "Intensity",
+                    "defaultValue": 0,
+                    "highlightValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Rot Z HW": {
+                    "type": "Intensity",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Rot Z HW fine": {
+                    "type": "Intensity",
+                    "defaultValue": 0,
+                    "highlightValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Red HW": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Green HW": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Blue HW": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "TextIndex": {
+                    "type": "Intensity",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "Text"
+                        }
+                    ]
+                },
+                "Fx1": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Fx2": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Fx3": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Fx4": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Fx5": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Fx6": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%",
+                            "showInMenu": false
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "StartLoop",
+                    "StartLoop fine"
+                ],
+                [
+                    "EndLoop",
+                    "EndLoop fine"
+                ],
+                [
+                    "Pos X",
+                    "Pos X fine"
+                ],
+                [
+                    "Pos Y",
+                    "Pos Y fine"
+                ],
+                [
+                    "Pos Z",
+                    "Pos Z fine"
+                ],
+                [
+                    "HorzSize",
+                    "HorzSize fine"
+                ],
+                [
+                    "VertSize",
+                    "VertSize fine"
+                ],
+                [
+                    "Rot X HW",
+                    "Rot X HW fine"
+                ],
+                [
+                    "Rot Y HW",
+                    "Rot Y HW fine"
+                ],
+                [
+                    "Rot Z HW",
+                    "Rot Z HW fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "43-channel Mode",
+                    "shortName": "43ch",
+                    "channels": [
+                        "Dimmer",
+                        "VisType",
+                        "VisIndex",
+                        "FxType",
+                        "FxIndex",
+                        "CopyMode",
+                        "MaskMode",
+                        "L/C Center",
+                        "L/C Width",
+                        "L/C Smooth",
+                        "MovieSpeed",
+                        "Speed/Loop",
+                        "LoopMode",
+                        "StartLoop",
+                        "StartLoop fine",
+                        "EndLoop",
+                        "EndLoop fine",
+                        "Pos X",
+                        "Pos X fine",
+                        "Pos Y",
+                        "Pos Y fine",
+                        "Pos Z",
+                        "Pos Z fine",
+                        "HorzSize",
+                        "HorzSize fine",
+                        "VertSize",
+                        "VertSize fine",
+                        "Rot X HW",
+                        "Rot X HW fine",
+                        "Rot Y HW",
+                        "Rot Y HW fine",
+                        "Rot Z HW",
+                        "Rot Z HW fine",
+                        "Red HW",
+                        "Green HW",
+                        "Blue HW",
+                        "TextIndex",
+                        "Fx1",
+                        "Fx2",
+                        "Fx3",
+                        "Fx4",
+                        "Fx5",
+                        "Fx6"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "ArKaos",
+            "name": "ArKaos Tiny",
+            "shortName": "ArKaos",
+            "comment": "43ch - LoopMode select on StartLoop and EndLoop       cd",
+            "physical": {
+                "dimensions": [100, 100, 100]
+            },
+            "availableChannels": {
+                "Dimmer": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "VisType": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 31],
+                            "name": "pict"
+                        },
+                        {
+                            "range": [32, 63],
+                            "name": "movie"
+                        },
+                        {
+                            "range": [64, 95],
+                            "name": "cam"
+                        },
+                        {
+                            "range": [96, 127],
+                            "name": "flash"
+                        }
+                    ]
+                },
+                "VisIndex": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "visual"
+                        }
+                    ]
+                },
+                "FxType": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 31],
+                            "name": "3D Fx"
+                        },
+                        {
+                            "range": [32, 63],
+                            "name": "video"
+                        },
+                        {
+                            "range": [64, 95],
+                            "name": "trans"
+                        },
+                        {
+                            "range": [96, 127],
+                            "name": "artis"
+                        },
+                        {
+                            "range": [128, 159],
+                            "name": "freeFr"
+                        }
+                    ]
+                },
+                "FxIndex": {
+                    "type": "Beam",
+                    "defaultValue": 1,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "Fx"
+                        }
+                    ]
+                },
+                "CopyMode": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 31],
+                            "name": "trans"
+                        },
+                        {
+                            "range": [32, 63],
+                            "name": "addition"
+                        },
+                        {
+                            "range": [64, 95],
+                            "name": "substraction"
+                        },
+                        {
+                            "range": [96, 127],
+                            "name": "multiplication"
+                        },
+                        {
+                            "range": [128, 159],
+                            "name": "minimum"
+                        },
+                        {
+                            "range": [160, 191],
+                            "name": "maximum"
+                        }
+                    ]
+                },
+                "MaskMode": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 31],
+                            "name": "none"
+                        },
+                        {
+                            "range": [32, 63],
+                            "name": "lum reject"
+                        },
+                        {
+                            "range": [64, 95],
+                            "name": "lum pass"
+                        },
+                        {
+                            "range": [96, 127],
+                            "name": "chr reject"
+                        },
+                        {
+                            "range": [128, 159],
+                            "name": "chr pass"
+                        },
+                        {
+                            "range": [160, 191],
+                            "name": "alpha"
+                        }
+                    ]
+                },
+                "L/C Center": {
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "cent"
+                        }
+                    ]
+                },
+                "L/C Width": {
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "defaultValue": 50,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "width"
+                        }
+                    ]
+                },
+                "L/C Smooth": {
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "defaultValue": 50,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "Smooth"
+                        }
+                    ]
+                },
+                "MovieSpeed": {
+                    "type": "Speed",
+                    "defaultValue": 64,
+                    "crossfade": true
+                },
+                "Speed/Loop": {
+                    "type": "Speed",
+                    "capabilities": [
+                        {
+                            "range": [0, 31],
+                            "name": "speed"
+                        },
+                        {
+                            "range": [32, 63],
+                            "name": "for/back"
+                        },
+                        {
+                            "range": [64, 65],
+                            "name": "ping/pong"
+                        }
+                    ]
+                },
+                "Pos X": {
+                    "type": "Intensity",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 32767],
+                            "name": "left",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [32768, 32768],
+                            "name": "32768",
+                            "warning": "Out of range!",
+                            "center": true
+                        },
+                        {
+                            "range": [32769, 65535],
+                            "name": "right",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Pos X fine": {
+                    "type": "Intensity",
+                    "defaultValue": 0,
+                    "highlightValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 32767],
+                            "name": "left",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [32768, 32768],
+                            "name": "32768",
+                            "warning": "Out of range!",
+                            "center": true
+                        },
+                        {
+                            "range": [32769, 65535],
+                            "name": "right",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Pos Y": {
+                    "type": "Intensity",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 32767],
+                            "name": "top",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [32768, 32768],
+                            "name": "32768",
+                            "warning": "Out of range!",
+                            "center": true
+                        },
+                        {
+                            "range": [32769, 65535],
+                            "name": "bottom",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Pos Y fine": {
+                    "type": "Intensity",
+                    "defaultValue": 0,
+                    "highlightValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 32767],
+                            "name": "top",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [32768, 32768],
+                            "name": "32768",
+                            "warning": "Out of range!",
+                            "center": true
+                        },
+                        {
+                            "range": [32769, 65535],
+                            "name": "bottom",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "HorzSize": {
+                    "type": "Intensity",
+                    "defaultValue": 65535,
+                    "highlightValue": 65535,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "VertSize": {
+                    "type": "Intensity",
+                    "defaultValue": 65535,
+                    "highlightValue": 65535,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "TextIndex": {
+                    "type": "Intensity",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "Text"
+                        }
+                    ]
+                },
+                "Fx1": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Fx2": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Fx3": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Fx4": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Fx5": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Fx6": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%",
+                            "showInMenu": false
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pos X",
+                    "Pos X fine"
+                ],
+                [
+                    "Pos Y",
+                    "Pos Y fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "25-channel Mode",
+                    "shortName": "25ch",
+                    "channels": [
+                        "Dimmer",
+                        "VisType",
+                        "VisIndex",
+                        "FxType",
+                        "FxIndex",
+                        "CopyMode",
+                        "MaskMode",
+                        "L/C Center",
+                        "L/C Width",
+                        "L/C Smooth",
+                        "MovieSpeed",
+                        "Speed/Loop",
+                        "Pos X",
+                        "Pos X fine",
+                        "Pos Y",
+                        "Pos Y fine",
+                        "HorzSize",
+                        "VertSize",
+                        "TextIndex",
+                        "Fx1",
+                        "Fx2",
+                        "Fx3",
+                        "Fx4",
+                        "Fx5",
+                        "Fx6"
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/fixtures/imports/ecue-MainLibrary/Ayrton.json
+++ b/fixtures/imports/ecue-MainLibrary/Ayrton.json
@@ -1,0 +1,97 @@
+{
+    "manufacturers": {
+        "Ayrton": {
+            "name": "Ayrton",
+            "website": "http://www.ayrton.eu"
+        }
+    },
+    "fixtures": [
+        {
+            "manufacturer": "Ayrton",
+            "name": "eyecolor",
+            "shortName": "eyecolor",
+            "physical": {
+                "dimensions": [300, 300, 500],
+                "weight": 8,
+                "power": 250
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "highlightValue": null
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 0,
+                    "crossfade": true,
+                    "highlightValue": null
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "highlightValue": null
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 0,
+                    "crossfade": true,
+                    "highlightValue": null
+                },
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "crossfade": true
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "crossfade": true
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "crossfade": true
+                },
+                "Rainbow": {
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "crossfade": true
+                },
+                "Strobe": {
+                    "type": "Strobe",
+                    "crossfade": true
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "9-channel Mode",
+                    "shortName": "9ch",
+                    "channels": [
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "Red",
+                        "Green",
+                        "Blue",
+                        "Rainbow",
+                        "Strobe"
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/fixtures/imports/ecue-MainLibrary/Botex.json
+++ b/fixtures/imports/ecue-MainLibrary/Botex.json
@@ -1,0 +1,175 @@
+{
+    "manufacturers": {
+        "Botex": {
+            "name": "Botex"
+        }
+    },
+    "fixtures": [
+        {
+            "manufacturer": "Botex",
+            "name": "4ch T-Bar",
+            "shortName": "4ch T-Bar",
+            "physical": {
+                "dimensions": [1310, 80, 80]
+            },
+            "availableChannels": {
+                "Channel 1": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Channel 2": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Channel 3": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Channel 4": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "4-channel Mode",
+                    "shortName": "4ch",
+                    "channels": [
+                        "Channel 1",
+                        "Channel 2",
+                        "Channel 3",
+                        "Channel 4"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Botex",
+            "name": "6ch T-Bar",
+            "shortName": "6ch T-Bar",
+            "physical": {
+                "dimensions": [2000, 80, 80]
+            },
+            "availableChannels": {
+                "Channel 1": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Channel 2": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Channel 3": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Channel 4": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Channel 5": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Channel 6": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "6-channel Mode",
+                    "shortName": "6ch",
+                    "channels": [
+                        "Channel 1",
+                        "Channel 2",
+                        "Channel 3",
+                        "Channel 4",
+                        "Channel 5",
+                        "Channel 6"
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/fixtures/imports/ecue-MainLibrary/Bright-Light.json
+++ b/fixtures/imports/ecue-MainLibrary/Bright-Light.json
@@ -1,0 +1,264 @@
+{
+    "manufacturers": {
+        "Bright Light": {
+            "name": "Bright Light"
+        }
+    },
+    "fixtures": [
+        {
+            "manufacturer": "Bright Light",
+            "name": "Spot 7",
+            "shortName": "Spot 7",
+            "physical": {
+                "dimensions": [70, 70, 160],
+                "weight": 0.4,
+                "power": 13
+            },
+            "availableChannels": {
+                "Dimmer": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "White": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Clr Macro": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 210],
+                            "name": "Colors"
+                        },
+                        {
+                            "range": [211, 215],
+                            "name": "3200K"
+                        },
+                        {
+                            "range": [216, 220],
+                            "name": "3400K"
+                        },
+                        {
+                            "range": [221, 225],
+                            "name": "4200K"
+                        },
+                        {
+                            "range": [226, 230],
+                            "name": "4900K"
+                        },
+                        {
+                            "range": [231, 235],
+                            "name": "5600K"
+                        },
+                        {
+                            "range": [236, 240],
+                            "name": "5900K"
+                        },
+                        {
+                            "range": [241, 245],
+                            "name": "6500K"
+                        },
+                        {
+                            "range": [246, 250],
+                            "name": "7200K"
+                        },
+                        {
+                            "range": [251, 255],
+                            "name": "8500K"
+                        }
+                    ]
+                },
+                "Strobe": {
+                    "type": "Strobe",
+                    "crossfade": true
+                },
+                "Auto": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Auto Speed": {
+                    "type": "Speed",
+                    "crossfade": true
+                }
+            },
+            "modes": [
+                {
+                    "name": "9-channel Mode",
+                    "shortName": "9ch",
+                    "channels": [
+                        "Dimmer",
+                        "Red",
+                        "Green",
+                        "Blue",
+                        "White",
+                        "Clr Macro",
+                        "Strobe",
+                        "Auto",
+                        "Auto Speed"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Bright Light",
+            "name": "Wash LED 49",
+            "shortName": "Wash LED 49",
+            "comment": "LED Moving Head",
+            "physical": {
+                "dimensions": [400, 400, 400],
+                "weight": 9,
+                "power": 120
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "highlightValue": 128,
+                    "crossfade": true
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "highlightValue": 128,
+                    "crossfade": true
+                },
+                "PT Speed": {
+                    "type": "Speed",
+                    "crossfade": true
+                },
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "White /Mac Spd": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "crossfade": true
+                },
+                "Macro": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 5],
+                            "name": "Close",
+                            "center": true
+                        },
+                        {
+                            "range": [6, 240],
+                            "name": "RGBW"
+                        },
+                        {
+                            "range": [241, 250],
+                            "name": "Auto"
+                        },
+                        {
+                            "range": [251, 255],
+                            "name": "White",
+                            "color": "#ffffff"
+                        }
+                    ]
+                },
+                "Dimmer": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Strobe": {
+                    "type": "Strobe",
+                    "crossfade": true
+                },
+                "Control": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 19],
+                            "name": "Normal"
+                        },
+                        {
+                            "range": [20, 39],
+                            "name": "Reset"
+                        },
+                        {
+                            "range": [40, 59],
+                            "name": "Auto1"
+                        },
+                        {
+                            "range": [60, 79],
+                            "name": "Auto2"
+                        },
+                        {
+                            "range": [80, 99],
+                            "name": "Sound1"
+                        },
+                        {
+                            "range": [100, 119],
+                            "name": "Sound2"
+                        },
+                        {
+                            "range": [120, 139],
+                            "name": "Custom"
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "11-channel Mode",
+                    "shortName": "11ch",
+                    "channels": [
+                        "Pan",
+                        "Tilt",
+                        "PT Speed",
+                        "Red",
+                        "Green",
+                        "Blue",
+                        "White /Mac Spd",
+                        "Macro",
+                        "Dimmer",
+                        "Strobe",
+                        "Control"
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/fixtures/imports/ecue-MainLibrary/CKC-Lighting.json
+++ b/fixtures/imports/ecue-MainLibrary/CKC-Lighting.json
@@ -1,0 +1,2727 @@
+{
+    "manufacturers": {
+        "CKC Lighting": {
+            "name": "CKC Lighting",
+            "website": "http://www.ckclighting.com/product.asp"
+        }
+    },
+    "fixtures": [
+        {
+            "manufacturer": "CKC Lighting",
+            "name": "CKC 567 RGY Laser",
+            "shortName": "CKC 567",
+            "physical": {
+                "dimensions": [200, 200, 300]
+            },
+            "availableChannels": {
+                "Shutter": {
+                    "type": "Shutter",
+                    "crossfade": true
+                },
+                "Image 1": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Roll Spd X1": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Roll Spd Y1": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Roll Spd Z1": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Size 1": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "X Position 1": {
+                    "type": "Intensity",
+                    "crossfade": true
+                },
+                "Y Position 1": {
+                    "type": "Intensity",
+                    "crossfade": true
+                },
+                "Image 1 Blank": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "crossfade": true
+                },
+                "Shutter 2": {
+                    "type": "Shutter",
+                    "crossfade": true
+                },
+                "Image 2": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Roll Spd X2": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Roll Spd Y2": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Roll Spd Z2": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Size 2": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "X Position 2": {
+                    "type": "Intensity",
+                    "crossfade": true
+                },
+                "Y Position 2": {
+                    "type": "Intensity",
+                    "crossfade": true
+                },
+                "Image 2 Blank": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "crossfade": true
+                }
+            },
+            "modes": [
+                {
+                    "name": "18-channel Mode",
+                    "shortName": "18ch",
+                    "channels": [
+                        "Shutter",
+                        "Image 1",
+                        "Roll Spd X1",
+                        "Roll Spd Y1",
+                        "Roll Spd Z1",
+                        "Size 1",
+                        "X Position 1",
+                        "Y Position 1",
+                        "Image 1 Blank",
+                        "Shutter 2",
+                        "Image 2",
+                        "Roll Spd X2",
+                        "Roll Spd Y2",
+                        "Roll Spd Z2",
+                        "Size 2",
+                        "X Position 2",
+                        "Y Position 2",
+                        "Image 2 Blank"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "CKC Lighting",
+            "name": "CKC-458",
+            "shortName": "CKC-458",
+            "comment": "575 Spot",
+            "physical": {
+                "dimensions": [550, 550, 700],
+                "weight": 33,
+                "power": 600
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "highlightValue": null
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 0,
+                    "crossfade": true,
+                    "highlightValue": null
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "highlightValue": null
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 0,
+                    "crossfade": true,
+                    "highlightValue": null
+                },
+                "Speed": {
+                    "type": "Speed",
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "Max Tracking",
+                            "center": true
+                        },
+                        {
+                            "range": [1, 249],
+                            "name": "Vector Min-Max"
+                        },
+                        {
+                            "range": [250, 252],
+                            "name": "Off Clr Gobo",
+                            "center": true
+                        },
+                        {
+                            "range": [253, 0],
+                            "name": "Off P/T",
+                            "center": true
+                        }
+                    ]
+                },
+                "Control": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 143],
+                            "name": "Park"
+                        },
+                        {
+                            "range": [144, 151],
+                            "name": "Shut P/T"
+                        },
+                        {
+                            "range": [152, 159],
+                            "name": "Shut Color"
+                        },
+                        {
+                            "range": [160, 167],
+                            "name": "Park"
+                        },
+                        {
+                            "range": [168, 175],
+                            "name": "Shut P/T Col"
+                        },
+                        {
+                            "range": [200, 207],
+                            "name": "Lamp OFF"
+                        },
+                        {
+                            "range": [208, 215],
+                            "name": "Lamp ON",
+                            "center": true
+                        },
+                        {
+                            "range": [240, 247],
+                            "name": "Reset"
+                        }
+                    ]
+                },
+                "Color 1": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 7],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [8, 14],
+                            "name": "Deep Blu"
+                        },
+                        {
+                            "range": [15, 21],
+                            "name": "Pink",
+                            "color": "#ffc0cb"
+                        },
+                        {
+                            "range": [22, 28],
+                            "name": "Cyan",
+                            "color": "#00ffff"
+                        },
+                        {
+                            "range": [29, 35],
+                            "name": "Green",
+                            "color": "#00ff00"
+                        },
+                        {
+                            "range": [36, 42],
+                            "name": "Yellow",
+                            "color": "#ffff00"
+                        },
+                        {
+                            "range": [43, 49],
+                            "name": "Mag"
+                        },
+                        {
+                            "range": [50, 56],
+                            "name": "Blue",
+                            "color": "#0000ff"
+                        },
+                        {
+                            "range": [57, 63],
+                            "name": "Deep Grn"
+                        },
+                        {
+                            "range": [64, 70],
+                            "name": "Red",
+                            "color": "#ff0000"
+                        },
+                        {
+                            "range": [71, 127],
+                            "name": "Split Colors"
+                        },
+                        {
+                            "range": [192, 255],
+                            "name": "Fwd"
+                        },
+                        {
+                            "range": [192, 255],
+                            "name": "Rev"
+                        }
+                    ]
+                },
+                "Color 2": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 7],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [8, 14],
+                            "name": "Red",
+                            "color": "#ff0000"
+                        },
+                        {
+                            "range": [15, 21],
+                            "name": "Deep Cyan"
+                        },
+                        {
+                            "range": [22, 28],
+                            "name": "Orange",
+                            "color": "#ff7f00"
+                        },
+                        {
+                            "range": [29, 35],
+                            "name": "Cyan",
+                            "color": "#00ffff"
+                        },
+                        {
+                            "range": [36, 42],
+                            "name": "Mag"
+                        },
+                        {
+                            "range": [43, 49],
+                            "name": "Yellow",
+                            "color": "#ffff00"
+                        },
+                        {
+                            "range": [50, 56],
+                            "name": "CTB"
+                        },
+                        {
+                            "range": [57, 63],
+                            "name": "CTO"
+                        },
+                        {
+                            "range": [64, 70],
+                            "name": "Blue",
+                            "color": "#0000ff"
+                        },
+                        {
+                            "range": [71, 127],
+                            "name": "Split Colors"
+                        },
+                        {
+                            "range": [192, 255],
+                            "name": "Fwd"
+                        },
+                        {
+                            "range": [192, 255],
+                            "name": "Rev"
+                        }
+                    ]
+                },
+                "Prism": {
+                    "type": "Prism",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "Open",
+                            "center": true
+                        },
+                        {
+                            "range": [1, 63],
+                            "name": "Rot Fwd"
+                        },
+                        {
+                            "range": [64, 64],
+                            "name": "Stop",
+                            "center": true
+                        },
+                        {
+                            "range": [65, 127],
+                            "name": "Rot Rev"
+                        },
+                        {
+                            "range": [128, 255],
+                            "name": "Prsm/Gobo Macro"
+                        }
+                    ]
+                },
+                "Fixed Gobo": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 7],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [8, 15],
+                            "name": "Gobo 1"
+                        },
+                        {
+                            "range": [16, 23],
+                            "name": "Gobo 2"
+                        },
+                        {
+                            "range": [24, 31],
+                            "name": "Gobo 3"
+                        },
+                        {
+                            "range": [32, 39],
+                            "name": "Gobo 4"
+                        },
+                        {
+                            "range": [40, 47],
+                            "name": "Gobo 5"
+                        },
+                        {
+                            "range": [48, 55],
+                            "name": "Gobo 6"
+                        },
+                        {
+                            "range": [56, 63],
+                            "name": "Gobo 7"
+                        },
+                        {
+                            "range": [64, 71],
+                            "name": "Gobo 8"
+                        },
+                        {
+                            "range": [72, 79],
+                            "name": "Gobo 9"
+                        },
+                        {
+                            "range": [80, 223],
+                            "name": "Gob Shake"
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "Gobo Roll"
+                        }
+                    ]
+                },
+                "Rot Gobo": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 7],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [8, 15],
+                            "name": "Gobo 1"
+                        },
+                        {
+                            "range": [16, 23],
+                            "name": "Gobo 2"
+                        },
+                        {
+                            "range": [24, 31],
+                            "name": "Gobo 3"
+                        },
+                        {
+                            "range": [32, 39],
+                            "name": "Gobo 4"
+                        },
+                        {
+                            "range": [40, 47],
+                            "name": "Gobo 5"
+                        },
+                        {
+                            "range": [48, 55],
+                            "name": "Gobo 6"
+                        },
+                        {
+                            "range": [56, 223],
+                            "name": "Shake"
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "Gobo Roll"
+                        }
+                    ]
+                },
+                "Rotation": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "Index"
+                        },
+                        {
+                            "range": [128, 191],
+                            "name": "Fwd"
+                        },
+                        {
+                            "range": [192, 192],
+                            "name": "No Rot"
+                        },
+                        {
+                            "range": [193, 255],
+                            "name": "Rev"
+                        }
+                    ]
+                },
+                "Iris": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 191],
+                            "name": "Max-Min"
+                        },
+                        {
+                            "range": [192, 223],
+                            "name": "Pulse Close"
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "Pulse Open"
+                        }
+                    ]
+                },
+                "Zoom/Focus": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 85],
+                            "name": "15 Deg"
+                        },
+                        {
+                            "range": [86, 170],
+                            "name": "18 Deg"
+                        },
+                        {
+                            "range": [171, 255],
+                            "name": "22 Deg"
+                        }
+                    ]
+                },
+                "Shutter": {
+                    "type": "Shutter",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "Closed",
+                            "center": true
+                        },
+                        {
+                            "range": [16, 159],
+                            "name": "Strobe"
+                        },
+                        {
+                            "range": [160, 239],
+                            "name": "Pulse"
+                        },
+                        {
+                            "range": [240, 255],
+                            "name": "Open",
+                            "center": true
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "16-channel Mode",
+                    "shortName": "16ch",
+                    "channels": [
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "Speed",
+                        "Control",
+                        "Color 1",
+                        "Color 2",
+                        "Prism",
+                        "Fixed Gobo",
+                        "Rot Gobo",
+                        "Rotation",
+                        "Iris",
+                        "Zoom/Focus",
+                        "Shutter",
+                        "Intensity"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "CKC Lighting",
+            "name": "CKC-458 Old",
+            "shortName": "CKC-458 A",
+            "comment": "575 Spot",
+            "physical": {
+                "dimensions": [550, 550, 700],
+                "weight": 33,
+                "power": 600
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "highlightValue": null
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 0,
+                    "crossfade": true,
+                    "highlightValue": null
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "highlightValue": null
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 0,
+                    "crossfade": true,
+                    "highlightValue": null
+                },
+                "Speed": {
+                    "type": "Speed",
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "Max Tracking",
+                            "center": true
+                        },
+                        {
+                            "range": [1, 249],
+                            "name": "Vector Min-Max"
+                        },
+                        {
+                            "range": [250, 252],
+                            "name": "Off Clr Gobo",
+                            "center": true
+                        },
+                        {
+                            "range": [253, 0],
+                            "name": "Off P/T",
+                            "center": true
+                        }
+                    ]
+                },
+                "Control": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "Park"
+                        },
+                        {
+                            "range": [128, 128],
+                            "name": "Reset"
+                        },
+                        {
+                            "range": [129, 143],
+                            "name": "Park"
+                        },
+                        {
+                            "range": [144, 144],
+                            "name": "Lamp ON"
+                        },
+                        {
+                            "range": [145, 159],
+                            "name": "Park"
+                        },
+                        {
+                            "range": [160, 160],
+                            "name": "Lamp OFF"
+                        },
+                        {
+                            "range": [161, 255],
+                            "name": "Park",
+                            "center": true
+                        }
+                    ]
+                },
+                "Color 1": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 11],
+                            "name": "Open",
+                            "center": true
+                        },
+                        {
+                            "range": [12, 25],
+                            "name": "Clr 1",
+                            "center": true
+                        },
+                        {
+                            "range": [26, 38],
+                            "name": "Clr 2",
+                            "center": true
+                        },
+                        {
+                            "range": [39, 50],
+                            "name": "Clr 3",
+                            "center": true
+                        },
+                        {
+                            "range": [51, 63],
+                            "name": "Clr 4",
+                            "center": true
+                        },
+                        {
+                            "range": [64, 76],
+                            "name": "Clr 5",
+                            "center": true
+                        },
+                        {
+                            "range": [77, 88],
+                            "name": "Clr 6",
+                            "center": true
+                        },
+                        {
+                            "range": [89, 101],
+                            "name": "Clr 7",
+                            "center": true
+                        },
+                        {
+                            "range": [102, 114],
+                            "name": "3200K",
+                            "center": true
+                        },
+                        {
+                            "range": [115, 127],
+                            "name": "6000K",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 192],
+                            "name": "Fwd"
+                        },
+                        {
+                            "range": [192, 255],
+                            "name": "Rev"
+                        }
+                    ]
+                },
+                "Color 2": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 12],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [13, 25],
+                            "name": "Clr 1"
+                        },
+                        {
+                            "range": [26, 38],
+                            "name": "Clr 2"
+                        },
+                        {
+                            "range": [39, 50],
+                            "name": "Clr 3"
+                        },
+                        {
+                            "range": [51, 63],
+                            "name": "Clr 4"
+                        },
+                        {
+                            "range": [64, 76],
+                            "name": "Clr 5"
+                        },
+                        {
+                            "range": [77, 88],
+                            "name": "Clr 6"
+                        },
+                        {
+                            "range": [89, 101],
+                            "name": "Clr 7"
+                        },
+                        {
+                            "range": [102, 114],
+                            "name": "Clr 8"
+                        },
+                        {
+                            "range": [115, 127],
+                            "name": "Clr 9"
+                        },
+                        {
+                            "range": [128, 192],
+                            "name": "Fwd"
+                        },
+                        {
+                            "range": [192, 255],
+                            "name": "Reverse"
+                        }
+                    ]
+                },
+                "Prism": {
+                    "type": "Prism",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "Open",
+                            "center": true
+                        },
+                        {
+                            "range": [1, 63],
+                            "name": "Rot Fwd"
+                        },
+                        {
+                            "range": [64, 64],
+                            "name": "Stop",
+                            "center": true
+                        },
+                        {
+                            "range": [65, 127],
+                            "name": "Rot Rev"
+                        },
+                        {
+                            "range": [128, 255],
+                            "name": "Prsm/Gobo Macro"
+                        }
+                    ]
+                },
+                "Fixed Gobo": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 7],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [8, 15],
+                            "name": "Gobo 1"
+                        },
+                        {
+                            "range": [16, 23],
+                            "name": "Gobo 2"
+                        },
+                        {
+                            "range": [24, 31],
+                            "name": "Gobo 3"
+                        },
+                        {
+                            "range": [32, 39],
+                            "name": "Gobo 4"
+                        },
+                        {
+                            "range": [40, 47],
+                            "name": "Gobo 5"
+                        },
+                        {
+                            "range": [48, 55],
+                            "name": "Gobo 6"
+                        },
+                        {
+                            "range": [56, 63],
+                            "name": "Gobo 7"
+                        },
+                        {
+                            "range": [64, 71],
+                            "name": "Gobo 8"
+                        },
+                        {
+                            "range": [72, 79],
+                            "name": "Gobo 9"
+                        },
+                        {
+                            "range": [80, 223],
+                            "name": "Gob Shake"
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "Gobo Roll"
+                        }
+                    ]
+                },
+                "Rot Gobo": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 31],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [32, 63],
+                            "name": "Gobo 1"
+                        },
+                        {
+                            "range": [64, 95],
+                            "name": "Gobo 2"
+                        },
+                        {
+                            "range": [96, 127],
+                            "name": "Gobo 3"
+                        },
+                        {
+                            "range": [128, 159],
+                            "name": "Gobo 4"
+                        },
+                        {
+                            "range": [169, 191],
+                            "name": "Gobo 5"
+                        },
+                        {
+                            "range": [192, 223],
+                            "name": "Gobo 6"
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "Rotate"
+                        }
+                    ]
+                },
+                "Rotation": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "Index"
+                        },
+                        {
+                            "range": [128, 191],
+                            "name": "Fwd"
+                        },
+                        {
+                            "range": [192, 192],
+                            "name": "No Rot"
+                        },
+                        {
+                            "range": [193, 255],
+                            "name": "Rev"
+                        }
+                    ]
+                },
+                "Iris": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 191],
+                            "name": "Max-Min"
+                        },
+                        {
+                            "range": [192, 223],
+                            "name": "Pulse Close"
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "Pulse Open"
+                        }
+                    ]
+                },
+                "Zoom/Focus": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 85],
+                            "name": "15 Deg"
+                        },
+                        {
+                            "range": [86, 170],
+                            "name": "18 Deg"
+                        },
+                        {
+                            "range": [171, 255],
+                            "name": "22 Deg"
+                        }
+                    ]
+                },
+                "Dimmer": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Shutter": {
+                    "type": "Shutter",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "Closed",
+                            "center": true
+                        },
+                        {
+                            "range": [16, 159],
+                            "name": "Strobe"
+                        },
+                        {
+                            "range": [160, 239],
+                            "name": "Pulse"
+                        },
+                        {
+                            "range": [240, 255],
+                            "name": "Open",
+                            "center": true
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "16-channel Mode",
+                    "shortName": "16ch",
+                    "channels": [
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "Speed",
+                        "Control",
+                        "Color 1",
+                        "Color 2",
+                        "Prism",
+                        "Fixed Gobo",
+                        "Rot Gobo",
+                        "Rotation",
+                        "Iris",
+                        "Zoom/Focus",
+                        "Dimmer",
+                        "Shutter"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "CKC Lighting",
+            "name": "CKC-459",
+            "shortName": "CKC-459",
+            "comment": "575 CMY Wash",
+            "physical": {
+                "dimensions": [550, 550, 700],
+                "weight": 32,
+                "power": 600
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "highlightValue": null
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 0,
+                    "crossfade": true,
+                    "highlightValue": null
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "highlightValue": null
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 0,
+                    "crossfade": true,
+                    "highlightValue": null
+                },
+                "Speed": {
+                    "type": "Speed",
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "Max Tracking",
+                            "center": true
+                        },
+                        {
+                            "range": [1, 249],
+                            "name": "Vector Min-Max"
+                        },
+                        {
+                            "range": [250, 252],
+                            "name": "Off Clr Gobo",
+                            "center": true
+                        },
+                        {
+                            "range": [253, 0],
+                            "name": "Off P/T",
+                            "center": true
+                        }
+                    ]
+                },
+                "Control": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 143],
+                            "name": "Park"
+                        },
+                        {
+                            "range": [144, 151],
+                            "name": "Shut P/T"
+                        },
+                        {
+                            "range": [152, 159],
+                            "name": "Shut Color"
+                        },
+                        {
+                            "range": [160, 167],
+                            "name": "Park"
+                        },
+                        {
+                            "range": [168, 175],
+                            "name": "Shut P/T Col"
+                        },
+                        {
+                            "range": [200, 207],
+                            "name": "Lamp OFF"
+                        },
+                        {
+                            "range": [208, 215],
+                            "name": "Lamp ON"
+                        },
+                        {
+                            "range": [240, 247],
+                            "name": "Reset"
+                        }
+                    ]
+                },
+                "Color": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 9],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [10, 18],
+                            "name": "Red",
+                            "color": "#ff0000"
+                        },
+                        {
+                            "range": [19, 27],
+                            "name": "Yellow",
+                            "color": "#ffff00"
+                        },
+                        {
+                            "range": [28, 36],
+                            "name": "Mag",
+                            "center": true
+                        },
+                        {
+                            "range": [37, 45],
+                            "name": "Green",
+                            "color": "#00ff00"
+                        },
+                        {
+                            "range": [46, 54],
+                            "name": "Orange",
+                            "color": "#ff7f00"
+                        },
+                        {
+                            "range": [55, 63],
+                            "name": "Blue",
+                            "color": "#0000ff"
+                        },
+                        {
+                            "range": [64, 72],
+                            "name": "Pink",
+                            "color": "#ffc0cb"
+                        },
+                        {
+                            "range": [73, 127],
+                            "name": "Split Colors"
+                        },
+                        {
+                            "range": [128, 191],
+                            "name": "Fwd"
+                        },
+                        {
+                            "range": [192, 255],
+                            "name": "Rev"
+                        }
+                    ]
+                },
+                "Yellow": {
+                    "type": "SingleColor",
+                    "color": "Yellow",
+                    "crossfade": true
+                },
+                "Magenta": {
+                    "type": "SingleColor",
+                    "color": "Magenta",
+                    "crossfade": true
+                },
+                "Cyan": {
+                    "type": "SingleColor",
+                    "color": "Cyan",
+                    "crossfade": true
+                },
+                "Clr Speed": {
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "crossfade": true
+                },
+                "Clr Macros": {
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "crossfade": true
+                },
+                "Beam Shape": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 70],
+                            "name": "Full",
+                            "center": true
+                        },
+                        {
+                            "range": [71, 230],
+                            "name": "Shape"
+                        },
+                        {
+                            "range": [231, 255],
+                            "name": "Frost",
+                            "color": "#edf5dd"
+                        }
+                    ]
+                },
+                "Zoom": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Shutter": {
+                    "type": "Shutter",
+                    "capabilities": [
+                        {
+                            "range": [0, 31],
+                            "name": "Closed",
+                            "center": true
+                        },
+                        {
+                            "range": [32, 63],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [64, 95],
+                            "name": "Strobe"
+                        },
+                        {
+                            "range": [96, 127],
+                            "name": "Open",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 159],
+                            "name": "Pulse"
+                        },
+                        {
+                            "range": [160, 191],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [192, 223],
+                            "name": "Random"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "16-channel Mode",
+                    "shortName": "16ch",
+                    "channels": [
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "Speed",
+                        "Control",
+                        "Color",
+                        "Yellow",
+                        "Magenta",
+                        "Cyan",
+                        "Clr Speed",
+                        "Clr Macros",
+                        "Beam Shape",
+                        "Zoom",
+                        "Shutter",
+                        "Intensity"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "CKC Lighting",
+            "name": "CKC-459 Old",
+            "shortName": "CKC-459 A",
+            "comment": "575 CMY Wash",
+            "physical": {
+                "dimensions": [550, 550, 700],
+                "weight": 32,
+                "power": 600
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "highlightValue": null
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 0,
+                    "crossfade": true,
+                    "highlightValue": null
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "highlightValue": null
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 0,
+                    "crossfade": true,
+                    "highlightValue": null
+                },
+                "Speed": {
+                    "type": "Speed",
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "Max Tracking",
+                            "center": true
+                        },
+                        {
+                            "range": [1, 249],
+                            "name": "Vector Min-Max"
+                        },
+                        {
+                            "range": [250, 252],
+                            "name": "Off Clr Gobo",
+                            "center": true
+                        },
+                        {
+                            "range": [253, 0],
+                            "name": "Off P/T",
+                            "center": true
+                        }
+                    ]
+                },
+                "Control": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "Park"
+                        },
+                        {
+                            "range": [128, 128],
+                            "name": "Reset"
+                        },
+                        {
+                            "range": [129, 143],
+                            "name": "Park"
+                        },
+                        {
+                            "range": [144, 144],
+                            "name": "Lamp ON"
+                        },
+                        {
+                            "range": [145, 159],
+                            "name": "Park"
+                        },
+                        {
+                            "range": [160, 160],
+                            "name": "Lamp OFF"
+                        },
+                        {
+                            "range": [161, 255],
+                            "name": "Park"
+                        }
+                    ]
+                },
+                "Color": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [16, 31],
+                            "name": "Red",
+                            "color": "#ff0000"
+                        },
+                        {
+                            "range": [32, 47],
+                            "name": "Yellow",
+                            "color": "#ffff00"
+                        },
+                        {
+                            "range": [48, 63],
+                            "name": "Rose",
+                            "color": "#ff007f",
+                            "center": true
+                        },
+                        {
+                            "range": [64, 79],
+                            "name": "Green",
+                            "color": "#00ff00"
+                        },
+                        {
+                            "range": [80, 95],
+                            "name": "Mag"
+                        },
+                        {
+                            "range": [96, 111],
+                            "name": "Blue",
+                            "color": "#0000ff"
+                        },
+                        {
+                            "range": [112, 127],
+                            "name": "Pink",
+                            "color": "#ffc0cb"
+                        },
+                        {
+                            "range": [128, 191],
+                            "name": "Fwd"
+                        },
+                        {
+                            "range": [192, 255],
+                            "name": "Reverse"
+                        }
+                    ]
+                },
+                "Cyan": {
+                    "type": "SingleColor",
+                    "color": "Cyan",
+                    "crossfade": true
+                },
+                "Magenta": {
+                    "type": "SingleColor",
+                    "color": "Magenta",
+                    "crossfade": true
+                },
+                "Yellow": {
+                    "type": "SingleColor",
+                    "color": "Yellow",
+                    "crossfade": true
+                },
+                "Clr Speed": {
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "crossfade": true
+                },
+                "Clr Macros": {
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "crossfade": true
+                },
+                "Beam Shape": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 70],
+                            "name": "Full",
+                            "center": true
+                        },
+                        {
+                            "range": [71, 230],
+                            "name": "Shape"
+                        },
+                        {
+                            "range": [231, 255],
+                            "name": "Frost",
+                            "color": "#edf5dd"
+                        }
+                    ]
+                },
+                "Zoom": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Shutter": {
+                    "type": "Shutter",
+                    "capabilities": [
+                        {
+                            "range": [0, 31],
+                            "name": "Closed",
+                            "center": true
+                        },
+                        {
+                            "range": [32, 63],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [64, 95],
+                            "name": "Strobe"
+                        },
+                        {
+                            "range": [96, 127],
+                            "name": "Open",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 159],
+                            "name": "Pulse"
+                        },
+                        {
+                            "range": [160, 191],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [192, 223],
+                            "name": "Random"
+                        }
+                    ]
+                },
+                "Dimmer": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "16-channel Mode",
+                    "shortName": "16ch",
+                    "channels": [
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "Speed",
+                        "Control",
+                        "Color",
+                        "Cyan",
+                        "Magenta",
+                        "Yellow",
+                        "Clr Speed",
+                        "Clr Macros",
+                        "Beam Shape",
+                        "Zoom",
+                        "Shutter",
+                        "Dimmer"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "CKC Lighting",
+            "name": "CKC-461",
+            "shortName": "CKC-461",
+            "comment": "Moving Spot 250  http://www.ckclighting.com/product.asp?ID=252",
+            "physical": {
+                "dimensions": [450, 450, 550],
+                "weight": 22,
+                "power": 300
+            },
+            "availableChannels": {
+                "Strobe": {
+                    "type": "Strobe",
+                    "defaultValue": 50,
+                    "highlightValue": 50,
+                    "capabilities": [
+                        {
+                            "range": [0, 31],
+                            "name": "Close"
+                        },
+                        {
+                            "range": [32, 63],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [64, 95],
+                            "name": "Strobe"
+                        },
+                        {
+                            "range": [96, 127],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [128, 159],
+                            "name": "Pulsing"
+                        },
+                        {
+                            "range": [160, 191],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [192, 223],
+                            "name": "Random"
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "Open"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Color": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [16, 31],
+                            "name": "Mag"
+                        },
+                        {
+                            "range": [32, 47],
+                            "name": "Yellow",
+                            "color": "#ffff00"
+                        },
+                        {
+                            "range": [48, 63],
+                            "name": "Orange",
+                            "color": "#ff7f00"
+                        },
+                        {
+                            "range": [64, 79],
+                            "name": "Green",
+                            "color": "#00ff00"
+                        },
+                        {
+                            "range": [80, 95],
+                            "name": "Red",
+                            "color": "#ff0000"
+                        },
+                        {
+                            "range": [96, 111],
+                            "name": "Blue",
+                            "color": "#0000ff"
+                        },
+                        {
+                            "range": [112, 127],
+                            "name": "Violet",
+                            "color": "#7f00ff"
+                        },
+                        {
+                            "range": [128, 191],
+                            "name": "Fwd"
+                        },
+                        {
+                            "range": [192, 255],
+                            "name": "Rev"
+                        }
+                    ]
+                },
+                "Gobo": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 18],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [19, 36],
+                            "name": "Gobo 1"
+                        },
+                        {
+                            "range": [37, 54],
+                            "name": "Gobo 2"
+                        },
+                        {
+                            "range": [55, 72],
+                            "name": "Gobo 3"
+                        },
+                        {
+                            "range": [73, 90],
+                            "name": "Gobo 4"
+                        },
+                        {
+                            "range": [91, 108],
+                            "name": "Gobo 5"
+                        },
+                        {
+                            "range": [109, 127],
+                            "name": "Gobo 6"
+                        },
+                        {
+                            "range": [128, 191],
+                            "name": "Fwd"
+                        },
+                        {
+                            "range": [192, 255],
+                            "name": "Rev"
+                        }
+                    ]
+                },
+                "Gobo Rotation": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "Index"
+                        },
+                        {
+                            "range": [128, 191],
+                            "name": "Fwd"
+                        },
+                        {
+                            "range": [192, 255],
+                            "name": "Rev"
+                        }
+                    ]
+                },
+                "Focus": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Control": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 199],
+                            "name": "Park"
+                        },
+                        {
+                            "range": [200, 207],
+                            "name": "Lamp OFF"
+                        },
+                        {
+                            "range": [208, 215],
+                            "name": "Lamp ON"
+                        },
+                        {
+                            "range": [216, 239],
+                            "name": "Park"
+                        },
+                        {
+                            "range": [240, 247],
+                            "name": "Reset"
+                        },
+                        {
+                            "range": [248, 255],
+                            "name": "Park"
+                        }
+                    ]
+                },
+                "P/T Speed": {
+                    "type": "Speed",
+                    "crossfade": true
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 0,
+                    "highlightValue": 0,
+                    "crossfade": true
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 0,
+                    "highlightValue": 0,
+                    "crossfade": true
+                },
+                "Prism": {
+                    "type": "Prism",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "No Func"
+                        },
+                        {
+                            "range": [128, 255],
+                            "name": "Prism"
+                        }
+                    ]
+                },
+                "Prism Rot": {
+                    "type": "Prism",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "Index"
+                        },
+                        {
+                            "range": [128, 191],
+                            "name": "Fwd"
+                        },
+                        {
+                            "range": [192, 255],
+                            "name": "Rev"
+                        }
+                    ]
+                },
+                "Macros": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Pan/Tilt Auto": {
+                    "type": "Pan",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 51],
+                            "name": "No Func"
+                        },
+                        {
+                            "range": [52, 102],
+                            "name": "Pan Auto"
+                        },
+                        {
+                            "range": [103, 153],
+                            "name": "Tilt Auto"
+                        },
+                        {
+                            "range": [154, 255],
+                            "name": "P/T Auto"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "16-channel Mode",
+                    "shortName": "16ch",
+                    "channels": [
+                        "Strobe",
+                        "Intensity",
+                        "Color",
+                        "Gobo",
+                        "Gobo Rotation",
+                        "Focus",
+                        "Control",
+                        "P/T Speed",
+                        "Pan",
+                        "Tilt",
+                        "Prism",
+                        "Prism Rot",
+                        "Macros",
+                        "Pan/Tilt Auto",
+                        "Pan fine",
+                        "Tilt fine"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "CKC Lighting",
+            "name": "LCD818 12ch",
+            "shortName": "LCD818 12ch",
+            "physical": {
+                "dimensions": [100, 100, 100]
+            },
+            "availableChannels": {
+                "Control": {
+                    "type": "Beam",
+                    "defaultValue": 10
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Flash": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Red1": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Green1": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Blue1": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Red2": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Green2": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Blue2": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Red3": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Green3": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Blue3": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true
+                }
+            },
+            "modes": [
+                {
+                    "name": "12-channel Mode",
+                    "shortName": "12ch",
+                    "channels": [
+                        "Control",
+                        "Intensity",
+                        "Flash",
+                        "Red1",
+                        "Green1",
+                        "Blue1",
+                        "Red2",
+                        "Green2",
+                        "Blue2",
+                        "Red3",
+                        "Green3",
+                        "Blue3"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "CKC Lighting",
+            "name": "LCD818 12ch Control",
+            "shortName": "LCD818 12ch Control",
+            "physical": {
+                "dimensions": [100, 100, 100]
+            },
+            "availableChannels": {
+                "Control": {
+                    "type": "Beam",
+                    "defaultValue": 10
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Flash": {
+                    "type": "Beam",
+                    "crossfade": true
+                }
+            },
+            "modes": [
+                {
+                    "name": "3-channel Mode",
+                    "shortName": "3ch",
+                    "channels": [
+                        "Control",
+                        "Intensity",
+                        "Flash"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "CKC Lighting",
+            "name": "LCD818 6ch",
+            "shortName": "LCD818 6ch",
+            "physical": {
+                "dimensions": [100, 100, 100]
+            },
+            "availableChannels": {
+                "Control": {
+                    "type": "Beam",
+                    "defaultValue": 25
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Flash": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true
+                }
+            },
+            "modes": [
+                {
+                    "name": "6-channel Mode",
+                    "shortName": "6ch",
+                    "channels": [
+                        "Control",
+                        "Intensity",
+                        "Flash",
+                        "Red",
+                        "Green",
+                        "Blue"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "CKC Lighting",
+            "name": "LED Par 38",
+            "shortName": "LED Par 38",
+            "physical": {
+                "dimensions": [120, 120, 200],
+                "weight": 1.2,
+                "power": 9
+            },
+            "availableChannels": {
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Dim /Strobe": {
+                    "type": "Strobe",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 189],
+                            "name": "Dim"
+                        },
+                        {
+                            "range": [190, 250],
+                            "name": "Strobe"
+                        },
+                        {
+                            "range": [251, 255],
+                            "name": "Full"
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "4-channel Mode",
+                    "shortName": "4ch",
+                    "channels": [
+                        "Red",
+                        "Green",
+                        "Blue",
+                        "Dim /Strobe"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "CKC Lighting",
+            "name": "LED Par 3ch",
+            "shortName": "LED Par 3ch",
+            "physical": {
+                "dimensions": [120, 120, 200]
+            },
+            "availableChannels": {
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true
+                }
+            },
+            "modes": [
+                {
+                    "name": "3-channel Mode",
+                    "shortName": "3ch",
+                    "channels": [
+                        "Red",
+                        "Green",
+                        "Blue"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "CKC Lighting",
+            "name": "LED Par 64 4ch",
+            "shortName": "LED Par 4ch",
+            "physical": {
+                "dimensions": [230, 230, 300],
+                "weight": 2.2,
+                "power": 28
+            },
+            "availableChannels": {
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Dim /Strobe": {
+                    "type": "Strobe",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 189],
+                            "name": "Dim"
+                        },
+                        {
+                            "range": [190, 250],
+                            "name": "Strobe"
+                        },
+                        {
+                            "range": [251, 255],
+                            "name": "Full"
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "4-channel Mode",
+                    "shortName": "4ch",
+                    "channels": [
+                        "Red",
+                        "Green",
+                        "Blue",
+                        "Dim /Strobe"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "CKC Lighting",
+            "name": "Tube Controller new",
+            "shortName": "Tube Control New CKC-602",
+            "physical": {
+                "dimensions": [200, 150, 50]
+            },
+            "availableChannels": {
+                "Program": {
+                    "type": "Effect",
+                    "capabilities": [
+                        {
+                            "range": [0, 16],
+                            "name": "RGB",
+                            "center": true
+                        },
+                        {
+                            "range": [17, 31],
+                            "name": "Static Clr Sel",
+                            "center": true
+                        },
+                        {
+                            "range": [32, 47],
+                            "name": "Clr Change",
+                            "center": true
+                        },
+                        {
+                            "range": [48, 63],
+                            "name": "Slow Flow",
+                            "center": true
+                        },
+                        {
+                            "range": [64, 79],
+                            "name": "Slow Flow 2",
+                            "center": true
+                        },
+                        {
+                            "range": [80, 95],
+                            "name": "Roll Chs 1",
+                            "center": true
+                        },
+                        {
+                            "range": [96, 111],
+                            "name": "Roll Chs 2",
+                            "center": true
+                        },
+                        {
+                            "range": [112, 127],
+                            "name": "Multi Clr",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 143],
+                            "name": "Fast Flow 1",
+                            "center": true
+                        },
+                        {
+                            "range": [144, 159],
+                            "name": "Fast Flow 2",
+                            "center": true
+                        },
+                        {
+                            "range": [160, 175],
+                            "name": "2 Clr Chase",
+                            "center": true
+                        },
+                        {
+                            "range": [176, 191],
+                            "name": "2 Clr Flow",
+                            "center": true
+                        },
+                        {
+                            "range": [192, 207],
+                            "name": "Clr Fade",
+                            "center": true
+                        },
+                        {
+                            "range": [208, 223],
+                            "name": "Tube Chs Sel",
+                            "center": true
+                        },
+                        {
+                            "range": [224, 239],
+                            "name": "Tube Chs2 Sel",
+                            "center": true
+                        },
+                        {
+                            "range": [240, 255],
+                            "name": "Auto Run",
+                            "center": true
+                        }
+                    ]
+                },
+                "Speed": {
+                    "type": "Speed"
+                },
+                "Flash Rate": {
+                    "type": "Beam"
+                },
+                "Color Select": {
+                    "type": "MultiColor",
+                    "capabilities": [
+                        {
+                            "range": [0, 8],
+                            "name": "Blk/Rd"
+                        },
+                        {
+                            "range": [9, 17],
+                            "name": "Blk/Gr"
+                        },
+                        {
+                            "range": [18, 26],
+                            "name": "Blk/Yel"
+                        },
+                        {
+                            "range": [27, 35],
+                            "name": "Blk/Blu"
+                        },
+                        {
+                            "range": [36, 44],
+                            "name": "Blk/Pur"
+                        },
+                        {
+                            "range": [46, 53],
+                            "name": "Blk/Cyan"
+                        },
+                        {
+                            "range": [54, 62],
+                            "name": "Blk/Wht"
+                        },
+                        {
+                            "range": [63, 71],
+                            "name": "Rd/Gr"
+                        },
+                        {
+                            "range": [72, 80],
+                            "name": "Rd/Yel"
+                        },
+                        {
+                            "range": [81, 89],
+                            "name": "Rd/Blu"
+                        },
+                        {
+                            "range": [90, 98],
+                            "name": "Rd/Pur"
+                        },
+                        {
+                            "range": [99, 107],
+                            "name": "Rd/Cyan"
+                        },
+                        {
+                            "range": [108, 116],
+                            "name": "Rd/Wht"
+                        },
+                        {
+                            "range": [117, 125],
+                            "name": "Gr/Yel"
+                        },
+                        {
+                            "range": [126, 134],
+                            "name": "Gr/Blu"
+                        },
+                        {
+                            "range": [135, 143],
+                            "name": "Gr/Pur"
+                        },
+                        {
+                            "range": [144, 152],
+                            "name": "Gr/Cyan"
+                        },
+                        {
+                            "range": [153, 161],
+                            "name": "Gr/Wht"
+                        },
+                        {
+                            "range": [162, 170],
+                            "name": "Yel/Blu"
+                        },
+                        {
+                            "range": [171, 179],
+                            "name": "Yel/Pur"
+                        },
+                        {
+                            "range": [180, 188],
+                            "name": "Yel/Cyan"
+                        },
+                        {
+                            "range": [189, 197],
+                            "name": "Yel/Wht"
+                        },
+                        {
+                            "range": [198, 206],
+                            "name": "Blu/Pur"
+                        },
+                        {
+                            "range": [207, 215],
+                            "name": "Blu/Cyan"
+                        },
+                        {
+                            "range": [216, 224],
+                            "name": "Blu/Wht"
+                        },
+                        {
+                            "range": [225, 233],
+                            "name": "Pur/Cyan"
+                        },
+                        {
+                            "range": [234, 242],
+                            "name": "Pur/Wht"
+                        },
+                        {
+                            "range": [243, 255],
+                            "name": "Cyan/Wht"
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "4-channel Mode",
+                    "shortName": "4ch",
+                    "channels": [
+                        "Program",
+                        "Speed",
+                        "Flash Rate",
+                        "Color Select"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "CKC Lighting",
+            "name": "Tube Controller Old",
+            "shortName": "Tube Control Old CKC-602",
+            "physical": {
+                "dimensions": [200, 150, 50]
+            },
+            "availableChannels": {
+                "Program": {
+                    "type": "Effect",
+                    "capabilities": [
+                        {
+                            "range": [0, 11],
+                            "name": "RGB"
+                        },
+                        {
+                            "range": [12, 23],
+                            "name": "Black",
+                            "color": "#000000"
+                        },
+                        {
+                            "range": [24, 35],
+                            "name": "Red",
+                            "color": "#ff0000"
+                        },
+                        {
+                            "range": [36, 47],
+                            "name": "Green",
+                            "color": "#00ff00"
+                        },
+                        {
+                            "range": [48, 59],
+                            "name": "Yellow",
+                            "color": "#ffff00"
+                        },
+                        {
+                            "range": [60, 71],
+                            "name": "Blue",
+                            "color": "#0000ff"
+                        },
+                        {
+                            "range": [72, 83],
+                            "name": "Purple",
+                            "color": "#800080"
+                        },
+                        {
+                            "range": [84, 95],
+                            "name": "Cyan",
+                            "color": "#00ffff"
+                        },
+                        {
+                            "range": [96, 107],
+                            "name": "White",
+                            "color": "#ffffff"
+                        },
+                        {
+                            "range": [108, 119],
+                            "name": "Clr Change"
+                        },
+                        {
+                            "range": [120, 131],
+                            "name": "Slow Flow"
+                        },
+                        {
+                            "range": [132, 143],
+                            "name": "Slow Flow 2"
+                        },
+                        {
+                            "range": [144, 155],
+                            "name": "Roll Chs 1"
+                        },
+                        {
+                            "range": [156, 167],
+                            "name": "Roll Chs 2"
+                        },
+                        {
+                            "range": [168, 179],
+                            "name": "Multi Clr"
+                        },
+                        {
+                            "range": [180, 191],
+                            "name": "Fast Flow 1"
+                        },
+                        {
+                            "range": [192, 203],
+                            "name": "Fast Flow 2"
+                        },
+                        {
+                            "range": [204, 215],
+                            "name": "2 Clr Chase"
+                        },
+                        {
+                            "range": [216, 227],
+                            "name": "2 Clr Flow"
+                        },
+                        {
+                            "range": [228, 239],
+                            "name": "Clr Fade"
+                        },
+                        {
+                            "range": [240, 255],
+                            "name": "Auto Run"
+                        }
+                    ]
+                },
+                "Speed": {
+                    "type": "Speed"
+                },
+                "Flash Rate": {
+                    "type": "Beam",
+                    "defaultValue": 255
+                },
+                "Color Select": {
+                    "type": "MultiColor",
+                    "capabilities": [
+                        {
+                            "range": [0, 11],
+                            "name": "Rd /Gr"
+                        },
+                        {
+                            "range": [12, 23],
+                            "name": "Rd /Yel"
+                        },
+                        {
+                            "range": [24, 35],
+                            "name": "Rd/Blu"
+                        },
+                        {
+                            "range": [36, 47],
+                            "name": "Rd/Pur"
+                        },
+                        {
+                            "range": [48, 59],
+                            "name": "Rd/Cyan"
+                        },
+                        {
+                            "range": [60, 71],
+                            "name": "Rd/Wht"
+                        },
+                        {
+                            "range": [72, 83],
+                            "name": "Gr/Yel"
+                        },
+                        {
+                            "range": [84, 95],
+                            "name": "Gr/Blu"
+                        },
+                        {
+                            "range": [96, 107],
+                            "name": "Gr/Pur"
+                        },
+                        {
+                            "range": [108, 119],
+                            "name": "Gr/Cyan"
+                        },
+                        {
+                            "range": [120, 131],
+                            "name": "Gr/Wht"
+                        },
+                        {
+                            "range": [132, 143],
+                            "name": "Yel/Blu"
+                        },
+                        {
+                            "range": [144, 155],
+                            "name": "Yel/Pur"
+                        },
+                        {
+                            "range": [156, 167],
+                            "name": "Yel/Cyan"
+                        },
+                        {
+                            "range": [168, 179],
+                            "name": "Yel/Wht"
+                        },
+                        {
+                            "range": [180, 191],
+                            "name": "Blu/Pur"
+                        },
+                        {
+                            "range": [192, 203],
+                            "name": "Blu/Cyan"
+                        },
+                        {
+                            "range": [204, 215],
+                            "name": "Blu/Wht"
+                        },
+                        {
+                            "range": [216, 227],
+                            "name": "Pur/Cyan"
+                        },
+                        {
+                            "range": [228, 239],
+                            "name": "Pur/Wht"
+                        },
+                        {
+                            "range": [240, 255],
+                            "name": "Cyan/Sht"
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "4-channel Mode",
+                    "shortName": "4ch",
+                    "channels": [
+                        "Program",
+                        "Speed",
+                        "Flash Rate",
+                        "Color Select"
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/fixtures/imports/ecue-MainLibrary/CLLS.json
+++ b/fixtures/imports/ecue-MainLibrary/CLLS.json
@@ -1,0 +1,77 @@
+{
+    "manufacturers": {
+        "CLLS": {
+            "name": "CLLS"
+        }
+    },
+    "fixtures": [
+        {
+            "manufacturer": "CLLS",
+            "name": "TL16",
+            "shortName": "TL16",
+            "physical": {
+                "dimensions": [100, 100, 100]
+            },
+            "availableChannels": {
+                "Beam 1": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Beam 2": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Beam 3": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Beam 4": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Beam 5": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Beam 6": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Beam 7": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Beam 8": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Beam Shutter": {
+                    "type": "Shutter",
+                    "crossfade": true
+                },
+                "Master Shutter": {
+                    "type": "Shutter",
+                    "crossfade": true
+                }
+            },
+            "modes": [
+                {
+                    "name": "10-channel Mode",
+                    "shortName": "10ch",
+                    "channels": [
+                        "Beam 1",
+                        "Beam 2",
+                        "Beam 3",
+                        "Beam 4",
+                        "Beam 5",
+                        "Beam 6",
+                        "Beam 7",
+                        "Beam 8",
+                        "Beam Shutter",
+                        "Master Shutter"
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/fixtures/imports/ecue-MainLibrary/Chauvet.json
+++ b/fixtures/imports/ecue-MainLibrary/Chauvet.json
@@ -1,0 +1,207 @@
+{
+    "manufacturers": {
+        "Chauvet": {
+            "name": "Chauvet",
+            "website": "http://www.chauvetlighting.com/"
+        }
+    },
+    "fixtures": [
+        {
+            "manufacturer": "Chauvet",
+            "name": "Arena Hazer",
+            "shortName": "Arena Hazer",
+            "comment": "http://www.chauvetlighting.com/arena-hazer.html",
+            "physical": {
+                "dimensions": [500, 500, 500],
+                "weight": 35
+            },
+            "availableChannels": {
+                "Haze": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "crossfade": true
+                },
+                "Fan": {
+                    "type": "Intensity",
+                    "warning": "Please check type!"
+                },
+                "Blower": {
+                    "type": "Intensity",
+                    "warning": "Please check type!"
+                }
+            },
+            "modes": [
+                {
+                    "name": "3-channel Mode",
+                    "shortName": "3ch",
+                    "channels": [
+                        "Haze",
+                        "Fan",
+                        "Blower"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Chauvet",
+            "name": "LED PAR 38",
+            "shortName": "PAR38",
+            "comment": "cd",
+            "physical": {
+                "dimensions": [235, 235, 300],
+                "weight": 1.5,
+                "power": 26
+            },
+            "availableChannels": {
+                "Strobe/Intensit": {
+                    "type": "Strobe",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 1],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [2, 127],
+                            "name": "strobe"
+                        },
+                        {
+                            "range": [128, 255],
+                            "name": "intensity"
+                        }
+                    ]
+                },
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true
+                }
+            },
+            "modes": [
+                {
+                    "name": "4-channel Mode",
+                    "shortName": "4ch",
+                    "channels": [
+                        "Strobe/Intensit",
+                        "Red",
+                        "Green",
+                        "Blue"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Chauvet",
+            "name": "LRG-55",
+            "shortName": "LRG55",
+            "comment": "cd http://www.chauvetlighting.com/scorpion-rg55.html",
+            "physical": {
+                "dimensions": [260, 130, 260],
+                "weight": 4.25,
+                "power": 25
+            },
+            "availableChannels": {
+                "Mode": {
+                    "type": "Beam",
+                    "highlightValue": 126,
+                    "capabilities": [
+                        {
+                            "range": [0, 10],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [11, 120],
+                            "name": "dynamic"
+                        },
+                        {
+                            "range": [121, 250],
+                            "name": "static"
+                        },
+                        {
+                            "range": [251, 255],
+                            "name": "audio"
+                        }
+                    ]
+                },
+                "Pattern": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "crossfade": true
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "crossfade": true
+                },
+                "P/T speed": {
+                    "type": "Speed",
+                    "defaultValue": 128,
+                    "crossfade": true
+                },
+                "Pattern speed": {
+                    "type": "Speed",
+                    "defaultValue": 128,
+                    "crossfade": true
+                },
+                "Pattern size": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Color": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 10],
+                            "name": "green & red"
+                        },
+                        {
+                            "range": [101, 200],
+                            "name": "green",
+                            "color": "#00ff00"
+                        },
+                        {
+                            "range": [201, 255],
+                            "name": "red",
+                            "color": "#ff0000"
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "8-channel Mode",
+                    "shortName": "8ch",
+                    "channels": [
+                        "Mode",
+                        "Pattern",
+                        "Pan",
+                        "Tilt",
+                        "P/T speed",
+                        "Pattern speed",
+                        "Pattern size",
+                        "Color"
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/fixtures/imports/ecue-MainLibrary/Clay-Paky.json
+++ b/fixtures/imports/ecue-MainLibrary/Clay-Paky.json
@@ -1,0 +1,13227 @@
+{
+    "manufacturers": {
+        "Clay Paky": {
+            "name": "Clay Paky",
+            "website": "www.claypaky.it"
+        }
+    },
+    "fixtures": [
+        {
+            "manufacturer": "Clay Paky",
+            "name": "Alpha Beam 700 STD Mode",
+            "shortName": "AlphaBeam700",
+            "physical": {
+                "dimensions": [390, 435, 635],
+                "weight": 20.8,
+                "power": 1050
+            },
+            "availableChannels": {
+                "Cyan": {
+                    "type": "SingleColor",
+                    "color": "Cyan",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Magenta": {
+                    "type": "SingleColor",
+                    "color": "Magenta",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Yellow": {
+                    "type": "SingleColor",
+                    "color": "Yellow",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Color Wheel": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "White",
+                            "color": "#ffffff",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [8, 8],
+                            "name": "White + Red",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [15, 15],
+                            "name": "Red",
+                            "color": "#ff0000",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [22, 22],
+                            "name": "Red + CTB",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [30, 30],
+                            "name": "CTB",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [37, 37],
+                            "name": "CTB + CTO 3200",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [45, 45],
+                            "name": "CTO 3200",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [52, 52],
+                            "name": "CTO 3200 + 2500",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [60, 60],
+                            "name": "CTO 2500",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [67, 67],
+                            "name": "CTO 2500 + Gr",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [75, 75],
+                            "name": "Green",
+                            "color": "#00ff00",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [82, 82],
+                            "name": "Green + Aqua",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [90, 90],
+                            "name": "Aquamarine",
+                            "color": "#7fffd4",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [97, 97],
+                            "name": "Aqua + Orange",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [105, 105],
+                            "name": "Orange",
+                            "color": "#ff7f00",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [112, 112],
+                            "name": "Or + Blue",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [120, 120],
+                            "name": "Blue",
+                            "color": "#0000ff",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [127, 127],
+                            "name": "Blue + White",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [128, 255],
+                            "name": "Rotation sl-fst",
+                            "showInMenu": false
+                        }
+                    ]
+                },
+                "Strobe": {
+                    "type": "Strobe",
+                    "defaultValue": 105,
+                    "highlightValue": 255,
+                    "capabilities": [
+                        {
+                            "range": [0, 3],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [4, 103],
+                            "name": "strobe"
+                        },
+                        {
+                            "range": [104, 107],
+                            "name": "open"
+                        },
+                        {
+                            "range": [108, 207],
+                            "name": "pulse"
+                        },
+                        {
+                            "range": [208, 212],
+                            "name": "open"
+                        },
+                        {
+                            "range": [213, 225],
+                            "name": "random sl strob"
+                        },
+                        {
+                            "range": [226, 238],
+                            "name": "random med st"
+                        },
+                        {
+                            "range": [239, 251],
+                            "name": "random fst st"
+                        },
+                        {
+                            "range": [252, 255],
+                            "name": "open"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 0,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "defaultValue": null
+                },
+                "Intensity fine": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "defaultValue": null
+                },
+                "Iris": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "open"
+                        },
+                        {
+                            "range": [1, 131],
+                            "name": "%"
+                        },
+                        {
+                            "range": [132, 171],
+                            "name": "pulse"
+                        },
+                        {
+                            "range": [172, 211],
+                            "name": "pulse opening"
+                        },
+                        {
+                            "range": [212, 251],
+                            "name": "pulse closing"
+                        },
+                        {
+                            "range": [252, 255],
+                            "name": "Maximum"
+                        }
+                    ]
+                },
+                "Static Gobo cha": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 7],
+                            "name": "open"
+                        },
+                        {
+                            "range": [8, 15],
+                            "name": "Gobo 1"
+                        },
+                        {
+                            "range": [16, 23],
+                            "name": "Gobo 2"
+                        },
+                        {
+                            "range": [24, 31],
+                            "name": "Gobo 3"
+                        },
+                        {
+                            "range": [32, 39],
+                            "name": "Gobo 4"
+                        },
+                        {
+                            "range": [40, 47],
+                            "name": "Gobo 5"
+                        },
+                        {
+                            "range": [48, 55],
+                            "name": "Gobo 6"
+                        },
+                        {
+                            "range": [56, 63],
+                            "name": "Gobo 7"
+                        },
+                        {
+                            "range": [64, 71],
+                            "name": "Gobo 8"
+                        },
+                        {
+                            "range": [72, 113],
+                            "name": "Rotation 1"
+                        },
+                        {
+                            "range": [114, 117],
+                            "name": "Stop"
+                        },
+                        {
+                            "range": [118, 159],
+                            "name": "Rotation 2"
+                        },
+                        {
+                            "range": [160, 175],
+                            "name": "Gobo 2 shake"
+                        },
+                        {
+                            "range": [176, 191],
+                            "name": "Gobo 3 shake"
+                        },
+                        {
+                            "range": [192, 207],
+                            "name": "Gobo 4 shake"
+                        },
+                        {
+                            "range": [208, 223],
+                            "name": "Gobo 5 shake"
+                        },
+                        {
+                            "range": [224, 239],
+                            "name": "Gobo 6 shake"
+                        },
+                        {
+                            "range": [240, 255],
+                            "name": "Gobo 7 shake"
+                        }
+                    ]
+                },
+                "Rot Gobo change": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 16],
+                            "name": "open"
+                        },
+                        {
+                            "range": [17, 32],
+                            "name": "Gobo 1"
+                        },
+                        {
+                            "range": [33, 48],
+                            "name": "Gobo 2"
+                        },
+                        {
+                            "range": [49, 64],
+                            "name": "Gobo 3"
+                        },
+                        {
+                            "range": [65, 81],
+                            "name": "Gobo 4"
+                        },
+                        {
+                            "range": [82, 97],
+                            "name": "Gobo 5"
+                        },
+                        {
+                            "range": [98, 113],
+                            "name": "Gobo 6"
+                        },
+                        {
+                            "range": [114, 129],
+                            "name": "Gobo 7"
+                        },
+                        {
+                            "range": [130, 255],
+                            "name": "shake"
+                        }
+                    ]
+                },
+                "Gobo rotation": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "0"
+                        },
+                        {
+                            "range": [21, 21],
+                            "name": "90"
+                        },
+                        {
+                            "range": [42, 42],
+                            "name": "180"
+                        },
+                        {
+                            "range": [63, 63],
+                            "name": "270"
+                        },
+                        {
+                            "range": [84, 84],
+                            "name": "360"
+                        },
+                        {
+                            "range": [105, 105],
+                            "name": "450"
+                        },
+                        {
+                            "range": [127, 127],
+                            "name": "540"
+                        },
+                        {
+                            "range": [128, 190],
+                            "name": "Rotation 1"
+                        },
+                        {
+                            "range": [191, 192],
+                            "name": "Stop"
+                        },
+                        {
+                            "range": [193, 255],
+                            "name": "Rotation 2"
+                        }
+                    ]
+                },
+                "Prisma insert": {
+                    "type": "Prism",
+                    "crossfade": true
+                },
+                "Prisma rotation": {
+                    "type": "Prism",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "0"
+                        },
+                        {
+                            "range": [21, 21],
+                            "name": "90"
+                        },
+                        {
+                            "range": [42, 42],
+                            "name": "180"
+                        },
+                        {
+                            "range": [63, 63],
+                            "name": "270"
+                        },
+                        {
+                            "range": [84, 84],
+                            "name": "360"
+                        },
+                        {
+                            "range": [105, 105],
+                            "name": "450"
+                        },
+                        {
+                            "range": [127, 127],
+                            "name": "540"
+                        },
+                        {
+                            "range": [128, 190],
+                            "name": "Rotation 1"
+                        },
+                        {
+                            "range": [191, 192],
+                            "name": "Stop"
+                        },
+                        {
+                            "range": [193, 255],
+                            "name": "Rotation 2"
+                        }
+                    ]
+                },
+                "Frost": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Focus": {
+                    "type": "Beam",
+                    "highlightValue": 128,
+                    "crossfade": true
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Function": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 12],
+                            "name": "Unused"
+                        },
+                        {
+                            "range": [13, 26],
+                            "name": "P+T Function"
+                        },
+                        {
+                            "range": [39, 51],
+                            "name": "Dimmer Curve"
+                        },
+                        {
+                            "range": [52, 255],
+                            "name": "Unused"
+                        }
+                    ]
+                },
+                "Reset": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 25],
+                            "name": "Unused"
+                        },
+                        {
+                            "range": [26, 76],
+                            "name": "Effect reset"
+                        },
+                        {
+                            "range": [77, 127],
+                            "name": "P+T reset"
+                        },
+                        {
+                            "range": [128, 255],
+                            "name": "Compl reset"
+                        }
+                    ]
+                },
+                "Lamp": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 25],
+                            "name": "idle"
+                        },
+                        {
+                            "range": [26, 100],
+                            "name": "lamp off"
+                        },
+                        {
+                            "range": [101, 179],
+                            "name": "50% power"
+                        },
+                        {
+                            "range": [180, 255],
+                            "name": "lamp on"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Intensity",
+                    "Intensity fine"
+                ],
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "22-channel Mode",
+                    "shortName": "22ch",
+                    "channels": [
+                        "Cyan",
+                        "Magenta",
+                        "Yellow",
+                        "Color Wheel",
+                        "Strobe",
+                        "Intensity",
+                        "Intensity fine",
+                        "Iris",
+                        "Static Gobo cha",
+                        "Rot Gobo change",
+                        "Gobo rotation",
+                        "Prisma insert",
+                        "Prisma rotation",
+                        "Frost",
+                        "Focus",
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "Function",
+                        "Reset",
+                        "Lamp"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Clay Paky",
+            "name": "Alpha Profile 1200 16Bit",
+            "shortName": "AlphaPro1216b",
+            "comment": "16Bit (CMY on) cd  http://www.claypaky.it/en/products/alpha-profile-1200",
+            "physical": {
+                "dimensions": [520, 520, 740],
+                "weight": 40,
+                "power": 1600
+            },
+            "availableChannels": {
+                "Cyan": {
+                    "type": "SingleColor",
+                    "color": "Cyan",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Magenta": {
+                    "type": "SingleColor",
+                    "color": "Magenta",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Yellow": {
+                    "type": "SingleColor",
+                    "color": "Yellow",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "CTO": {
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Color": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 17],
+                            "name": "open"
+                        },
+                        {
+                            "range": [18, 35],
+                            "name": "red",
+                            "color": "#ff0000"
+                        },
+                        {
+                            "range": [36, 53],
+                            "name": "yellow",
+                            "color": "#ffff00"
+                        },
+                        {
+                            "range": [54, 71],
+                            "name": "violet",
+                            "color": "#7f00ff"
+                        },
+                        {
+                            "range": [72, 89],
+                            "name": "green",
+                            "color": "#00ff00"
+                        },
+                        {
+                            "range": [90, 107],
+                            "name": "orange",
+                            "color": "#ff7f00"
+                        },
+                        {
+                            "range": [108, 127],
+                            "name": "blue",
+                            "color": "#0000ff"
+                        },
+                        {
+                            "range": [128, 255],
+                            "name": "rot."
+                        }
+                    ]
+                },
+                "Strobe": {
+                    "type": "Strobe",
+                    "highlightValue": 255,
+                    "capabilities": [
+                        {
+                            "range": [0, 3],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [4, 103],
+                            "name": "strobe"
+                        },
+                        {
+                            "range": [104, 107],
+                            "name": "open"
+                        },
+                        {
+                            "range": [108, 207],
+                            "name": "pulse"
+                        },
+                        {
+                            "range": [208, 212],
+                            "name": "open"
+                        },
+                        {
+                            "range": [213, 251],
+                            "name": "random"
+                        },
+                        {
+                            "range": [252, 255],
+                            "name": "open"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Iris": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "open"
+                        },
+                        {
+                            "range": [1, 131],
+                            "name": "%"
+                        },
+                        {
+                            "range": [132, 251],
+                            "name": "pulse"
+                        },
+                        {
+                            "range": [252, 255],
+                            "name": "closed"
+                        }
+                    ]
+                },
+                "Gobo1": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 7],
+                            "name": "open"
+                        },
+                        {
+                            "range": [8, 15],
+                            "name": "slot1"
+                        },
+                        {
+                            "range": [16, 23],
+                            "name": "slot2"
+                        },
+                        {
+                            "range": [24, 31],
+                            "name": "slot3"
+                        },
+                        {
+                            "range": [32, 39],
+                            "name": "slot4"
+                        },
+                        {
+                            "range": [40, 47],
+                            "name": "slot5"
+                        },
+                        {
+                            "range": [48, 55],
+                            "name": "slot6"
+                        },
+                        {
+                            "range": [56, 63],
+                            "name": "slot7"
+                        },
+                        {
+                            "range": [64, 71],
+                            "name": "slot8"
+                        },
+                        {
+                            "range": [72, 113],
+                            "name": ">>"
+                        },
+                        {
+                            "range": [114, 117],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [118, 159],
+                            "name": "<<"
+                        },
+                        {
+                            "range": [160, 255],
+                            "name": "shake"
+                        }
+                    ]
+                },
+                "Gobo2": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 17],
+                            "name": "open"
+                        },
+                        {
+                            "range": [18, 35],
+                            "name": "slot1"
+                        },
+                        {
+                            "range": [36, 53],
+                            "name": "slot2"
+                        },
+                        {
+                            "range": [54, 71],
+                            "name": "slot3"
+                        },
+                        {
+                            "range": [72, 89],
+                            "name": "slot4"
+                        },
+                        {
+                            "range": [90, 107],
+                            "name": "slot5"
+                        },
+                        {
+                            "range": [108, 129],
+                            "name": "slot6"
+                        },
+                        {
+                            "range": [130, 255],
+                            "name": "shake"
+                        }
+                    ]
+                },
+                "Gobo2 rot.": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "ind."
+                        },
+                        {
+                            "range": [128, 190],
+                            "name": "<<"
+                        },
+                        {
+                            "range": [191, 192],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [193, 255],
+                            "name": ">>"
+                        }
+                    ],
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "Gobo2 rot. fine": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "ind."
+                        },
+                        {
+                            "range": [128, 190],
+                            "name": "<<"
+                        },
+                        {
+                            "range": [191, 192],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [193, 255],
+                            "name": ">>"
+                        }
+                    ],
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "Blade up1": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Blade up2": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Blade dw1": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Blade dw2": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Blade rg1": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Blade rg2": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Blade lf1": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Blade lf2": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Blade rot.": {
+                    "type": "Beam",
+                    "highlightValue": 128,
+                    "crossfade": true
+                },
+                "Effect": {
+                    "type": "Effect",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 60],
+                            "name": "open"
+                        },
+                        {
+                            "range": [61, 101],
+                            "name": "light frost"
+                        },
+                        {
+                            "range": [102, 152],
+                            "name": "havy frost"
+                        },
+                        {
+                            "range": [153, 203],
+                            "name": "prisma"
+                        },
+                        {
+                            "range": [204, 255],
+                            "name": "animation"
+                        }
+                    ]
+                },
+                "Prisma rot.": {
+                    "type": "Prism",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "ind."
+                        },
+                        {
+                            "range": [128, 190],
+                            "name": "<<"
+                        },
+                        {
+                            "range": [191, 192],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [193, 255],
+                            "name": ">>"
+                        }
+                    ]
+                },
+                "Focus": {
+                    "type": "Beam",
+                    "highlightValue": 128,
+                    "crossfade": true
+                },
+                "Zoom": {
+                    "type": "Beam",
+                    "highlightValue": 128,
+                    "crossfade": true
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Reset": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "idle"
+                        },
+                        {
+                            "range": [128, 255],
+                            "name": "reset"
+                        }
+                    ]
+                },
+                "Lamp": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 25],
+                            "name": "idle"
+                        },
+                        {
+                            "range": [26, 100],
+                            "name": "lamp off"
+                        },
+                        {
+                            "range": [101, 179],
+                            "name": "50% power"
+                        },
+                        {
+                            "range": [180, 255],
+                            "name": "lamp on"
+                        }
+                    ]
+                },
+                "P/T speed": {
+                    "type": "Speed",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Col. speed": {
+                    "type": "Speed",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Beam speed": {
+                    "type": "Speed",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Gobo speed": {
+                    "type": "Speed",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Gobo2 rot.",
+                    "Gobo2 rot. fine"
+                ],
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "35-channel Mode",
+                    "shortName": "35ch",
+                    "channels": [
+                        "Cyan",
+                        "Magenta",
+                        "Yellow",
+                        "CTO",
+                        "Color",
+                        "Strobe",
+                        "Intensity",
+                        "Iris",
+                        "Gobo1",
+                        "Gobo2",
+                        "Gobo2 rot.",
+                        "Blade up1",
+                        "Blade up2",
+                        "Blade dw1",
+                        "Blade dw2",
+                        "Blade rg1",
+                        "Blade rg2",
+                        "Blade lf1",
+                        "Blade lf2",
+                        "Blade rot.",
+                        "Effect",
+                        "Prisma rot.",
+                        "Focus",
+                        "Zoom",
+                        "Pan",
+                        "Tilt",
+                        "Reset",
+                        "Lamp",
+                        "Pan fine",
+                        "Tilt fine",
+                        "Gobo2 rot. fine",
+                        "P/T speed",
+                        "Col. speed",
+                        "Beam speed",
+                        "Gobo speed"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Clay Paky",
+            "name": "Alpha Profile 1200 Extn",
+            "shortName": "AlphaPro12ex",
+            "comment": "Extn (CMY on) cd",
+            "physical": {
+                "dimensions": [520, 520, 740],
+                "weight": 40,
+                "power": 1600
+            },
+            "availableChannels": {
+                "Cyan": {
+                    "type": "SingleColor",
+                    "color": "Cyan",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Magenta": {
+                    "type": "SingleColor",
+                    "color": "Magenta",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Yellow": {
+                    "type": "SingleColor",
+                    "color": "Yellow",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "CTO": {
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Color": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 17],
+                            "name": "open"
+                        },
+                        {
+                            "range": [18, 35],
+                            "name": "red",
+                            "color": "#ff0000"
+                        },
+                        {
+                            "range": [36, 53],
+                            "name": "yellow",
+                            "color": "#ffff00"
+                        },
+                        {
+                            "range": [54, 71],
+                            "name": "violet",
+                            "color": "#7f00ff"
+                        },
+                        {
+                            "range": [72, 89],
+                            "name": "green",
+                            "color": "#00ff00"
+                        },
+                        {
+                            "range": [90, 107],
+                            "name": "orange",
+                            "color": "#ff7f00"
+                        },
+                        {
+                            "range": [108, 127],
+                            "name": "blue",
+                            "color": "#0000ff"
+                        },
+                        {
+                            "range": [128, 255],
+                            "name": "rot."
+                        }
+                    ]
+                },
+                "Strobe": {
+                    "type": "Strobe",
+                    "highlightValue": 255,
+                    "capabilities": [
+                        {
+                            "range": [0, 3],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [4, 103],
+                            "name": "strobe"
+                        },
+                        {
+                            "range": [104, 107],
+                            "name": "open"
+                        },
+                        {
+                            "range": [108, 207],
+                            "name": "pulse"
+                        },
+                        {
+                            "range": [208, 212],
+                            "name": "open"
+                        },
+                        {
+                            "range": [213, 251],
+                            "name": "random"
+                        },
+                        {
+                            "range": [252, 255],
+                            "name": "open"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Iris": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "open"
+                        },
+                        {
+                            "range": [1, 131],
+                            "name": "%"
+                        },
+                        {
+                            "range": [132, 251],
+                            "name": "pulse"
+                        },
+                        {
+                            "range": [252, 255],
+                            "name": "closed"
+                        }
+                    ]
+                },
+                "Gobo1": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 7],
+                            "name": "open"
+                        },
+                        {
+                            "range": [8, 15],
+                            "name": "slot1"
+                        },
+                        {
+                            "range": [16, 23],
+                            "name": "slot2"
+                        },
+                        {
+                            "range": [24, 31],
+                            "name": "slot3"
+                        },
+                        {
+                            "range": [32, 39],
+                            "name": "slot4"
+                        },
+                        {
+                            "range": [40, 47],
+                            "name": "slot5"
+                        },
+                        {
+                            "range": [48, 55],
+                            "name": "slot6"
+                        },
+                        {
+                            "range": [56, 63],
+                            "name": "slot7"
+                        },
+                        {
+                            "range": [64, 71],
+                            "name": "slot8"
+                        },
+                        {
+                            "range": [72, 113],
+                            "name": ">>"
+                        },
+                        {
+                            "range": [114, 117],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [118, 159],
+                            "name": "<<"
+                        },
+                        {
+                            "range": [160, 255],
+                            "name": "shake"
+                        }
+                    ]
+                },
+                "Gobo2": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 17],
+                            "name": "open"
+                        },
+                        {
+                            "range": [18, 35],
+                            "name": "slot1"
+                        },
+                        {
+                            "range": [36, 53],
+                            "name": "slot2"
+                        },
+                        {
+                            "range": [54, 71],
+                            "name": "slot3"
+                        },
+                        {
+                            "range": [72, 89],
+                            "name": "slot4"
+                        },
+                        {
+                            "range": [90, 107],
+                            "name": "slot5"
+                        },
+                        {
+                            "range": [108, 129],
+                            "name": "slot6"
+                        },
+                        {
+                            "range": [130, 255],
+                            "name": "shake"
+                        }
+                    ]
+                },
+                "Gobo2 rot.": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "ind."
+                        },
+                        {
+                            "range": [128, 190],
+                            "name": "<<"
+                        },
+                        {
+                            "range": [191, 192],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [193, 255],
+                            "name": ">>"
+                        }
+                    ],
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "Gobo2 rot. fine": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "ind."
+                        },
+                        {
+                            "range": [128, 190],
+                            "name": "<<"
+                        },
+                        {
+                            "range": [191, 192],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [193, 255],
+                            "name": ">>"
+                        }
+                    ],
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "Blade up1": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Blade up2": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Blade dw1": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Blade dw2": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Blade rg1": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Blade rg2": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Blade lf1": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Blade lf2": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Blade rot.": {
+                    "type": "Beam",
+                    "highlightValue": 128,
+                    "crossfade": true
+                },
+                "Effect": {
+                    "type": "Effect",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 60],
+                            "name": "open"
+                        },
+                        {
+                            "range": [61, 101],
+                            "name": "light frost"
+                        },
+                        {
+                            "range": [102, 152],
+                            "name": "havy frost"
+                        },
+                        {
+                            "range": [153, 203],
+                            "name": "prisma"
+                        },
+                        {
+                            "range": [204, 255],
+                            "name": "animation"
+                        }
+                    ]
+                },
+                "Prisma rot.": {
+                    "type": "Prism",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "ind."
+                        },
+                        {
+                            "range": [128, 190],
+                            "name": "<<"
+                        },
+                        {
+                            "range": [191, 192],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [193, 255],
+                            "name": ">>"
+                        }
+                    ]
+                },
+                "Focus": {
+                    "type": "Beam",
+                    "highlightValue": 128,
+                    "crossfade": true
+                },
+                "Zoom": {
+                    "type": "Beam",
+                    "highlightValue": 128,
+                    "crossfade": true
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Reset": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "idle"
+                        },
+                        {
+                            "range": [128, 255],
+                            "name": "reset"
+                        }
+                    ]
+                },
+                "Lamp": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 25],
+                            "name": "idle"
+                        },
+                        {
+                            "range": [26, 100],
+                            "name": "lamp off"
+                        },
+                        {
+                            "range": [101, 179],
+                            "name": "50% power"
+                        },
+                        {
+                            "range": [180, 255],
+                            "name": "lamp on"
+                        }
+                    ]
+                },
+                "P/T speed": {
+                    "type": "Speed",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Col. speed": {
+                    "type": "Speed",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Beam speed": {
+                    "type": "Speed",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Gobo speed": {
+                    "type": "Speed",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Gobo2 rot.",
+                    "Gobo2 rot. fine"
+                ],
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "35-channel Mode",
+                    "shortName": "35ch",
+                    "channels": [
+                        "Cyan",
+                        "Magenta",
+                        "Yellow",
+                        "CTO",
+                        "Color",
+                        "Strobe",
+                        "Intensity",
+                        "Iris",
+                        "Gobo1",
+                        "Gobo2",
+                        "Gobo2 rot.",
+                        "Gobo2 rot. fine",
+                        "Blade up1",
+                        "Blade up2",
+                        "Blade dw1",
+                        "Blade dw2",
+                        "Blade rg1",
+                        "Blade rg2",
+                        "Blade lf1",
+                        "Blade lf2",
+                        "Effect",
+                        null,
+                        "Prisma rot.",
+                        "Focus",
+                        "Zoom",
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "Reset",
+                        "Lamp",
+                        "P/T speed",
+                        "Col. speed",
+                        "Beam speed",
+                        "Gobo speed"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Clay Paky",
+            "name": "Alpha Profile 1200 Stnd",
+            "shortName": "AlphaPro12stnd",
+            "comment": "Stnd (CMY on) cd",
+            "physical": {
+                "dimensions": [520, 520, 740],
+                "weight": 40,
+                "power": 1600
+            },
+            "availableChannels": {
+                "Cyan": {
+                    "type": "SingleColor",
+                    "color": "Cyan",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Magenta": {
+                    "type": "SingleColor",
+                    "color": "Magenta",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Yellow": {
+                    "type": "SingleColor",
+                    "color": "Yellow",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "CTO": {
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Color": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 17],
+                            "name": "open"
+                        },
+                        {
+                            "range": [18, 35],
+                            "name": "red",
+                            "color": "#ff0000"
+                        },
+                        {
+                            "range": [36, 53],
+                            "name": "yellow",
+                            "color": "#ffff00"
+                        },
+                        {
+                            "range": [54, 71],
+                            "name": "violet",
+                            "color": "#7f00ff"
+                        },
+                        {
+                            "range": [72, 89],
+                            "name": "green",
+                            "color": "#00ff00"
+                        },
+                        {
+                            "range": [90, 107],
+                            "name": "orange",
+                            "color": "#ff7f00"
+                        },
+                        {
+                            "range": [108, 127],
+                            "name": "blue",
+                            "color": "#0000ff"
+                        },
+                        {
+                            "range": [128, 255],
+                            "name": "rot."
+                        }
+                    ]
+                },
+                "Strobe": {
+                    "type": "Strobe",
+                    "highlightValue": 255,
+                    "capabilities": [
+                        {
+                            "range": [0, 3],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [4, 103],
+                            "name": "strobe"
+                        },
+                        {
+                            "range": [104, 107],
+                            "name": "open"
+                        },
+                        {
+                            "range": [108, 207],
+                            "name": "pulse"
+                        },
+                        {
+                            "range": [208, 212],
+                            "name": "open"
+                        },
+                        {
+                            "range": [213, 251],
+                            "name": "random"
+                        },
+                        {
+                            "range": [252, 255],
+                            "name": "open"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Iris": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "open"
+                        },
+                        {
+                            "range": [1, 131],
+                            "name": "%"
+                        },
+                        {
+                            "range": [132, 251],
+                            "name": "pulse"
+                        },
+                        {
+                            "range": [252, 255],
+                            "name": "closed"
+                        }
+                    ]
+                },
+                "Gobo1": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 7],
+                            "name": "open"
+                        },
+                        {
+                            "range": [8, 15],
+                            "name": "slot1"
+                        },
+                        {
+                            "range": [16, 23],
+                            "name": "slot2"
+                        },
+                        {
+                            "range": [24, 31],
+                            "name": "slot3"
+                        },
+                        {
+                            "range": [32, 39],
+                            "name": "slot4"
+                        },
+                        {
+                            "range": [40, 47],
+                            "name": "slot5"
+                        },
+                        {
+                            "range": [48, 55],
+                            "name": "slot6"
+                        },
+                        {
+                            "range": [56, 63],
+                            "name": "slot7"
+                        },
+                        {
+                            "range": [64, 71],
+                            "name": "slot8"
+                        },
+                        {
+                            "range": [72, 113],
+                            "name": ">>"
+                        },
+                        {
+                            "range": [114, 117],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [118, 159],
+                            "name": "<<"
+                        },
+                        {
+                            "range": [160, 255],
+                            "name": "shake"
+                        }
+                    ]
+                },
+                "Gobo2": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 17],
+                            "name": "open"
+                        },
+                        {
+                            "range": [18, 35],
+                            "name": "slot1"
+                        },
+                        {
+                            "range": [36, 53],
+                            "name": "slot2"
+                        },
+                        {
+                            "range": [54, 71],
+                            "name": "slot3"
+                        },
+                        {
+                            "range": [72, 89],
+                            "name": "slot4"
+                        },
+                        {
+                            "range": [90, 107],
+                            "name": "slot5"
+                        },
+                        {
+                            "range": [108, 129],
+                            "name": "slot6"
+                        },
+                        {
+                            "range": [130, 255],
+                            "name": "shake"
+                        }
+                    ]
+                },
+                "Gobo2 rot.": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "ind."
+                        },
+                        {
+                            "range": [128, 190],
+                            "name": "<<"
+                        },
+                        {
+                            "range": [191, 192],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [193, 255],
+                            "name": ">>"
+                        }
+                    ]
+                },
+                "Blade up1": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Blade up2": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Blade dw1": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Blade dw2": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Blade rg1": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Blade rg2": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Blade lf1": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Blade lf2": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Blade rot.": {
+                    "type": "Beam",
+                    "highlightValue": 128,
+                    "crossfade": true
+                },
+                "Effect": {
+                    "type": "Effect",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 60],
+                            "name": "open"
+                        },
+                        {
+                            "range": [61, 101],
+                            "name": "light frost"
+                        },
+                        {
+                            "range": [102, 152],
+                            "name": "havy frost"
+                        },
+                        {
+                            "range": [153, 203],
+                            "name": "prisma"
+                        },
+                        {
+                            "range": [204, 255],
+                            "name": "animation"
+                        }
+                    ]
+                },
+                "Prisma rot.": {
+                    "type": "Prism",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "ind."
+                        },
+                        {
+                            "range": [128, 190],
+                            "name": "<<"
+                        },
+                        {
+                            "range": [191, 192],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [193, 255],
+                            "name": ">>"
+                        }
+                    ]
+                },
+                "Focus": {
+                    "type": "Beam",
+                    "highlightValue": 128,
+                    "crossfade": true
+                },
+                "Zoom": {
+                    "type": "Beam",
+                    "highlightValue": 128,
+                    "crossfade": true
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true
+                },
+                "Reset": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "idle"
+                        },
+                        {
+                            "range": [128, 255],
+                            "name": "reset"
+                        }
+                    ]
+                },
+                "Lamp": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 25],
+                            "name": "idle"
+                        },
+                        {
+                            "range": [26, 100],
+                            "name": "lamp off"
+                        },
+                        {
+                            "range": [101, 179],
+                            "name": "50% power"
+                        },
+                        {
+                            "range": [180, 255],
+                            "name": "lamp on"
+                        }
+                    ]
+                },
+                "P/T speed": {
+                    "type": "Speed",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Col. speed": {
+                    "type": "Speed",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Beam speed": {
+                    "type": "Speed",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Gobo speed": {
+                    "type": "Speed",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true
+                }
+            },
+            "modes": [
+                {
+                    "name": "35-channel Mode",
+                    "shortName": "35ch",
+                    "channels": [
+                        "Cyan",
+                        "Magenta",
+                        "Yellow",
+                        "CTO",
+                        "Color",
+                        "Strobe",
+                        "Intensity",
+                        "Iris",
+                        "Gobo1",
+                        "Gobo2",
+                        "Gobo2 rot.",
+                        "Blade up1",
+                        "Blade up2",
+                        "Blade dw1",
+                        "Blade dw2",
+                        "Blade rg1",
+                        "Blade rg2",
+                        "Blade lf1",
+                        "Blade lf2",
+                        "Blade rot.",
+                        "Effect",
+                        "Prisma rot.",
+                        "Focus",
+                        "Zoom",
+                        "Pan",
+                        "Tilt",
+                        "Reset",
+                        "Lamp",
+                        null,
+                        null,
+                        null,
+                        "P/T speed",
+                        "Col. speed",
+                        "Beam speed",
+                        "Gobo speed"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Clay Paky",
+            "name": "Alpha Profile 700 STD Mode",
+            "shortName": "AlphaProfile700",
+            "physical": {
+                "dimensions": [390, 455, 650],
+                "weight": 31.5,
+                "power": 1050
+            },
+            "availableChannels": {
+                "Cyan": {
+                    "type": "SingleColor",
+                    "color": "Cyan",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Magenta": {
+                    "type": "SingleColor",
+                    "color": "Magenta",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Yellow": {
+                    "type": "SingleColor",
+                    "color": "Yellow",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "CTO": {
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Color Wheel": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "White",
+                            "color": "#ffffff",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [8, 8],
+                            "name": "White + Red",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [15, 15],
+                            "name": "Red",
+                            "color": "#ff0000",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [22, 22],
+                            "name": "Red + CTO",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [30, 30],
+                            "name": "CTO",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [37, 37],
+                            "name": "CTO + Green",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [45, 45],
+                            "name": "Green",
+                            "color": "#00ff00",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [52, 52],
+                            "name": "Green + Light G",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [60, 60],
+                            "name": "Light Green",
+                            "color": "#90ee90",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [67, 67],
+                            "name": "Light G + Lav",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [75, 75],
+                            "name": "Lavender",
+                            "color": "#b57edc",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [82, 82],
+                            "name": "Lav + Aqua",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [90, 90],
+                            "name": "Aquamarine",
+                            "color": "#7fffd4",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [97, 97],
+                            "name": "Aqua + Orange",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [105, 105],
+                            "name": "Orange",
+                            "color": "#ff7f00",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [112, 112],
+                            "name": "Or + Blue",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [120, 120],
+                            "name": "Blue",
+                            "color": "#0000ff",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [127, 127],
+                            "name": "Blue + White",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [128, 255],
+                            "name": "Rotation sl-fst",
+                            "showInMenu": false
+                        }
+                    ]
+                },
+                "Macro Colours": {
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "crossfade": true
+                },
+                "Strobe": {
+                    "type": "Strobe",
+                    "defaultValue": 105,
+                    "highlightValue": 255,
+                    "capabilities": [
+                        {
+                            "range": [0, 3],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [4, 103],
+                            "name": "strobe"
+                        },
+                        {
+                            "range": [104, 107],
+                            "name": "open"
+                        },
+                        {
+                            "range": [108, 207],
+                            "name": "pulse"
+                        },
+                        {
+                            "range": [208, 212],
+                            "name": "open"
+                        },
+                        {
+                            "range": [213, 225],
+                            "name": "random sl strob"
+                        },
+                        {
+                            "range": [226, 238],
+                            "name": "random med st"
+                        },
+                        {
+                            "range": [239, 251],
+                            "name": "random fst st"
+                        },
+                        {
+                            "range": [252, 255],
+                            "name": "open"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 0,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "defaultValue": null
+                },
+                "Intensity fine": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "defaultValue": null
+                },
+                "Iris": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "open"
+                        },
+                        {
+                            "range": [1, 131],
+                            "name": "%"
+                        },
+                        {
+                            "range": [132, 171],
+                            "name": "pulse"
+                        },
+                        {
+                            "range": [172, 211],
+                            "name": "pulse opening"
+                        },
+                        {
+                            "range": [212, 251],
+                            "name": "pulse closing"
+                        },
+                        {
+                            "range": [252, 255],
+                            "name": "Maximum"
+                        }
+                    ]
+                },
+                "Gobo1": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 16],
+                            "name": "open"
+                        },
+                        {
+                            "range": [17, 32],
+                            "name": "slot1"
+                        },
+                        {
+                            "range": [33, 48],
+                            "name": "slot2"
+                        },
+                        {
+                            "range": [49, 64],
+                            "name": "slot3"
+                        },
+                        {
+                            "range": [65, 81],
+                            "name": "slot4"
+                        },
+                        {
+                            "range": [82, 97],
+                            "name": "slot5"
+                        },
+                        {
+                            "range": [98, 113],
+                            "name": "slot6"
+                        },
+                        {
+                            "range": [114, 129],
+                            "name": "slot7"
+                        },
+                        {
+                            "range": [130, 255],
+                            "name": "shake"
+                        }
+                    ]
+                },
+                "Gobo rotation": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "0"
+                        },
+                        {
+                            "range": [21, 21],
+                            "name": "90"
+                        },
+                        {
+                            "range": [42, 42],
+                            "name": "180"
+                        },
+                        {
+                            "range": [63, 63],
+                            "name": "270"
+                        },
+                        {
+                            "range": [84, 84],
+                            "name": "360"
+                        },
+                        {
+                            "range": [105, 105],
+                            "name": "450"
+                        },
+                        {
+                            "range": [127, 127],
+                            "name": "540"
+                        },
+                        {
+                            "range": [128, 190],
+                            "name": "Rotation 1"
+                        },
+                        {
+                            "range": [191, 192],
+                            "name": "Stop"
+                        },
+                        {
+                            "range": [193, 255],
+                            "name": "Rotation 2"
+                        }
+                    ]
+                },
+                "Gobo fine": {
+                    "type": "Gobo",
+                    "crossfade": true
+                },
+                "Prisma": {
+                    "type": "Prism",
+                    "crossfade": true
+                },
+                "Frost": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Blade up1": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Blade up2": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Blade dw1": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Blade dw2": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Blade rg1": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Blade rg2": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Blade lf1": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Blade lf2": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Framing rot": {
+                    "type": "Beam",
+                    "highlightValue": 128,
+                    "crossfade": true
+                },
+                "Focus": {
+                    "type": "Beam",
+                    "highlightValue": 0,
+                    "crossfade": true,
+                    "defaultValue": null
+                },
+                "Focus fine": {
+                    "type": "Beam",
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "defaultValue": null
+                },
+                "Zoom": {
+                    "type": "Beam",
+                    "highlightValue": 128,
+                    "crossfade": true
+                },
+                "Autofocus": {
+                    "type": "Beam",
+                    "highlightValue": 128,
+                    "crossfade": true
+                },
+                "Autofocus adj": {
+                    "type": "Beam",
+                    "highlightValue": 128,
+                    "crossfade": true
+                },
+                "Macro Effect": {
+                    "type": "Effect",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 7],
+                            "name": "off"
+                        },
+                        {
+                            "range": [8, 255],
+                            "name": "light frost"
+                        }
+                    ]
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Function": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 37],
+                            "name": "Unused"
+                        },
+                        {
+                            "range": [38, 50],
+                            "name": "Conventional"
+                        },
+                        {
+                            "range": [51, 62],
+                            "name": "Linear"
+                        },
+                        {
+                            "range": [63, 255],
+                            "name": "Unused"
+                        }
+                    ]
+                },
+                "Reset": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 25],
+                            "name": "Unused"
+                        },
+                        {
+                            "range": [26, 76],
+                            "name": "Effect reset"
+                        },
+                        {
+                            "range": [77, 127],
+                            "name": "P+T reset"
+                        },
+                        {
+                            "range": [128, 255],
+                            "name": "Compl reset"
+                        }
+                    ]
+                },
+                "Lamp": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 25],
+                            "name": "idle"
+                        },
+                        {
+                            "range": [26, 100],
+                            "name": "lamp off"
+                        },
+                        {
+                            "range": [101, 179],
+                            "name": "50% power"
+                        },
+                        {
+                            "range": [180, 255],
+                            "name": "lamp on"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Intensity",
+                    "Intensity fine"
+                ],
+                [
+                    "Focus",
+                    "Focus fine"
+                ],
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "37-channel Mode",
+                    "shortName": "37ch",
+                    "channels": [
+                        "Cyan",
+                        "Magenta",
+                        "Yellow",
+                        "CTO",
+                        "Color Wheel",
+                        "Macro Colours",
+                        "Strobe",
+                        "Intensity",
+                        "Intensity fine",
+                        "Iris",
+                        "Gobo1",
+                        "Gobo rotation",
+                        "Gobo fine",
+                        "Prisma",
+                        "Frost",
+                        "Blade up1",
+                        "Blade up2",
+                        "Blade dw1",
+                        "Blade dw2",
+                        "Blade rg1",
+                        "Blade rg2",
+                        "Blade lf1",
+                        "Blade lf2",
+                        "Framing rot",
+                        "Focus",
+                        "Focus fine",
+                        "Zoom",
+                        "Autofocus",
+                        "Autofocus adj",
+                        "Macro Effect",
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "Function",
+                        "Reset",
+                        "Lamp"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Clay Paky",
+            "name": "Alpha Spot HPE 16b",
+            "shortName": "AlphaSHPE16",
+            "comment": "16Bit (CMY on) cd",
+            "physical": {
+                "dimensions": [415, 415, 610],
+                "weight": 21.4,
+                "power": 740
+            },
+            "availableChannels": {
+                "Cyan": {
+                    "type": "SingleColor",
+                    "color": "Cyan",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Magenta": {
+                    "type": "SingleColor",
+                    "color": "Magenta",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Yellow": {
+                    "type": "SingleColor",
+                    "color": "Yellow",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "CTO": {
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Color": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 17],
+                            "name": "open"
+                        },
+                        {
+                            "range": [18, 26],
+                            "name": "red",
+                            "color": "#ff0000"
+                        },
+                        {
+                            "range": [27, 53],
+                            "name": "yellow",
+                            "color": "#ffff00"
+                        },
+                        {
+                            "range": [54, 71],
+                            "name": "violet",
+                            "color": "#7f00ff"
+                        },
+                        {
+                            "range": [72, 89],
+                            "name": "green",
+                            "color": "#00ff00"
+                        },
+                        {
+                            "range": [90, 107],
+                            "name": "orange",
+                            "color": "#ff7f00"
+                        },
+                        {
+                            "range": [108, 127],
+                            "name": "blue",
+                            "color": "#0000ff"
+                        },
+                        {
+                            "range": [128, 255],
+                            "name": "rot."
+                        }
+                    ]
+                },
+                "Strobe": {
+                    "type": "Strobe",
+                    "highlightValue": 255,
+                    "capabilities": [
+                        {
+                            "range": [0, 3],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [4, 103],
+                            "name": "strobe"
+                        },
+                        {
+                            "range": [104, 107],
+                            "name": "open"
+                        },
+                        {
+                            "range": [108, 207],
+                            "name": "pulse"
+                        },
+                        {
+                            "range": [208, 212],
+                            "name": "open"
+                        },
+                        {
+                            "range": [213, 251],
+                            "name": "random"
+                        },
+                        {
+                            "range": [252, 255],
+                            "name": "open"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Iris": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "open"
+                        },
+                        {
+                            "range": [1, 131],
+                            "name": "%"
+                        },
+                        {
+                            "range": [132, 251],
+                            "name": "pulse"
+                        },
+                        {
+                            "range": [252, 255],
+                            "name": "closed"
+                        }
+                    ]
+                },
+                "Gobo1": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 7],
+                            "name": "open"
+                        },
+                        {
+                            "range": [8, 15],
+                            "name": "slot1"
+                        },
+                        {
+                            "range": [16, 23],
+                            "name": "slot2"
+                        },
+                        {
+                            "range": [24, 31],
+                            "name": "slot3"
+                        },
+                        {
+                            "range": [32, 39],
+                            "name": "slot4"
+                        },
+                        {
+                            "range": [40, 47],
+                            "name": "slot5"
+                        },
+                        {
+                            "range": [48, 55],
+                            "name": "slot6"
+                        },
+                        {
+                            "range": [56, 63],
+                            "name": "slot7"
+                        },
+                        {
+                            "range": [64, 71],
+                            "name": "slot8"
+                        },
+                        {
+                            "range": [72, 113],
+                            "name": ">>"
+                        },
+                        {
+                            "range": [114, 117],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [118, 159],
+                            "name": "<<"
+                        },
+                        {
+                            "range": [160, 255],
+                            "name": "shake"
+                        }
+                    ]
+                },
+                "Gobo2": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 17],
+                            "name": "open"
+                        },
+                        {
+                            "range": [18, 35],
+                            "name": "slot1"
+                        },
+                        {
+                            "range": [36, 53],
+                            "name": "slot2"
+                        },
+                        {
+                            "range": [54, 71],
+                            "name": "slot3"
+                        },
+                        {
+                            "range": [72, 89],
+                            "name": "slot4"
+                        },
+                        {
+                            "range": [90, 107],
+                            "name": "slot5"
+                        },
+                        {
+                            "range": [108, 129],
+                            "name": "slot6"
+                        },
+                        {
+                            "range": [130, 255],
+                            "name": "shake"
+                        }
+                    ]
+                },
+                "Gobo2 rot.": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "ind."
+                        },
+                        {
+                            "range": [128, 190],
+                            "name": "<<"
+                        },
+                        {
+                            "range": [191, 192],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [193, 255],
+                            "name": ">>"
+                        }
+                    ],
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "Gobo2 rot. fine": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "ind."
+                        },
+                        {
+                            "range": [128, 190],
+                            "name": "<<"
+                        },
+                        {
+                            "range": [191, 192],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [193, 255],
+                            "name": ">>"
+                        }
+                    ],
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "Gobo3": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 17],
+                            "name": "open"
+                        },
+                        {
+                            "range": [18, 35],
+                            "name": "slot1"
+                        },
+                        {
+                            "range": [36, 53],
+                            "name": "slot2"
+                        },
+                        {
+                            "range": [54, 71],
+                            "name": "slot3"
+                        },
+                        {
+                            "range": [72, 89],
+                            "name": "slot4"
+                        },
+                        {
+                            "range": [90, 107],
+                            "name": "slot5"
+                        },
+                        {
+                            "range": [108, 129],
+                            "name": "slot6"
+                        },
+                        {
+                            "range": [130, 255],
+                            "name": "shake"
+                        }
+                    ]
+                },
+                "Gobo3 rot.": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "ind."
+                        },
+                        {
+                            "range": [128, 190],
+                            "name": "<<"
+                        },
+                        {
+                            "range": [191, 192],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [193, 255],
+                            "name": ">>"
+                        }
+                    ],
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "Gobo3 rot. fine": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "ind."
+                        },
+                        {
+                            "range": [128, 190],
+                            "name": "<<"
+                        },
+                        {
+                            "range": [191, 192],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [193, 255],
+                            "name": ">>"
+                        }
+                    ],
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "Animation": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Animation rot.": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 124],
+                            "name": "<<"
+                        },
+                        {
+                            "range": [125, 130],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [131, 255],
+                            "name": ">>"
+                        }
+                    ]
+                },
+                "Effect": {
+                    "type": "Effect",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 62],
+                            "name": "open"
+                        },
+                        {
+                            "range": [63, 125],
+                            "name": "face"
+                        },
+                        {
+                            "range": [126, 188],
+                            "name": "lens"
+                        },
+                        {
+                            "range": [189, 255],
+                            "name": "prisma"
+                        }
+                    ]
+                },
+                "Prisma rot.": {
+                    "type": "Prism",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "ind."
+                        },
+                        {
+                            "range": [128, 190],
+                            "name": "<<"
+                        },
+                        {
+                            "range": [191, 192],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [193, 255],
+                            "name": ">>"
+                        }
+                    ]
+                },
+                "Frost": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Focus": {
+                    "type": "Beam",
+                    "highlightValue": 128,
+                    "crossfade": true
+                },
+                "Zoom": {
+                    "type": "Beam",
+                    "highlightValue": 128,
+                    "crossfade": true
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Reset": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "idle"
+                        },
+                        {
+                            "range": [128, 255],
+                            "name": "reset"
+                        }
+                    ]
+                },
+                "Lamp": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 25],
+                            "name": "idle"
+                        },
+                        {
+                            "range": [26, 100],
+                            "name": "lamp off"
+                        },
+                        {
+                            "range": [101, 179],
+                            "name": "50% power"
+                        },
+                        {
+                            "range": [180, 255],
+                            "name": "lamp on"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Gobo2 rot.",
+                    "Gobo2 rot. fine"
+                ],
+                [
+                    "Gobo3 rot.",
+                    "Gobo3 rot. fine"
+                ],
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "28-channel Mode",
+                    "shortName": "28ch",
+                    "channels": [
+                        "Cyan",
+                        "Magenta",
+                        "Yellow",
+                        "CTO",
+                        "Color",
+                        "Strobe",
+                        "Intensity",
+                        "Iris",
+                        "Gobo1",
+                        "Gobo2",
+                        "Gobo2 rot.",
+                        "Gobo3",
+                        "Gobo3 rot.",
+                        "Animation",
+                        "Animation rot.",
+                        "Effect",
+                        "Prisma rot.",
+                        "Frost",
+                        "Focus",
+                        "Zoom",
+                        "Pan",
+                        "Tilt",
+                        "Reset",
+                        "Lamp",
+                        "Pan fine",
+                        "Tilt fine",
+                        "Gobo2 rot. fine",
+                        "Gobo3 rot. fine"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Clay Paky",
+            "name": "Alpha Spot HPE 700 STD Mode",
+            "shortName": "AlphaSpotHPE700",
+            "physical": {
+                "dimensions": [390, 415, 615],
+                "weight": 22.9,
+                "power": 1050
+            },
+            "availableChannels": {
+                "Cyan": {
+                    "type": "SingleColor",
+                    "color": "Cyan",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Magenta": {
+                    "type": "SingleColor",
+                    "color": "Magenta",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Yellow": {
+                    "type": "SingleColor",
+                    "color": "Yellow",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Uni field lens": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "Excluded"
+                        },
+                        {
+                            "range": [128, 255],
+                            "name": "Inserted"
+                        }
+                    ]
+                },
+                "Color Wheel": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "White",
+                            "color": "#ffffff",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [8, 8],
+                            "name": "White + Red",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [15, 15],
+                            "name": "Red",
+                            "color": "#ff0000",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [22, 22],
+                            "name": "Red + Green 1",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [30, 30],
+                            "name": "Green",
+                            "color": "#00ff00",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [37, 37],
+                            "name": "Green +CTO 2500",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [45, 45],
+                            "name": "CTO 2500",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [52, 52],
+                            "name": "CTO 2500 + 3200",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [60, 60],
+                            "name": "CTO 3200",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [67, 67],
+                            "name": "CTO 3200 + Gr",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [75, 75],
+                            "name": "Green",
+                            "color": "#00ff00",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [82, 82],
+                            "name": "Green + Aqua",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [90, 90],
+                            "name": "Aquamarine",
+                            "color": "#7fffd4",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [97, 97],
+                            "name": "Aqua + Orange",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [105, 105],
+                            "name": "Orange",
+                            "color": "#ff7f00",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [112, 112],
+                            "name": "Or + Blue",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [120, 120],
+                            "name": "Blue",
+                            "color": "#0000ff",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [127, 127],
+                            "name": "Blue + White",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [128, 255],
+                            "name": "Rotation sl-fst",
+                            "showInMenu": false
+                        }
+                    ]
+                },
+                "Strobe": {
+                    "type": "Strobe",
+                    "defaultValue": 105,
+                    "highlightValue": 255,
+                    "capabilities": [
+                        {
+                            "range": [0, 3],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [4, 103],
+                            "name": "strobe"
+                        },
+                        {
+                            "range": [104, 107],
+                            "name": "open"
+                        },
+                        {
+                            "range": [108, 207],
+                            "name": "pulse"
+                        },
+                        {
+                            "range": [208, 212],
+                            "name": "open"
+                        },
+                        {
+                            "range": [213, 225],
+                            "name": "random sl strob"
+                        },
+                        {
+                            "range": [226, 238],
+                            "name": "random med st"
+                        },
+                        {
+                            "range": [239, 251],
+                            "name": "random fst st"
+                        },
+                        {
+                            "range": [252, 255],
+                            "name": "open"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 0,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "defaultValue": null
+                },
+                "Intensity fine": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "defaultValue": null
+                },
+                "Iris": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "open"
+                        },
+                        {
+                            "range": [1, 131],
+                            "name": "%"
+                        },
+                        {
+                            "range": [132, 171],
+                            "name": "pulse"
+                        },
+                        {
+                            "range": [172, 211],
+                            "name": "pulse opening"
+                        },
+                        {
+                            "range": [212, 251],
+                            "name": "pulse closing"
+                        },
+                        {
+                            "range": [252, 255],
+                            "name": "Maximum"
+                        }
+                    ]
+                },
+                "Static Gobo cha": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 7],
+                            "name": "open"
+                        },
+                        {
+                            "range": [8, 15],
+                            "name": "Gobo 1"
+                        },
+                        {
+                            "range": [16, 23],
+                            "name": "Gobo 2"
+                        },
+                        {
+                            "range": [24, 31],
+                            "name": "Gobo 3"
+                        },
+                        {
+                            "range": [32, 39],
+                            "name": "Gobo 4"
+                        },
+                        {
+                            "range": [40, 47],
+                            "name": "Gobo 5"
+                        },
+                        {
+                            "range": [48, 55],
+                            "name": "Gobo 6"
+                        },
+                        {
+                            "range": [56, 63],
+                            "name": "Gobo 7"
+                        },
+                        {
+                            "range": [64, 71],
+                            "name": "Gobo 8"
+                        },
+                        {
+                            "range": [72, 113],
+                            "name": "Rotation 1"
+                        },
+                        {
+                            "range": [114, 117],
+                            "name": "Stop"
+                        },
+                        {
+                            "range": [118, 159],
+                            "name": "Rotation 2"
+                        },
+                        {
+                            "range": [160, 175],
+                            "name": "Gobo 2 shake"
+                        },
+                        {
+                            "range": [176, 191],
+                            "name": "Gobo 3 shake"
+                        },
+                        {
+                            "range": [192, 207],
+                            "name": "Gobo 4 shake"
+                        },
+                        {
+                            "range": [208, 223],
+                            "name": "Gobo 5 shake"
+                        },
+                        {
+                            "range": [224, 239],
+                            "name": "Gobo 6 shake"
+                        },
+                        {
+                            "range": [240, 255],
+                            "name": "Gobo 7 shake"
+                        }
+                    ]
+                },
+                "Rot Gobo change": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 16],
+                            "name": "open"
+                        },
+                        {
+                            "range": [17, 32],
+                            "name": "Gobo 1"
+                        },
+                        {
+                            "range": [33, 48],
+                            "name": "Gobo 2"
+                        },
+                        {
+                            "range": [49, 64],
+                            "name": "Gobo 3"
+                        },
+                        {
+                            "range": [65, 81],
+                            "name": "Gobo 4"
+                        },
+                        {
+                            "range": [82, 97],
+                            "name": "Gobo 5"
+                        },
+                        {
+                            "range": [98, 113],
+                            "name": "Gobo 6"
+                        },
+                        {
+                            "range": [114, 129],
+                            "name": "Gobo 7"
+                        },
+                        {
+                            "range": [130, 255],
+                            "name": "shake"
+                        }
+                    ]
+                },
+                "Gobo rotation": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "0"
+                        },
+                        {
+                            "range": [21, 21],
+                            "name": "90"
+                        },
+                        {
+                            "range": [42, 42],
+                            "name": "180"
+                        },
+                        {
+                            "range": [63, 63],
+                            "name": "270"
+                        },
+                        {
+                            "range": [84, 84],
+                            "name": "360"
+                        },
+                        {
+                            "range": [105, 105],
+                            "name": "450"
+                        },
+                        {
+                            "range": [127, 127],
+                            "name": "540"
+                        },
+                        {
+                            "range": [128, 190],
+                            "name": "Rotation 1"
+                        },
+                        {
+                            "range": [191, 192],
+                            "name": "Stop"
+                        },
+                        {
+                            "range": [193, 255],
+                            "name": "Rotation 2"
+                        }
+                    ]
+                },
+                "Gobo fine": {
+                    "type": "Gobo",
+                    "crossfade": true
+                },
+                "Prisma insert": {
+                    "type": "Prism",
+                    "crossfade": true
+                },
+                "Prisma rotation": {
+                    "type": "Prism",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "0"
+                        },
+                        {
+                            "range": [21, 21],
+                            "name": "90"
+                        },
+                        {
+                            "range": [42, 42],
+                            "name": "180"
+                        },
+                        {
+                            "range": [63, 63],
+                            "name": "270"
+                        },
+                        {
+                            "range": [84, 84],
+                            "name": "360"
+                        },
+                        {
+                            "range": [105, 105],
+                            "name": "450"
+                        },
+                        {
+                            "range": [127, 127],
+                            "name": "540"
+                        },
+                        {
+                            "range": [128, 190],
+                            "name": "Rotation 1"
+                        },
+                        {
+                            "range": [191, 192],
+                            "name": "Stop"
+                        },
+                        {
+                            "range": [193, 255],
+                            "name": "Rotation 2"
+                        }
+                    ]
+                },
+                "Frost": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Focus": {
+                    "type": "Beam",
+                    "highlightValue": 128,
+                    "crossfade": true
+                },
+                "Zoom": {
+                    "type": "Beam",
+                    "highlightValue": 128,
+                    "crossfade": true
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Function": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 12],
+                            "name": "Unused"
+                        },
+                        {
+                            "range": [13, 26],
+                            "name": "P+T Function"
+                        },
+                        {
+                            "range": [39, 51],
+                            "name": "Dimmer Curve"
+                        },
+                        {
+                            "range": [52, 255],
+                            "name": "Unused"
+                        }
+                    ]
+                },
+                "Reset": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 25],
+                            "name": "Unused"
+                        },
+                        {
+                            "range": [26, 76],
+                            "name": "Effect reset"
+                        },
+                        {
+                            "range": [77, 127],
+                            "name": "P+T reset"
+                        },
+                        {
+                            "range": [128, 255],
+                            "name": "Compl reset"
+                        }
+                    ]
+                },
+                "Lamp": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 25],
+                            "name": "idle"
+                        },
+                        {
+                            "range": [26, 100],
+                            "name": "lamp off"
+                        },
+                        {
+                            "range": [101, 179],
+                            "name": "50% power"
+                        },
+                        {
+                            "range": [180, 255],
+                            "name": "lamp on"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Intensity",
+                    "Intensity fine"
+                ],
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "25-channel Mode",
+                    "shortName": "25ch",
+                    "channels": [
+                        "Cyan",
+                        "Magenta",
+                        "Yellow",
+                        "Uni field lens",
+                        "Color Wheel",
+                        "Strobe",
+                        "Intensity",
+                        "Intensity fine",
+                        "Iris",
+                        "Static Gobo cha",
+                        "Rot Gobo change",
+                        "Gobo rotation",
+                        "Gobo fine",
+                        "Prisma insert",
+                        "Prisma rotation",
+                        "Frost",
+                        "Focus",
+                        "Zoom",
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "Function",
+                        "Reset",
+                        "Lamp"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Clay Paky",
+            "name": "Alpha Spot HPE Extn",
+            "shortName": "AlphaSHPEex",
+            "comment": "Extn (CMY on) cd",
+            "physical": {
+                "dimensions": [415, 415, 610],
+                "weight": 21.4,
+                "power": 740
+            },
+            "availableChannels": {
+                "Cyan": {
+                    "type": "SingleColor",
+                    "color": "Cyan",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Magenta": {
+                    "type": "SingleColor",
+                    "color": "Magenta",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Yellow": {
+                    "type": "SingleColor",
+                    "color": "Yellow",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "CTO": {
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Color": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 17],
+                            "name": "open"
+                        },
+                        {
+                            "range": [18, 26],
+                            "name": "red",
+                            "color": "#ff0000"
+                        },
+                        {
+                            "range": [27, 53],
+                            "name": "yellow",
+                            "color": "#ffff00"
+                        },
+                        {
+                            "range": [54, 71],
+                            "name": "violet",
+                            "color": "#7f00ff"
+                        },
+                        {
+                            "range": [72, 89],
+                            "name": "green",
+                            "color": "#00ff00"
+                        },
+                        {
+                            "range": [90, 107],
+                            "name": "orange",
+                            "color": "#ff7f00"
+                        },
+                        {
+                            "range": [108, 127],
+                            "name": "blue",
+                            "color": "#0000ff"
+                        },
+                        {
+                            "range": [128, 255],
+                            "name": "rot."
+                        }
+                    ]
+                },
+                "Strobe": {
+                    "type": "Strobe",
+                    "highlightValue": 255,
+                    "capabilities": [
+                        {
+                            "range": [0, 3],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [4, 103],
+                            "name": "strobe"
+                        },
+                        {
+                            "range": [104, 107],
+                            "name": "open"
+                        },
+                        {
+                            "range": [108, 207],
+                            "name": "pulse"
+                        },
+                        {
+                            "range": [208, 212],
+                            "name": "open"
+                        },
+                        {
+                            "range": [213, 251],
+                            "name": "random"
+                        },
+                        {
+                            "range": [252, 255],
+                            "name": "open"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Iris": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "open"
+                        },
+                        {
+                            "range": [1, 131],
+                            "name": "%"
+                        },
+                        {
+                            "range": [132, 251],
+                            "name": "pulse"
+                        },
+                        {
+                            "range": [252, 255],
+                            "name": "closed"
+                        }
+                    ]
+                },
+                "Gobo1": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 7],
+                            "name": "open"
+                        },
+                        {
+                            "range": [8, 15],
+                            "name": "slot1"
+                        },
+                        {
+                            "range": [16, 23],
+                            "name": "slot2"
+                        },
+                        {
+                            "range": [24, 31],
+                            "name": "slot3"
+                        },
+                        {
+                            "range": [32, 39],
+                            "name": "slot4"
+                        },
+                        {
+                            "range": [40, 47],
+                            "name": "slot5"
+                        },
+                        {
+                            "range": [48, 55],
+                            "name": "slot6"
+                        },
+                        {
+                            "range": [56, 63],
+                            "name": "slot7"
+                        },
+                        {
+                            "range": [64, 71],
+                            "name": "slot8"
+                        },
+                        {
+                            "range": [72, 113],
+                            "name": ">>"
+                        },
+                        {
+                            "range": [114, 117],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [118, 159],
+                            "name": "<<"
+                        },
+                        {
+                            "range": [160, 255],
+                            "name": "shake"
+                        }
+                    ]
+                },
+                "Gobo2": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 17],
+                            "name": "open"
+                        },
+                        {
+                            "range": [18, 35],
+                            "name": "slot1"
+                        },
+                        {
+                            "range": [36, 53],
+                            "name": "slot2"
+                        },
+                        {
+                            "range": [54, 71],
+                            "name": "slot3"
+                        },
+                        {
+                            "range": [72, 89],
+                            "name": "slot4"
+                        },
+                        {
+                            "range": [90, 107],
+                            "name": "slot5"
+                        },
+                        {
+                            "range": [108, 129],
+                            "name": "slot6"
+                        },
+                        {
+                            "range": [130, 255],
+                            "name": "shake"
+                        }
+                    ]
+                },
+                "Gobo2 rot.": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "ind."
+                        },
+                        {
+                            "range": [128, 190],
+                            "name": "<<"
+                        },
+                        {
+                            "range": [191, 192],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [193, 255],
+                            "name": ">>"
+                        }
+                    ],
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "Gobo2 rot. fine": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "ind."
+                        },
+                        {
+                            "range": [128, 190],
+                            "name": "<<"
+                        },
+                        {
+                            "range": [191, 192],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [193, 255],
+                            "name": ">>"
+                        }
+                    ],
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "Gobo3": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 17],
+                            "name": "open"
+                        },
+                        {
+                            "range": [18, 35],
+                            "name": "slot1"
+                        },
+                        {
+                            "range": [36, 53],
+                            "name": "slot2"
+                        },
+                        {
+                            "range": [54, 71],
+                            "name": "slot3"
+                        },
+                        {
+                            "range": [72, 89],
+                            "name": "slot4"
+                        },
+                        {
+                            "range": [90, 107],
+                            "name": "slot5"
+                        },
+                        {
+                            "range": [108, 129],
+                            "name": "slot6"
+                        },
+                        {
+                            "range": [130, 255],
+                            "name": "shake"
+                        }
+                    ]
+                },
+                "Gobo3 rot.": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "ind."
+                        },
+                        {
+                            "range": [128, 190],
+                            "name": "<<"
+                        },
+                        {
+                            "range": [191, 192],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [193, 255],
+                            "name": ">>"
+                        }
+                    ],
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "Gobo3 rot. fine": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "ind."
+                        },
+                        {
+                            "range": [128, 190],
+                            "name": "<<"
+                        },
+                        {
+                            "range": [191, 192],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [193, 255],
+                            "name": ">>"
+                        }
+                    ],
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "Animation": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Animation rot.": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 124],
+                            "name": "<<"
+                        },
+                        {
+                            "range": [125, 130],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [131, 255],
+                            "name": ">>"
+                        }
+                    ]
+                },
+                "Effect": {
+                    "type": "Effect",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 62],
+                            "name": "open"
+                        },
+                        {
+                            "range": [63, 125],
+                            "name": "face"
+                        },
+                        {
+                            "range": [126, 188],
+                            "name": "lens"
+                        },
+                        {
+                            "range": [189, 255],
+                            "name": "prisma"
+                        }
+                    ]
+                },
+                "Prisma rot.": {
+                    "type": "Prism",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "ind."
+                        },
+                        {
+                            "range": [128, 190],
+                            "name": "<<"
+                        },
+                        {
+                            "range": [191, 192],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [193, 255],
+                            "name": ">>"
+                        }
+                    ]
+                },
+                "Frost": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Focus": {
+                    "type": "Beam",
+                    "highlightValue": 128,
+                    "crossfade": true
+                },
+                "Zoom": {
+                    "type": "Beam",
+                    "highlightValue": 128,
+                    "crossfade": true
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Reset": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "idle"
+                        },
+                        {
+                            "range": [128, 255],
+                            "name": "reset"
+                        }
+                    ]
+                },
+                "Lamp": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 25],
+                            "name": "idle"
+                        },
+                        {
+                            "range": [26, 100],
+                            "name": "lamp off"
+                        },
+                        {
+                            "range": [101, 179],
+                            "name": "50% power"
+                        },
+                        {
+                            "range": [180, 255],
+                            "name": "lamp on"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Gobo2 rot.",
+                    "Gobo2 rot. fine"
+                ],
+                [
+                    "Gobo3 rot.",
+                    "Gobo3 rot. fine"
+                ],
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "28-channel Mode",
+                    "shortName": "28ch",
+                    "channels": [
+                        "Cyan",
+                        "Magenta",
+                        "Yellow",
+                        "CTO",
+                        "Color",
+                        "Strobe",
+                        "Intensity",
+                        "Iris",
+                        "Gobo1",
+                        "Gobo2",
+                        "Gobo2 rot.",
+                        "Gobo2 rot. fine",
+                        "Gobo3",
+                        "Gobo3 rot.",
+                        "Gobo3 rot. fine",
+                        "Animation",
+                        "Animation rot.",
+                        "Effect",
+                        "Prisma rot.",
+                        "Frost",
+                        "Focus",
+                        "Zoom",
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "Reset",
+                        "Lamp"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Clay Paky",
+            "name": "Alpha Spot HPE Stnd",
+            "shortName": "AlphaSHPEst",
+            "comment": "Stnd (CMY on) cd",
+            "physical": {
+                "dimensions": [415, 415, 610],
+                "weight": 21.4,
+                "power": 740
+            },
+            "availableChannels": {
+                "Cyan": {
+                    "type": "SingleColor",
+                    "color": "Cyan",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Magenta": {
+                    "type": "SingleColor",
+                    "color": "Magenta",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Yellow": {
+                    "type": "SingleColor",
+                    "color": "Yellow",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "CTO": {
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Color": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 17],
+                            "name": "open"
+                        },
+                        {
+                            "range": [18, 26],
+                            "name": "red",
+                            "color": "#ff0000"
+                        },
+                        {
+                            "range": [27, 53],
+                            "name": "yellow",
+                            "color": "#ffff00"
+                        },
+                        {
+                            "range": [54, 71],
+                            "name": "violet",
+                            "color": "#7f00ff"
+                        },
+                        {
+                            "range": [72, 89],
+                            "name": "green",
+                            "color": "#00ff00"
+                        },
+                        {
+                            "range": [90, 107],
+                            "name": "orange",
+                            "color": "#ff7f00"
+                        },
+                        {
+                            "range": [108, 127],
+                            "name": "blue",
+                            "color": "#0000ff"
+                        },
+                        {
+                            "range": [128, 255],
+                            "name": "rot."
+                        }
+                    ]
+                },
+                "Strobe": {
+                    "type": "Strobe",
+                    "highlightValue": 255,
+                    "capabilities": [
+                        {
+                            "range": [0, 3],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [4, 103],
+                            "name": "strobe"
+                        },
+                        {
+                            "range": [104, 107],
+                            "name": "open"
+                        },
+                        {
+                            "range": [108, 207],
+                            "name": "pulse"
+                        },
+                        {
+                            "range": [208, 212],
+                            "name": "open"
+                        },
+                        {
+                            "range": [213, 251],
+                            "name": "random"
+                        },
+                        {
+                            "range": [252, 255],
+                            "name": "open"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Iris": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "open"
+                        },
+                        {
+                            "range": [1, 131],
+                            "name": "%"
+                        },
+                        {
+                            "range": [132, 251],
+                            "name": "pulse"
+                        },
+                        {
+                            "range": [252, 255],
+                            "name": "closed"
+                        }
+                    ]
+                },
+                "Gobo1": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 7],
+                            "name": "open"
+                        },
+                        {
+                            "range": [8, 15],
+                            "name": "slot1"
+                        },
+                        {
+                            "range": [16, 23],
+                            "name": "slot2"
+                        },
+                        {
+                            "range": [24, 31],
+                            "name": "slot3"
+                        },
+                        {
+                            "range": [32, 39],
+                            "name": "slot4"
+                        },
+                        {
+                            "range": [40, 47],
+                            "name": "slot5"
+                        },
+                        {
+                            "range": [48, 55],
+                            "name": "slot6"
+                        },
+                        {
+                            "range": [56, 63],
+                            "name": "slot7"
+                        },
+                        {
+                            "range": [64, 71],
+                            "name": "slot8"
+                        },
+                        {
+                            "range": [72, 113],
+                            "name": ">>"
+                        },
+                        {
+                            "range": [114, 117],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [118, 159],
+                            "name": "<<"
+                        },
+                        {
+                            "range": [160, 255],
+                            "name": "shake"
+                        }
+                    ]
+                },
+                "Gobo2": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 17],
+                            "name": "open"
+                        },
+                        {
+                            "range": [18, 35],
+                            "name": "slot1"
+                        },
+                        {
+                            "range": [36, 53],
+                            "name": "slot2"
+                        },
+                        {
+                            "range": [54, 71],
+                            "name": "slot3"
+                        },
+                        {
+                            "range": [72, 89],
+                            "name": "slot4"
+                        },
+                        {
+                            "range": [90, 107],
+                            "name": "slot5"
+                        },
+                        {
+                            "range": [108, 129],
+                            "name": "slot6"
+                        },
+                        {
+                            "range": [130, 255],
+                            "name": "shake"
+                        }
+                    ]
+                },
+                "Gobo2 rot.": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "ind."
+                        },
+                        {
+                            "range": [128, 190],
+                            "name": "<<"
+                        },
+                        {
+                            "range": [191, 192],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [193, 255],
+                            "name": ">>"
+                        }
+                    ]
+                },
+                "Gobo3": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 17],
+                            "name": "open"
+                        },
+                        {
+                            "range": [18, 35],
+                            "name": "slot1"
+                        },
+                        {
+                            "range": [36, 53],
+                            "name": "slot2"
+                        },
+                        {
+                            "range": [54, 71],
+                            "name": "slot3"
+                        },
+                        {
+                            "range": [72, 89],
+                            "name": "slot4"
+                        },
+                        {
+                            "range": [90, 107],
+                            "name": "slot5"
+                        },
+                        {
+                            "range": [108, 129],
+                            "name": "slot6"
+                        },
+                        {
+                            "range": [130, 255],
+                            "name": "shake"
+                        }
+                    ]
+                },
+                "Gobo3 rot.": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "ind."
+                        },
+                        {
+                            "range": [128, 190],
+                            "name": "<<"
+                        },
+                        {
+                            "range": [191, 192],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [193, 255],
+                            "name": ">>"
+                        }
+                    ]
+                },
+                "Animation": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Animation rot.": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 124],
+                            "name": "<<"
+                        },
+                        {
+                            "range": [125, 130],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [131, 255],
+                            "name": ">>"
+                        }
+                    ]
+                },
+                "Effect": {
+                    "type": "Effect",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 62],
+                            "name": "open"
+                        },
+                        {
+                            "range": [63, 125],
+                            "name": "face"
+                        },
+                        {
+                            "range": [126, 188],
+                            "name": "lens"
+                        },
+                        {
+                            "range": [189, 255],
+                            "name": "prisma"
+                        }
+                    ]
+                },
+                "Prisma rot.": {
+                    "type": "Prism",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "ind."
+                        },
+                        {
+                            "range": [128, 190],
+                            "name": "<<"
+                        },
+                        {
+                            "range": [191, 192],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [193, 255],
+                            "name": ">>"
+                        }
+                    ]
+                },
+                "Frost": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Focus": {
+                    "type": "Beam",
+                    "highlightValue": 128,
+                    "crossfade": true
+                },
+                "Zoom": {
+                    "type": "Beam",
+                    "highlightValue": 128,
+                    "crossfade": true
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true
+                },
+                "Reset": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "idle"
+                        },
+                        {
+                            "range": [128, 255],
+                            "name": "reset"
+                        }
+                    ]
+                },
+                "Lamp": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 25],
+                            "name": "idle"
+                        },
+                        {
+                            "range": [26, 100],
+                            "name": "lamp off"
+                        },
+                        {
+                            "range": [101, 179],
+                            "name": "50% power"
+                        },
+                        {
+                            "range": [180, 255],
+                            "name": "lamp on"
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "24-channel Mode",
+                    "shortName": "24ch",
+                    "channels": [
+                        "Cyan",
+                        "Magenta",
+                        "Yellow",
+                        "CTO",
+                        "Color",
+                        "Strobe",
+                        "Intensity",
+                        "Iris",
+                        "Gobo1",
+                        "Gobo2",
+                        "Gobo2 rot.",
+                        "Gobo3",
+                        "Gobo3 rot.",
+                        "Animation",
+                        "Animation rot.",
+                        "Effect",
+                        "Prisma rot.",
+                        "Frost",
+                        "Focus",
+                        "Zoom",
+                        "Pan",
+                        "Tilt",
+                        "Reset",
+                        "Lamp"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Clay Paky",
+            "name": "Alpha Wash 1200 16b",
+            "shortName": "AlphaWash1216b",
+            "comment": "16bit (CMY on) cd",
+            "physical": {
+                "dimensions": [516, 516, 740],
+                "weight": 35.8,
+                "power": 1550
+            },
+            "availableChannels": {
+                "Cyan": {
+                    "type": "SingleColor",
+                    "color": "Cyan",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Magenta": {
+                    "type": "SingleColor",
+                    "color": "Magenta",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Yellow": {
+                    "type": "SingleColor",
+                    "color": "Yellow",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "CTO": {
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Color": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 24],
+                            "name": "open"
+                        },
+                        {
+                            "range": [25, 49],
+                            "name": "CTB"
+                        },
+                        {
+                            "range": [50, 74],
+                            "name": "red",
+                            "color": "#ff0000"
+                        },
+                        {
+                            "range": [75, 99],
+                            "name": "congo"
+                        },
+                        {
+                            "range": [100, 127],
+                            "name": "UV"
+                        },
+                        {
+                            "range": [128, 255],
+                            "name": "rot."
+                        }
+                    ]
+                },
+                "Strobe": {
+                    "type": "Strobe",
+                    "highlightValue": 255,
+                    "capabilities": [
+                        {
+                            "range": [0, 3],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [4, 103],
+                            "name": "strobe"
+                        },
+                        {
+                            "range": [104, 107],
+                            "name": "open"
+                        },
+                        {
+                            "range": [108, 207],
+                            "name": "pulse"
+                        },
+                        {
+                            "range": [208, 212],
+                            "name": "open"
+                        },
+                        {
+                            "range": [213, 251],
+                            "name": "random"
+                        },
+                        {
+                            "range": [252, 255],
+                            "name": "open"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Frost": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Ovalizer": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Zoom": {
+                    "type": "Beam",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Reset": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "idle"
+                        },
+                        {
+                            "range": [128, 255],
+                            "name": "reset"
+                        }
+                    ]
+                },
+                "Lamp": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 25],
+                            "name": "idle"
+                        },
+                        {
+                            "range": [26, 100],
+                            "name": "lamp off"
+                        },
+                        {
+                            "range": [101, 179],
+                            "name": "50% power"
+                        },
+                        {
+                            "range": [180, 255],
+                            "name": "lamp on"
+                        }
+                    ]
+                },
+                "P/T speed": {
+                    "type": "Speed",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Col. speed": {
+                    "type": "Speed",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Beam speed": {
+                    "type": "Speed",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Beam sh speed": {
+                    "type": "Speed",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "20-channel Mode",
+                    "shortName": "20ch",
+                    "channels": [
+                        "Cyan",
+                        "Magenta",
+                        "Yellow",
+                        "CTO",
+                        "Color",
+                        "Strobe",
+                        "Intensity",
+                        "Frost",
+                        "Ovalizer",
+                        "Zoom",
+                        "Pan",
+                        "Tilt",
+                        "Reset",
+                        "Lamp",
+                        "Pan fine",
+                        "Tilt fine",
+                        "P/T speed",
+                        "Col. speed",
+                        "Beam speed",
+                        "Beam sh speed"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Clay Paky",
+            "name": "Alpha Wash 1200 extn",
+            "shortName": "AlphaWash12extn",
+            "comment": "extn (CMY on) cd",
+            "physical": {
+                "dimensions": [516, 516, 740],
+                "weight": 35.8,
+                "power": 1550
+            },
+            "availableChannels": {
+                "Cyan": {
+                    "type": "SingleColor",
+                    "color": "Cyan",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Magenta": {
+                    "type": "SingleColor",
+                    "color": "Magenta",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Yellow": {
+                    "type": "SingleColor",
+                    "color": "Yellow",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "CTO": {
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Color": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 24],
+                            "name": "open"
+                        },
+                        {
+                            "range": [25, 49],
+                            "name": "CTB"
+                        },
+                        {
+                            "range": [50, 74],
+                            "name": "red",
+                            "color": "#ff0000"
+                        },
+                        {
+                            "range": [75, 99],
+                            "name": "congo"
+                        },
+                        {
+                            "range": [100, 127],
+                            "name": "UV"
+                        },
+                        {
+                            "range": [128, 255],
+                            "name": "rot."
+                        }
+                    ]
+                },
+                "Strobe": {
+                    "type": "Strobe",
+                    "highlightValue": 255,
+                    "capabilities": [
+                        {
+                            "range": [0, 3],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [4, 103],
+                            "name": "strobe"
+                        },
+                        {
+                            "range": [104, 107],
+                            "name": "open"
+                        },
+                        {
+                            "range": [108, 207],
+                            "name": "pulse"
+                        },
+                        {
+                            "range": [208, 212],
+                            "name": "open"
+                        },
+                        {
+                            "range": [213, 251],
+                            "name": "random"
+                        },
+                        {
+                            "range": [252, 255],
+                            "name": "open"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Frost": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Ovalizer": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Zoom": {
+                    "type": "Beam",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Reset": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "idle"
+                        },
+                        {
+                            "range": [128, 255],
+                            "name": "reset"
+                        }
+                    ]
+                },
+                "Lamp": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 25],
+                            "name": "idle"
+                        },
+                        {
+                            "range": [26, 100],
+                            "name": "lamp off"
+                        },
+                        {
+                            "range": [101, 179],
+                            "name": "50% power"
+                        },
+                        {
+                            "range": [180, 255],
+                            "name": "lamp on"
+                        }
+                    ]
+                },
+                "P/T speed": {
+                    "type": "Speed",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Col. speed": {
+                    "type": "Speed",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Beam speed": {
+                    "type": "Speed",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Beam sh speed": {
+                    "type": "Speed",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "20-channel Mode",
+                    "shortName": "20ch",
+                    "channels": [
+                        "Cyan",
+                        "Magenta",
+                        "Yellow",
+                        "CTO",
+                        "Color",
+                        "Strobe",
+                        "Intensity",
+                        "Frost",
+                        "Ovalizer",
+                        "Zoom",
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "Reset",
+                        "Lamp",
+                        "P/T speed",
+                        "Col. speed",
+                        "Beam speed",
+                        "Beam sh speed"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Clay Paky",
+            "name": "Alpha Wash 1200 Stnd",
+            "shortName": "AlphaWash12stnd",
+            "comment": "Stnd (CMY on) cd",
+            "physical": {
+                "dimensions": [516, 516, 740],
+                "weight": 35.8,
+                "power": 1550
+            },
+            "availableChannels": {
+                "Cyan": {
+                    "type": "SingleColor",
+                    "color": "Cyan",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Magenta": {
+                    "type": "SingleColor",
+                    "color": "Magenta",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Yellow": {
+                    "type": "SingleColor",
+                    "color": "Yellow",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "CTO": {
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Color": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 24],
+                            "name": "open"
+                        },
+                        {
+                            "range": [25, 49],
+                            "name": "CTB"
+                        },
+                        {
+                            "range": [50, 74],
+                            "name": "red",
+                            "color": "#ff0000"
+                        },
+                        {
+                            "range": [75, 99],
+                            "name": "congo"
+                        },
+                        {
+                            "range": [100, 127],
+                            "name": "UV"
+                        },
+                        {
+                            "range": [128, 255],
+                            "name": "rot."
+                        }
+                    ]
+                },
+                "Strobe": {
+                    "type": "Strobe",
+                    "highlightValue": 255,
+                    "capabilities": [
+                        {
+                            "range": [0, 3],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [4, 103],
+                            "name": "strobe"
+                        },
+                        {
+                            "range": [104, 107],
+                            "name": "open"
+                        },
+                        {
+                            "range": [108, 207],
+                            "name": "pulse"
+                        },
+                        {
+                            "range": [208, 212],
+                            "name": "open"
+                        },
+                        {
+                            "range": [213, 251],
+                            "name": "random"
+                        },
+                        {
+                            "range": [252, 255],
+                            "name": "open"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Frost": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Ovalizer": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Zoom": {
+                    "type": "Beam",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true
+                },
+                "Reset": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "idle"
+                        },
+                        {
+                            "range": [128, 255],
+                            "name": "reset"
+                        }
+                    ]
+                },
+                "Lamp": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 25],
+                            "name": "idle"
+                        },
+                        {
+                            "range": [26, 100],
+                            "name": "lamp off"
+                        },
+                        {
+                            "range": [101, 179],
+                            "name": "50% power"
+                        },
+                        {
+                            "range": [180, 255],
+                            "name": "lamp on"
+                        }
+                    ]
+                },
+                "P/T speed": {
+                    "type": "Speed",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Col. speed": {
+                    "type": "Speed",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Beam speed": {
+                    "type": "Speed",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Beam sh speed": {
+                    "type": "Speed",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true
+                }
+            },
+            "modes": [
+                {
+                    "name": "18-channel Mode",
+                    "shortName": "18ch",
+                    "channels": [
+                        "Cyan",
+                        "Magenta",
+                        "Yellow",
+                        "CTO",
+                        "Color",
+                        "Strobe",
+                        "Intensity",
+                        "Frost",
+                        "Ovalizer",
+                        "Zoom",
+                        "Pan",
+                        "Tilt",
+                        "Reset",
+                        "Lamp",
+                        "P/T speed",
+                        "Col. speed",
+                        "Beam speed",
+                        "Beam sh speed"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Clay Paky",
+            "name": "Alpha Wash Easy 1200 16b",
+            "shortName": "AlphaWashEasy1216b",
+            "comment": "16Bit (CMY on) cd",
+            "physical": {
+                "dimensions": [516, 516, 740],
+                "weight": 45,
+                "power": 1550
+            },
+            "availableChannels": {
+                "Cyan": {
+                    "type": "SingleColor",
+                    "color": "Cyan",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Magenta": {
+                    "type": "SingleColor",
+                    "color": "Magenta",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Yellow": {
+                    "type": "SingleColor",
+                    "color": "Yellow",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "CTO": {
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Strobe": {
+                    "type": "Strobe",
+                    "highlightValue": 255,
+                    "capabilities": [
+                        {
+                            "range": [0, 3],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [4, 103],
+                            "name": "strobe"
+                        },
+                        {
+                            "range": [104, 107],
+                            "name": "open"
+                        },
+                        {
+                            "range": [108, 207],
+                            "name": "pulse"
+                        },
+                        {
+                            "range": [208, 212],
+                            "name": "open"
+                        },
+                        {
+                            "range": [213, 251],
+                            "name": "random"
+                        },
+                        {
+                            "range": [252, 255],
+                            "name": "open"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Frost": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Ovalizer": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Reset": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "idle"
+                        },
+                        {
+                            "range": [128, 255],
+                            "name": "reset"
+                        }
+                    ]
+                },
+                "Lamp": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 25],
+                            "name": "idle"
+                        },
+                        {
+                            "range": [26, 100],
+                            "name": "lamp off"
+                        },
+                        {
+                            "range": [101, 179],
+                            "name": "50% power"
+                        },
+                        {
+                            "range": [180, 255],
+                            "name": "lamp on"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "14-channel Mode",
+                    "shortName": "14ch",
+                    "channels": [
+                        "Cyan",
+                        "Magenta",
+                        "Yellow",
+                        "CTO",
+                        "Strobe",
+                        "Intensity",
+                        "Frost",
+                        "Ovalizer",
+                        "Pan",
+                        "Tilt",
+                        "Reset",
+                        "Lamp",
+                        "Pan fine",
+                        "Tilt fine"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Clay Paky",
+            "name": "Alpha Wash Easy 1200 extn",
+            "shortName": "AlphaWashEasy12extn",
+            "comment": "extn (CMY on) cd",
+            "physical": {
+                "dimensions": [516, 516, 740],
+                "weight": 45,
+                "power": 1550
+            },
+            "availableChannels": {
+                "Cyan": {
+                    "type": "SingleColor",
+                    "color": "Cyan",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Magenta": {
+                    "type": "SingleColor",
+                    "color": "Magenta",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Yellow": {
+                    "type": "SingleColor",
+                    "color": "Yellow",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "CTO": {
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Strobe": {
+                    "type": "Strobe",
+                    "highlightValue": 255,
+                    "capabilities": [
+                        {
+                            "range": [0, 3],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [4, 103],
+                            "name": "strobe"
+                        },
+                        {
+                            "range": [104, 107],
+                            "name": "open"
+                        },
+                        {
+                            "range": [108, 207],
+                            "name": "pulse"
+                        },
+                        {
+                            "range": [208, 212],
+                            "name": "open"
+                        },
+                        {
+                            "range": [213, 251],
+                            "name": "random"
+                        },
+                        {
+                            "range": [252, 255],
+                            "name": "open"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Frost": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Ovalizer": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Reset": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "idle"
+                        },
+                        {
+                            "range": [128, 255],
+                            "name": "reset"
+                        }
+                    ]
+                },
+                "Lamp": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 25],
+                            "name": "idle"
+                        },
+                        {
+                            "range": [26, 100],
+                            "name": "lamp off"
+                        },
+                        {
+                            "range": [101, 179],
+                            "name": "50% power"
+                        },
+                        {
+                            "range": [180, 255],
+                            "name": "lamp on"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "14-channel Mode",
+                    "shortName": "14ch",
+                    "channels": [
+                        "Cyan",
+                        "Magenta",
+                        "Yellow",
+                        "CTO",
+                        "Strobe",
+                        "Intensity",
+                        "Frost",
+                        "Ovalizer",
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "Reset",
+                        "Lamp"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Clay Paky",
+            "name": "Alpha Wash Easy 1200 Stnd",
+            "shortName": "AlphaWashEasy12stnd",
+            "comment": "Stnd (CMY on) cd",
+            "physical": {
+                "dimensions": [516, 516, 740],
+                "weight": 45,
+                "power": 1550
+            },
+            "availableChannels": {
+                "Cyan": {
+                    "type": "SingleColor",
+                    "color": "Cyan",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Magenta": {
+                    "type": "SingleColor",
+                    "color": "Magenta",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Yellow": {
+                    "type": "SingleColor",
+                    "color": "Yellow",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "CTO": {
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Strobe": {
+                    "type": "Strobe",
+                    "highlightValue": 255,
+                    "capabilities": [
+                        {
+                            "range": [0, 3],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [4, 103],
+                            "name": "strobe"
+                        },
+                        {
+                            "range": [104, 107],
+                            "name": "open"
+                        },
+                        {
+                            "range": [108, 207],
+                            "name": "pulse"
+                        },
+                        {
+                            "range": [208, 212],
+                            "name": "open"
+                        },
+                        {
+                            "range": [213, 251],
+                            "name": "random"
+                        },
+                        {
+                            "range": [252, 255],
+                            "name": "open"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Frost": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Ovalizer": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true
+                },
+                "Reset": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "idle"
+                        },
+                        {
+                            "range": [128, 255],
+                            "name": "reset"
+                        }
+                    ]
+                },
+                "Lamp": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 25],
+                            "name": "idle"
+                        },
+                        {
+                            "range": [26, 100],
+                            "name": "lamp off"
+                        },
+                        {
+                            "range": [101, 179],
+                            "name": "50% power"
+                        },
+                        {
+                            "range": [180, 255],
+                            "name": "lamp on"
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "12-channel Mode",
+                    "shortName": "12ch",
+                    "channels": [
+                        "Cyan",
+                        "Magenta",
+                        "Yellow",
+                        "CTO",
+                        "Strobe",
+                        "Intensity",
+                        "Frost",
+                        "Ovalizer",
+                        "Pan",
+                        "Tilt",
+                        "Reset",
+                        "Lamp"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Clay Paky",
+            "name": "Astroscan",
+            "shortName": "Astro",
+            "comment": "9-Kanal => DIP Schalter 4 off",
+            "physical": {
+                "dimensions": [330, 225, 1165],
+                "weight": 39.1,
+                "power": 1500
+            },
+            "availableChannels": {
+                "Iris": {
+                    "type": "Beam",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Color_Disc": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [64, 64],
+                            "name": "yellow",
+                            "color": "#ffff00"
+                        },
+                        {
+                            "range": [96, 96],
+                            "name": "violet",
+                            "color": "#7f00ff"
+                        },
+                        {
+                            "range": [128, 128],
+                            "name": "green",
+                            "color": "#00ff00"
+                        },
+                        {
+                            "range": [160, 160],
+                            "name": "orange",
+                            "color": "#ff7f00"
+                        },
+                        {
+                            "range": [192, 192],
+                            "name": "blue",
+                            "color": "#0000ff"
+                        },
+                        {
+                            "range": [224, 224],
+                            "name": "pink",
+                            "color": "#ffc0cb"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "white",
+                            "color": "#ffffff"
+                        },
+                        {
+                            "range": [32, 32],
+                            "name": "red",
+                            "color": "#ff0000"
+                        },
+                        {
+                            "range": [0, 0],
+                            "name": "white",
+                            "color": "#ffffff"
+                        }
+                    ]
+                },
+                "Control": {
+                    "type": "Beam",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "Lamp_off"
+                        },
+                        {
+                            "range": [128, 255],
+                            "name": "Lamp_on"
+                        }
+                    ]
+                },
+                "Shutter": {
+                    "type": "Shutter",
+                    "highlightValue": 129,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [128, 139],
+                            "name": "open"
+                        },
+                        {
+                            "range": [140, 243],
+                            "name": "strobe"
+                        },
+                        {
+                            "range": [244, 255],
+                            "name": "open"
+                        }
+                    ]
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true
+                },
+                "Gobo": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 51],
+                            "name": "white",
+                            "color": "#ffffff"
+                        },
+                        {
+                            "range": [52, 102],
+                            "name": "Gobo1"
+                        },
+                        {
+                            "range": [103, 155],
+                            "name": "Gobo2"
+                        },
+                        {
+                            "range": [156, 207],
+                            "name": "Gobo3"
+                        },
+                        {
+                            "range": [208, 255],
+                            "name": "Gobo4"
+                        }
+                    ]
+                },
+                "Gobo_Rot": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "Position"
+                        },
+                        {
+                            "range": [128, 190],
+                            "name": "Rotation"
+                        },
+                        {
+                            "range": [191, 192],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [193, 255],
+                            "name": "Rotation"
+                        }
+                    ]
+                },
+                "Mirror_Rot": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "Position"
+                        },
+                        {
+                            "range": [128, 190],
+                            "name": "Rotation"
+                        },
+                        {
+                            "range": [191, 192],
+                            "name": "Stop"
+                        },
+                        {
+                            "range": [193, 255],
+                            "name": "Rotation"
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "9-channel Mode",
+                    "shortName": "9ch",
+                    "channels": [
+                        "Iris",
+                        "Color_Disc",
+                        "Control",
+                        "Shutter",
+                        "Pan",
+                        "Tilt",
+                        "Gobo",
+                        "Gobo_Rot",
+                        "Mirror_Rot"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Clay Paky",
+            "name": "Color 150 CMY",
+            "shortName": "Color150C",
+            "comment": "DIP 11=ON",
+            "physical": {
+                "dimensions": [350, 250, 550],
+                "weight": 17,
+                "power": 250
+            },
+            "availableChannels": {
+                "Cyan": {
+                    "type": "SingleColor",
+                    "color": "Cyan",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Magenta": {
+                    "type": "SingleColor",
+                    "color": "Magenta",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Yellow": {
+                    "type": "SingleColor",
+                    "color": "Yellow",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "4-channel Mode",
+                    "shortName": "4ch",
+                    "channels": [
+                        "Cyan",
+                        "Magenta",
+                        "Yellow",
+                        "Intensity"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Clay Paky",
+            "name": "Color 150 RGB",
+            "shortName": "Color150R",
+            "comment": "DIP 11=OFF",
+            "physical": {
+                "dimensions": [350, 250, 550],
+                "weight": 17,
+                "power": 250
+            },
+            "availableChannels": {
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "4-channel Mode",
+                    "shortName": "4ch",
+                    "channels": [
+                        "Red",
+                        "Green",
+                        "Blue",
+                        "Intensity"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Clay Paky",
+            "name": "Color 250 CMY",
+            "shortName": "Color250C",
+            "comment": "DIP 11=ON",
+            "physical": {
+                "dimensions": [350, 250, 550],
+                "weight": 17,
+                "power": 400
+            },
+            "availableChannels": {
+                "Cyan": {
+                    "type": "SingleColor",
+                    "color": "Cyan",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Magenta": {
+                    "type": "SingleColor",
+                    "color": "Magenta",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Yellow": {
+                    "type": "SingleColor",
+                    "color": "Yellow",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "4-channel Mode",
+                    "shortName": "4ch",
+                    "channels": [
+                        "Cyan",
+                        "Magenta",
+                        "Yellow",
+                        "Intensity"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Clay Paky",
+            "name": "Color 250 RGB",
+            "shortName": "Color250R",
+            "comment": "DIP 11=OFF",
+            "physical": {
+                "dimensions": [350, 250, 550],
+                "weight": 17,
+                "power": 400
+            },
+            "availableChannels": {
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "4-channel Mode",
+                    "shortName": "4ch",
+                    "channels": [
+                        "Red",
+                        "Green",
+                        "Blue",
+                        "Intensity"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Clay Paky",
+            "name": "Color 400 CMY",
+            "shortName": "Color400C",
+            "comment": "DIP 11=ON",
+            "physical": {
+                "dimensions": [350, 250, 550],
+                "weight": 22,
+                "power": 700
+            },
+            "availableChannels": {
+                "Cyan": {
+                    "type": "SingleColor",
+                    "color": "Cyan",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Magenta": {
+                    "type": "SingleColor",
+                    "color": "Magenta",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Yellow": {
+                    "type": "SingleColor",
+                    "color": "Yellow",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "4-channel Mode",
+                    "shortName": "4ch",
+                    "channels": [
+                        "Cyan",
+                        "Magenta",
+                        "Yellow",
+                        "Intensity"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Clay Paky",
+            "name": "Color 400 RGB",
+            "shortName": "Color400R",
+            "comment": "DIP 11=OFF",
+            "physical": {
+                "dimensions": [350, 250, 550],
+                "weight": 22,
+                "power": 700
+            },
+            "availableChannels": {
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "4-channel Mode",
+                    "shortName": "4ch",
+                    "channels": [
+                        "Red",
+                        "Green",
+                        "Blue",
+                        "Intensity"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Clay Paky",
+            "name": "Color 575 CMY",
+            "shortName": "Color575C",
+            "comment": "DIP 11=ON",
+            "physical": {
+                "dimensions": [520, 620, 400],
+                "weight": 33,
+                "power": 1650
+            },
+            "availableChannels": {
+                "Cyan": {
+                    "type": "SingleColor",
+                    "color": "Cyan",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Magenta": {
+                    "type": "SingleColor",
+                    "color": "Magenta",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Yellow": {
+                    "type": "SingleColor",
+                    "color": "Yellow",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "4-channel Mode",
+                    "shortName": "4ch",
+                    "channels": [
+                        "Cyan",
+                        "Magenta",
+                        "Yellow",
+                        "Intensity"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Clay Paky",
+            "name": "Color 575 RGB",
+            "shortName": "Color575R",
+            "comment": "DIP 11=OFF",
+            "physical": {
+                "dimensions": [520, 620, 400],
+                "weight": 33,
+                "power": 1650
+            },
+            "availableChannels": {
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "4-channel Mode",
+                    "shortName": "4ch",
+                    "channels": [
+                        "Red",
+                        "Green",
+                        "Blue",
+                        "Intensity"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Clay Paky",
+            "name": "Color MH CMY",
+            "shortName": "ColorMHC",
+            "comment": "DIP 8=ON",
+            "physical": {
+                "dimensions": [430, 430, 550],
+                "weight": 27.4,
+                "power": 750
+            },
+            "availableChannels": {
+                "Cyan": {
+                    "type": "SingleColor",
+                    "color": "Cyan",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Magenta": {
+                    "type": "SingleColor",
+                    "color": "Magenta",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Yellow": {
+                    "type": "SingleColor",
+                    "color": "Yellow",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "8-channel Mode",
+                    "shortName": "8ch",
+                    "channels": [
+                        "Cyan",
+                        "Magenta",
+                        "Yellow",
+                        "Intensity",
+                        "Pan",
+                        "Tilt",
+                        "Pan fine",
+                        "Tilt fine"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Clay Paky",
+            "name": "Color MH RGB",
+            "shortName": "ColorMHR",
+            "comment": "DIP 8=OFF",
+            "physical": {
+                "dimensions": [430, 430, 550],
+                "weight": 27.4,
+                "power": 750
+            },
+            "availableChannels": {
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 126,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 11,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 126,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 11,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "8-channel Mode",
+                    "shortName": "8ch",
+                    "channels": [
+                        "Red",
+                        "Green",
+                        "Blue",
+                        "Intensity",
+                        "Pan",
+                        "Tilt",
+                        "Pan fine",
+                        "Tilt fine"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Clay Paky",
+            "name": "Golden Scan HPE",
+            "shortName": "GScanHPE",
+            "comment": "http://www.claypaky.it/media/documents/MiniScan300-150_Manual_EN.pdf",
+            "physical": {
+                "dimensions": [330, 235, 1230],
+                "weight": 37,
+                "power": 3000
+            },
+            "availableChannels": {
+                "Iris": {
+                    "type": "Beam",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "Iris",
+                            "color": "#5a4fcf"
+                        }
+                    ]
+                },
+                "Color": {
+                    "type": "MultiColor",
+                    "capabilities": [
+                        {
+                            "range": [0, 31],
+                            "name": "White",
+                            "color": "#ffffff"
+                        },
+                        {
+                            "range": [32, 63],
+                            "name": "Red",
+                            "color": "#ff0000"
+                        },
+                        {
+                            "range": [64, 95],
+                            "name": "Yellow",
+                            "color": "#ffff00"
+                        },
+                        {
+                            "range": [96, 127],
+                            "name": "Violet",
+                            "color": "#7f00ff"
+                        },
+                        {
+                            "range": [128, 159],
+                            "name": "Green",
+                            "color": "#00ff00"
+                        },
+                        {
+                            "range": [160, 191],
+                            "name": "Orange",
+                            "color": "#ff7f00"
+                        },
+                        {
+                            "range": [192, 223],
+                            "name": "Blue",
+                            "color": "#0000ff"
+                        },
+                        {
+                            "range": [224, 254],
+                            "name": "Pink",
+                            "color": "#ffc0cb"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "White",
+                            "color": "#ffffff"
+                        }
+                    ]
+                },
+                "Color FX": {
+                    "type": "MultiColor",
+                    "capabilities": [
+                        {
+                            "range": [0, 17],
+                            "name": "White",
+                            "color": "#ffffff",
+                            "center": true
+                        },
+                        {
+                            "range": [18, 35],
+                            "name": "White+Yellow"
+                        },
+                        {
+                            "range": [36, 53],
+                            "name": "Yellow+Hole",
+                            "center": true
+                        },
+                        {
+                            "range": [54, 71],
+                            "name": "Yellow+Blue",
+                            "center": true
+                        },
+                        {
+                            "range": [72, 89],
+                            "name": "Blue+Hole",
+                            "center": true
+                        },
+                        {
+                            "range": [90, 107],
+                            "name": "Blue+Hole+4Cl",
+                            "center": true
+                        },
+                        {
+                            "range": [108, 125],
+                            "name": "4 Colours",
+                            "center": true
+                        },
+                        {
+                            "range": [126, 143],
+                            "name": "4 Col+Yellow",
+                            "center": true
+                        },
+                        {
+                            "range": [144, 161],
+                            "name": "Yellow",
+                            "color": "#ffff00",
+                            "center": true
+                        },
+                        {
+                            "range": [162, 179],
+                            "name": "Yellow+Orange",
+                            "center": true
+                        },
+                        {
+                            "range": [180, 197],
+                            "name": "Orange",
+                            "color": "#ff7f00",
+                            "center": true
+                        },
+                        {
+                            "range": [198, 215],
+                            "name": "Orange+Warm",
+                            "center": true
+                        },
+                        {
+                            "range": [216, 233],
+                            "name": "Warm"
+                        },
+                        {
+                            "range": [234, 251],
+                            "name": "Warm+Cold"
+                        },
+                        {
+                            "range": [252, 255],
+                            "name": "Cold"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "Closed"
+                        },
+                        {
+                            "range": [128, 139],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [140, 243],
+                            "name": "Strobe"
+                        },
+                        {
+                            "range": [244, 255],
+                            "name": "Open"
+                        }
+                    ]
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Effects": {
+                    "type": "Effect",
+                    "capabilities": [
+                        {
+                            "range": [0, 63],
+                            "name": "White",
+                            "color": "#ffffff"
+                        },
+                        {
+                            "range": [64, 127],
+                            "name": "Light Frost"
+                        },
+                        {
+                            "range": [128, 191],
+                            "name": "Heavy Frost"
+                        },
+                        {
+                            "range": [192, 254],
+                            "name": "5 Facet Prism"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "Blue",
+                            "color": "#0000ff"
+                        }
+                    ]
+                },
+                "Prism": {
+                    "type": "Prism",
+                    "capabilities": [
+                        {
+                            "range": [0, 10],
+                            "name": "White",
+                            "color": "#ffffff"
+                        },
+                        {
+                            "range": [11, 20],
+                            "name": "4 Face"
+                        },
+                        {
+                            "range": [21, 30],
+                            "name": "2 Face"
+                        },
+                        {
+                            "range": [31, 40],
+                            "name": "Cyl Prism"
+                        },
+                        {
+                            "range": [41, 50],
+                            "name": "3D Prism"
+                        },
+                        {
+                            "range": [51, -1],
+                            "name": "3D Rot Left",
+                            "warning": "Out of range!",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [0, 77],
+                            "name": "3D Stop"
+                        },
+                        {
+                            "range": [78, 101],
+                            "name": "3D Rot Right",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [102, 127],
+                            "name": "Cyl Rot Right",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [128, 128],
+                            "name": "Cyl Stop"
+                        },
+                        {
+                            "range": [129, 152],
+                            "name": "Cyl Rot Left",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [153, 178],
+                            "name": "2 Face Rot Left",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [179, 179],
+                            "name": "2 Face Stop"
+                        },
+                        {
+                            "range": [180, 203],
+                            "name": "2 Fce Rot Right",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [204, 229],
+                            "name": "4 Fce Rot Right",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [230, 230],
+                            "name": "4 Face Stop"
+                        },
+                        {
+                            "range": [231, 255],
+                            "name": "4 Face Rot Left",
+                            "showInMenu": false,
+                            "center": true
+                        }
+                    ]
+                },
+                "Focus": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "Lens only"
+                        },
+                        {
+                            "range": [128, 255],
+                            "name": "Lens+add. Lens"
+                        }
+                    ]
+                },
+                "Gobo": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 63],
+                            "name": "White",
+                            "color": "#ffffff"
+                        },
+                        {
+                            "range": [64, 127],
+                            "name": "Gobo 1"
+                        },
+                        {
+                            "range": [128, 191],
+                            "name": "Gobo 2"
+                        },
+                        {
+                            "range": [192, 254],
+                            "name": "Gobo 3"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "Gobo 4"
+                        }
+                    ]
+                },
+                "RotGoboSel": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 51],
+                            "name": "White",
+                            "color": "#ffffff",
+                            "center": true
+                        },
+                        {
+                            "range": [52, 103],
+                            "name": "Gobo 1",
+                            "center": true
+                        },
+                        {
+                            "range": [104, 155],
+                            "name": "Gobo 2",
+                            "center": true
+                        },
+                        {
+                            "range": [156, 207],
+                            "name": "Gobo 3",
+                            "center": true
+                        },
+                        {
+                            "range": [208, 255],
+                            "name": "Gobo 4",
+                            "center": true
+                        }
+                    ]
+                },
+                "Gobo rot.": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "Gobo pos",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [128, 190],
+                            "name": "Gobo rot Right",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [191, 192],
+                            "name": "Gobo Stop",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [193, 255],
+                            "name": "Gobo rot Left",
+                            "showInMenu": false,
+                            "center": true
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "12-channel Mode",
+                    "shortName": "12ch",
+                    "channels": [
+                        "Iris",
+                        "Color",
+                        "Color FX",
+                        "Intensity",
+                        "Pan",
+                        "Tilt",
+                        "Effects",
+                        "Prism",
+                        "Focus",
+                        "Gobo",
+                        "RotGoboSel",
+                        "Gobo rot."
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Clay Paky",
+            "name": "Goldenscan 2 6 Channel",
+            "shortName": "Gscan2Chn6",
+            "comment": "http://www.claypaky.it/media/documents/MiniScan300-150_Manual_EN.pdf",
+            "physical": {
+                "dimensions": [330, 235, 1230],
+                "weight": 37,
+                "power": 3000
+            },
+            "availableChannels": {
+                "Iris": {
+                    "type": "Beam",
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Colour": {
+                    "type": "MultiColor",
+                    "capabilities": [
+                        {
+                            "range": [0, 31],
+                            "name": "White",
+                            "color": "#ffffff"
+                        },
+                        {
+                            "range": [32, 63],
+                            "name": "Red",
+                            "color": "#ff0000"
+                        },
+                        {
+                            "range": [64, 95],
+                            "name": "Yellow",
+                            "color": "#ffff00"
+                        },
+                        {
+                            "range": [96, 127],
+                            "name": "Violet",
+                            "color": "#7f00ff"
+                        },
+                        {
+                            "range": [128, 159],
+                            "name": "Green",
+                            "color": "#00ff00"
+                        },
+                        {
+                            "range": [160, 191],
+                            "name": "Orange",
+                            "color": "#ff7f00"
+                        },
+                        {
+                            "range": [192, 223],
+                            "name": "Blue",
+                            "color": "#0000ff"
+                        },
+                        {
+                            "range": [224, 254],
+                            "name": "Pink",
+                            "color": "#ffc0cb"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "White",
+                            "color": "#ffffff"
+                        }
+                    ]
+                },
+                "Gobo": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 13],
+                            "name": "open"
+                        },
+                        {
+                            "range": [14, 27],
+                            "name": "Gobo1"
+                        },
+                        {
+                            "range": [28, 41],
+                            "name": "Gobo2"
+                        },
+                        {
+                            "range": [42, 55],
+                            "name": "Gobo3"
+                        },
+                        {
+                            "range": [56, 69],
+                            "name": "Gobo4"
+                        },
+                        {
+                            "range": [70, 84],
+                            "name": "Gobo2+5"
+                        },
+                        {
+                            "range": [85, 98],
+                            "name": "Gobo2+6"
+                        },
+                        {
+                            "range": [99, 112],
+                            "name": "Gobo2+7"
+                        },
+                        {
+                            "range": [113, 126],
+                            "name": "Gobo2+8"
+                        },
+                        {
+                            "range": [127, 141],
+                            "name": "Gobo1+8"
+                        },
+                        {
+                            "range": [142, 155],
+                            "name": "Gobo1+7"
+                        },
+                        {
+                            "range": [156, 169],
+                            "name": "Gobo1+6"
+                        },
+                        {
+                            "range": [170, 183],
+                            "name": "Gobo1+5"
+                        },
+                        {
+                            "range": [184, 197],
+                            "name": "Gobo5"
+                        },
+                        {
+                            "range": [198, 212],
+                            "name": "Gobo6"
+                        },
+                        {
+                            "range": [213, 226],
+                            "name": "Gobo7"
+                        },
+                        {
+                            "range": [227, 240],
+                            "name": "Gobo8"
+                        },
+                        {
+                            "range": [241, 255],
+                            "name": "open"
+                        }
+                    ]
+                },
+                "Intensity/ Str.": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "Closed"
+                        },
+                        {
+                            "range": [128, 128],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [129, 229],
+                            "name": "Strobe"
+                        },
+                        {
+                            "range": [230, 255],
+                            "name": "Open"
+                        }
+                    ]
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "6-channel Mode",
+                    "shortName": "6ch",
+                    "channels": [
+                        "Iris",
+                        "Colour",
+                        "Gobo",
+                        "Intensity/ Str.",
+                        "Pan",
+                        "Tilt"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Clay Paky",
+            "name": "Goldenscan 3 6 Channel",
+            "shortName": "Gscan3Chn6",
+            "comment": "http://www.claypaky.it/media/documents/MiniScan300-150_Manual_EN.pdf",
+            "physical": {
+                "dimensions": [330, 235, 1230],
+                "weight": 37,
+                "power": 3000
+            },
+            "availableChannels": {
+                "Iris/Gobo": {
+                    "type": "Gobo",
+                    "defaultValue": 64,
+                    "highlightValue": 64,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 64],
+                            "name": "Iris",
+                            "color": "#5a4fcf"
+                        },
+                        {
+                            "range": [65, 191],
+                            "name": "Gobo Pos"
+                        },
+                        {
+                            "range": [192, 222],
+                            "name": "Rot Right",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [223, 224],
+                            "name": "Gobo Stop"
+                        },
+                        {
+                            "range": [225, 255],
+                            "name": "Rot Left",
+                            "showInMenu": false,
+                            "center": true
+                        }
+                    ]
+                },
+                "Colour": {
+                    "type": "MultiColor",
+                    "capabilities": [
+                        {
+                            "range": [0, 31],
+                            "name": "White",
+                            "color": "#ffffff"
+                        },
+                        {
+                            "range": [32, 63],
+                            "name": "Red",
+                            "color": "#ff0000"
+                        },
+                        {
+                            "range": [64, 95],
+                            "name": "Yellow",
+                            "color": "#ffff00"
+                        },
+                        {
+                            "range": [96, 127],
+                            "name": "Violet",
+                            "color": "#7f00ff"
+                        },
+                        {
+                            "range": [128, 159],
+                            "name": "Green",
+                            "color": "#00ff00"
+                        },
+                        {
+                            "range": [160, 191],
+                            "name": "Orange",
+                            "color": "#ff7f00"
+                        },
+                        {
+                            "range": [192, 223],
+                            "name": "Blue",
+                            "color": "#0000ff"
+                        },
+                        {
+                            "range": [224, 254],
+                            "name": "Pink",
+                            "color": "#ffc0cb"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "White",
+                            "color": "#ffffff"
+                        }
+                    ]
+                },
+                "FX": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 10],
+                            "name": "White",
+                            "color": "#ffffff"
+                        },
+                        {
+                            "range": [11, 20],
+                            "name": "Warm"
+                        },
+                        {
+                            "range": [21, 30],
+                            "name": "Cold"
+                        },
+                        {
+                            "range": [31, 40],
+                            "name": "Prism"
+                        },
+                        {
+                            "range": [41, 51],
+                            "name": "Frost",
+                            "color": "#edf5dd"
+                        },
+                        {
+                            "range": [52, 64],
+                            "name": "Triangle"
+                        },
+                        {
+                            "range": [65, 77],
+                            "name": "Triangle Warm",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [78, 90],
+                            "name": "Triangle Cold",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [91, 103],
+                            "name": "Triangle Prism",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [104, 116],
+                            "name": "Circle"
+                        },
+                        {
+                            "range": [117, 129],
+                            "name": "Circle Warm",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [130, 142],
+                            "name": "Circle Cold",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [143, 155],
+                            "name": "Circle Prism",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [156, 168],
+                            "name": "Line"
+                        },
+                        {
+                            "range": [169, 181],
+                            "name": "Line Warm",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [182, 194],
+                            "name": "Line Cold",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [195, 207],
+                            "name": "Line Prism",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [208, 220],
+                            "name": "Sun",
+                            "color": "#fbac13"
+                        },
+                        {
+                            "range": [221, 233],
+                            "name": "Sun Warm",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [234, 246],
+                            "name": "Sun Cold",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [247, 255],
+                            "name": "Sun Prism",
+                            "showInMenu": false
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "Closed"
+                        },
+                        {
+                            "range": [128, 139],
+                            "name": "Open Strope"
+                        },
+                        {
+                            "range": [140, 243],
+                            "name": "Strobe"
+                        },
+                        {
+                            "range": [244, 255],
+                            "name": "Open"
+                        }
+                    ]
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "6-channel Mode",
+                    "shortName": "6ch",
+                    "channels": [
+                        "Iris/Gobo",
+                        "Colour",
+                        "FX",
+                        "Intensity",
+                        "Pan",
+                        "Tilt"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Clay Paky",
+            "name": "Goldenscan 3 8 Channel",
+            "shortName": "Gscan3Chn8",
+            "comment": "http://www.claypaky.it/media/documents/MiniScan300-150_Manual_EN.pdf",
+            "physical": {
+                "dimensions": [330, 235, 1230],
+                "weight": 37,
+                "power": 3000
+            },
+            "availableChannels": {
+                "Iris": {
+                    "type": "Beam",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "Iris",
+                            "color": "#5a4fcf"
+                        }
+                    ]
+                },
+                "Colour": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 31],
+                            "name": "White",
+                            "color": "#ffffff"
+                        },
+                        {
+                            "range": [32, 63],
+                            "name": "Red",
+                            "color": "#ff0000"
+                        },
+                        {
+                            "range": [64, 95],
+                            "name": "Yellow",
+                            "color": "#ffff00"
+                        },
+                        {
+                            "range": [96, 127],
+                            "name": "Violet",
+                            "color": "#7f00ff"
+                        },
+                        {
+                            "range": [128, 159],
+                            "name": "Green",
+                            "color": "#00ff00"
+                        },
+                        {
+                            "range": [160, 191],
+                            "name": "Orange",
+                            "color": "#ff7f00"
+                        },
+                        {
+                            "range": [192, 223],
+                            "name": "Blue",
+                            "color": "#0000ff"
+                        },
+                        {
+                            "range": [224, 254],
+                            "name": "Pink",
+                            "color": "#ffc0cb"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "White",
+                            "color": "#ffffff"
+                        }
+                    ]
+                },
+                "FX": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 51],
+                            "name": "White",
+                            "color": "#ffffff"
+                        },
+                        {
+                            "range": [52, 103],
+                            "name": "Warm"
+                        },
+                        {
+                            "range": [104, 155],
+                            "name": "Cold"
+                        },
+                        {
+                            "range": [156, 207],
+                            "name": "Prism"
+                        },
+                        {
+                            "range": [208, 255],
+                            "name": "Frost",
+                            "color": "#edf5dd"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "Closed"
+                        },
+                        {
+                            "range": [128, 139],
+                            "name": "Open Strobe"
+                        },
+                        {
+                            "range": [140, 243],
+                            "name": "Strobe"
+                        },
+                        {
+                            "range": [244, 255],
+                            "name": "Open"
+                        }
+                    ]
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Gobo": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 51],
+                            "name": "White",
+                            "color": "#ffffff"
+                        },
+                        {
+                            "range": [52, 102],
+                            "name": "Triangle"
+                        },
+                        {
+                            "range": [103, 155],
+                            "name": "Circle"
+                        },
+                        {
+                            "range": [156, 207],
+                            "name": "Line"
+                        },
+                        {
+                            "range": [208, 255],
+                            "name": "Sun",
+                            "color": "#fbac13"
+                        }
+                    ]
+                },
+                "Gobo Rot": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "Gobo Pos",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [128, 190],
+                            "name": "Rot Right",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [191, 192],
+                            "name": "Gobo Stop",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [193, 255],
+                            "name": "Rot Left",
+                            "showInMenu": false,
+                            "center": true
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "8-channel Mode",
+                    "shortName": "8ch",
+                    "channels": [
+                        "Iris",
+                        "Colour",
+                        "FX",
+                        "Intensity",
+                        "Pan",
+                        "Tilt",
+                        "Gobo",
+                        "Gobo Rot"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Clay Paky",
+            "name": "Goldenscan 4 16bit",
+            "shortName": "Gscan416bit",
+            "comment": "cd http://www.claypaky.it/media/documents/MiniScan300-150_Manual_EN.pdf",
+            "physical": {
+                "dimensions": [330, 235, 1230],
+                "weight": 37,
+                "power": 3000
+            },
+            "availableChannels": {
+                "Iris": {
+                    "type": "Beam",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 126],
+                            "name": "%"
+                        },
+                        {
+                            "range": [127, 131],
+                            "name": "open"
+                        },
+                        {
+                            "range": [132, 251],
+                            "name": "pulse"
+                        },
+                        {
+                            "range": [252, 255],
+                            "name": "open"
+                        }
+                    ]
+                },
+                "Colour": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "open"
+                        },
+                        {
+                            "range": [16, 31],
+                            "name": "red",
+                            "color": "#ff0000"
+                        },
+                        {
+                            "range": [32, 47],
+                            "name": "yellow",
+                            "color": "#ffff00"
+                        },
+                        {
+                            "range": [48, 63],
+                            "name": "violet",
+                            "color": "#7f00ff"
+                        },
+                        {
+                            "range": [64, 79],
+                            "name": "green",
+                            "color": "#00ff00"
+                        },
+                        {
+                            "range": [80, 95],
+                            "name": "orange",
+                            "color": "#ff7f00"
+                        },
+                        {
+                            "range": [96, 111],
+                            "name": "blue",
+                            "color": "#0000ff"
+                        },
+                        {
+                            "range": [112, 127],
+                            "name": "pink",
+                            "color": "#ffc0cb"
+                        },
+                        {
+                            "range": [128, 255],
+                            "name": ">>"
+                        }
+                    ]
+                },
+                "FX": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 51],
+                            "name": "open"
+                        },
+                        {
+                            "range": [52, 103],
+                            "name": "CTO"
+                        },
+                        {
+                            "range": [104, 155],
+                            "name": "CTB"
+                        },
+                        {
+                            "range": [156, 207],
+                            "name": "prisma"
+                        },
+                        {
+                            "range": [208, 255],
+                            "name": "frost",
+                            "color": "#edf5dd"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "Closed"
+                        },
+                        {
+                            "range": [128, 139],
+                            "name": "Open Strobe"
+                        },
+                        {
+                            "range": [140, 243],
+                            "name": "Strobe"
+                        },
+                        {
+                            "range": [244, 255],
+                            "name": "Open"
+                        }
+                    ]
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 0,
+                    "highlightValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 0,
+                    "highlightValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Gobo1": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 51],
+                            "name": "open"
+                        },
+                        {
+                            "range": [52, 102],
+                            "name": "slot1"
+                        },
+                        {
+                            "range": [103, 153],
+                            "name": "slot2"
+                        },
+                        {
+                            "range": [154, 204],
+                            "name": "slot3"
+                        },
+                        {
+                            "range": [205, 255],
+                            "name": "slot4"
+                        }
+                    ]
+                },
+                "Gobo1 Rot": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "index",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [128, 190],
+                            "name": ">>",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [191, 192],
+                            "name": "stop",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [193, 255],
+                            "name": "<<",
+                            "showInMenu": false,
+                            "center": true
+                        }
+                    ]
+                },
+                "Gobo2": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 47],
+                            "name": "open"
+                        },
+                        {
+                            "range": [48, 99],
+                            "name": "slot1"
+                        },
+                        {
+                            "range": [100, 151],
+                            "name": "slot2"
+                        },
+                        {
+                            "range": [152, 203],
+                            "name": "slot3"
+                        },
+                        {
+                            "range": [204, 255],
+                            "name": "slot4"
+                        }
+                    ]
+                },
+                "Reset": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "idle"
+                        },
+                        {
+                            "range": [128, 255],
+                            "name": "reset"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "12-channel Mode",
+                    "shortName": "12ch",
+                    "channels": [
+                        "Iris",
+                        "Colour",
+                        "FX",
+                        "Intensity",
+                        "Pan",
+                        "Tilt",
+                        "Gobo1",
+                        "Gobo1 Rot",
+                        "Gobo2",
+                        "Reset",
+                        "Pan fine",
+                        "Tilt fine"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Clay Paky",
+            "name": "Goldenscan 4 8bit",
+            "shortName": "Gscan48bit",
+            "comment": "cd http://www.claypaky.it/media/documents/MiniScan300-150_Manual_EN.pdf",
+            "physical": {
+                "dimensions": [330, 235, 1230],
+                "weight": 37,
+                "power": 3000
+            },
+            "availableChannels": {
+                "Iris": {
+                    "type": "Beam",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 126],
+                            "name": "%"
+                        },
+                        {
+                            "range": [127, 131],
+                            "name": "open"
+                        },
+                        {
+                            "range": [132, 251],
+                            "name": "pulse"
+                        },
+                        {
+                            "range": [252, 255],
+                            "name": "open"
+                        }
+                    ]
+                },
+                "Colour": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "open"
+                        },
+                        {
+                            "range": [16, 31],
+                            "name": "red",
+                            "color": "#ff0000"
+                        },
+                        {
+                            "range": [32, 47],
+                            "name": "yellow",
+                            "color": "#ffff00"
+                        },
+                        {
+                            "range": [48, 63],
+                            "name": "violet",
+                            "color": "#7f00ff"
+                        },
+                        {
+                            "range": [64, 79],
+                            "name": "green",
+                            "color": "#00ff00"
+                        },
+                        {
+                            "range": [80, 95],
+                            "name": "orange",
+                            "color": "#ff7f00"
+                        },
+                        {
+                            "range": [96, 111],
+                            "name": "blue",
+                            "color": "#0000ff"
+                        },
+                        {
+                            "range": [112, 127],
+                            "name": "pink",
+                            "color": "#ffc0cb"
+                        },
+                        {
+                            "range": [128, 255],
+                            "name": ">>"
+                        }
+                    ]
+                },
+                "FX": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 51],
+                            "name": "open"
+                        },
+                        {
+                            "range": [52, 103],
+                            "name": "CTO"
+                        },
+                        {
+                            "range": [104, 155],
+                            "name": "CTB"
+                        },
+                        {
+                            "range": [156, 207],
+                            "name": "prisma"
+                        },
+                        {
+                            "range": [208, 255],
+                            "name": "frost",
+                            "color": "#edf5dd"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "Closed"
+                        },
+                        {
+                            "range": [128, 139],
+                            "name": "Open Strobe"
+                        },
+                        {
+                            "range": [140, 243],
+                            "name": "Strobe"
+                        },
+                        {
+                            "range": [244, 255],
+                            "name": "Open"
+                        }
+                    ]
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Gobo1": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 51],
+                            "name": "open"
+                        },
+                        {
+                            "range": [52, 102],
+                            "name": "slot1"
+                        },
+                        {
+                            "range": [103, 153],
+                            "name": "slot2"
+                        },
+                        {
+                            "range": [154, 204],
+                            "name": "slot3"
+                        },
+                        {
+                            "range": [205, 255],
+                            "name": "slot4"
+                        }
+                    ]
+                },
+                "Gobo1 Rot": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "index",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [128, 190],
+                            "name": ">>",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [191, 192],
+                            "name": "stop",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [193, 255],
+                            "name": "<<",
+                            "showInMenu": false,
+                            "center": true
+                        }
+                    ]
+                },
+                "Gobo2": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 47],
+                            "name": "open"
+                        },
+                        {
+                            "range": [48, 99],
+                            "name": "slot1"
+                        },
+                        {
+                            "range": [100, 151],
+                            "name": "slot2"
+                        },
+                        {
+                            "range": [152, 203],
+                            "name": "slot3"
+                        },
+                        {
+                            "range": [204, 255],
+                            "name": "slot4"
+                        }
+                    ]
+                },
+                "Reset": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "idle"
+                        },
+                        {
+                            "range": [128, 255],
+                            "name": "reset"
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "10-channel Mode",
+                    "shortName": "10ch",
+                    "channels": [
+                        "Iris",
+                        "Colour",
+                        "FX",
+                        "Intensity",
+                        "Pan",
+                        "Tilt",
+                        "Gobo1",
+                        "Gobo1 Rot",
+                        "Gobo2",
+                        "Reset"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Clay Paky",
+            "name": "Mini Scan 300",
+            "shortName": "MScan300",
+            "comment": "http://www.claypaky.it/media/documents/MiniScan300-150_Manual_DE.pdf",
+            "physical": {
+                "dimensions": [240, 280, 600],
+                "weight": 10.5,
+                "power": 800
+            },
+            "availableChannels": {
+                "Color": {
+                    "type": "MultiColor",
+                    "capabilities": [
+                        {
+                            "range": [0, 18],
+                            "name": "white",
+                            "color": "#ffffff"
+                        },
+                        {
+                            "range": [19, 36],
+                            "name": "red",
+                            "color": "#ff0000"
+                        },
+                        {
+                            "range": [37, 54],
+                            "name": "yellow",
+                            "color": "#ffff00"
+                        },
+                        {
+                            "range": [55, 72],
+                            "name": "violett"
+                        },
+                        {
+                            "range": [73, 90],
+                            "name": "green",
+                            "color": "#00ff00"
+                        },
+                        {
+                            "range": [91, 108],
+                            "name": "orange",
+                            "color": "#ff7f00"
+                        },
+                        {
+                            "range": [109, 126],
+                            "name": "blue",
+                            "color": "#0000ff"
+                        },
+                        {
+                            "range": [128, 128],
+                            "name": "rose",
+                            "color": "#ff007f"
+                        },
+                        {
+                            "range": [129, 255],
+                            "name": "rotation"
+                        }
+                    ]
+                },
+                "Shutter": {
+                    "type": "Shutter",
+                    "highlightValue": 75,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 76],
+                            "name": "%"
+                        },
+                        {
+                            "range": [77, 128],
+                            "name": "strobe"
+                        },
+                        {
+                            "range": [129, 255],
+                            "name": "gobos"
+                        }
+                    ]
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "4-channel Mode",
+                    "shortName": "4ch",
+                    "channels": [
+                        "Color",
+                        "Shutter",
+                        "Pan",
+                        "Tilt"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Clay Paky",
+            "name": "Mini Scan HPE",
+            "shortName": "MScanHPE",
+            "comment": "http://www.claypaky.it/media/documents/MiniScanHPE_Manual_EN_Rev2.pdf",
+            "physical": {
+                "dimensions": [300, 300, 600],
+                "weight": 16,
+                "power": 900
+            },
+            "availableChannels": {
+                "Color": {
+                    "type": "MultiColor",
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "white",
+                            "color": "#ffffff"
+                        },
+                        {
+                            "range": [16, 32],
+                            "name": "red",
+                            "color": "#ff0000"
+                        },
+                        {
+                            "range": [33, 48],
+                            "name": "yellow",
+                            "color": "#ffff00"
+                        },
+                        {
+                            "range": [49, 65],
+                            "name": "violet",
+                            "color": "#7f00ff"
+                        },
+                        {
+                            "range": [66, 81],
+                            "name": "green",
+                            "color": "#00ff00"
+                        },
+                        {
+                            "range": [82, 97],
+                            "name": "orange",
+                            "color": "#ff7f00"
+                        },
+                        {
+                            "range": [98, 114],
+                            "name": "blue",
+                            "color": "#0000ff"
+                        },
+                        {
+                            "range": [115, 127],
+                            "name": "pink",
+                            "color": "#ffc0cb"
+                        },
+                        {
+                            "range": [128, 255],
+                            "name": "rotation"
+                        }
+                    ]
+                },
+                "Gobo.Rot": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 20],
+                            "name": "0"
+                        },
+                        {
+                            "range": [21, 41],
+                            "name": "90"
+                        },
+                        {
+                            "range": [42, 62],
+                            "name": "180"
+                        },
+                        {
+                            "range": [63, 83],
+                            "name": "270"
+                        },
+                        {
+                            "range": [84, 104],
+                            "name": "360"
+                        },
+                        {
+                            "range": [105, 126],
+                            "name": "450"
+                        },
+                        {
+                            "range": [127, 127],
+                            "name": "540"
+                        },
+                        {
+                            "range": [128, 190],
+                            "name": "rotation"
+                        },
+                        {
+                            "range": [191, 192],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [193, 255],
+                            "name": "rotation"
+                        }
+                    ]
+                },
+                "Gobo": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 36],
+                            "name": "white",
+                            "color": "#ffffff",
+                            "center": true
+                        },
+                        {
+                            "range": [37, 73],
+                            "name": "gobo1",
+                            "center": true
+                        },
+                        {
+                            "range": [74, 110],
+                            "name": "gobo2",
+                            "center": true
+                        },
+                        {
+                            "range": [111, 147],
+                            "name": "gobo3",
+                            "center": true
+                        },
+                        {
+                            "range": [148, 184],
+                            "name": "gobo4",
+                            "center": true
+                        },
+                        {
+                            "range": [185, 221],
+                            "name": "gobo5",
+                            "center": true
+                        },
+                        {
+                            "range": [222, 255],
+                            "name": "gobo6",
+                            "center": true
+                        }
+                    ]
+                },
+                "Shutter": {
+                    "type": "Shutter",
+                    "highlightValue": 129,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 139],
+                            "name": "%"
+                        },
+                        {
+                            "range": [140, 243],
+                            "name": "strobe"
+                        },
+                        {
+                            "range": [244, 255],
+                            "name": "open"
+                        }
+                    ]
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Effects": {
+                    "type": "Effect",
+                    "capabilities": [
+                        {
+                            "range": [0, 35],
+                            "name": "white",
+                            "color": "#ffffff"
+                        },
+                        {
+                            "range": [36, 71],
+                            "name": "warm"
+                        },
+                        {
+                            "range": [72, 108],
+                            "name": "cold"
+                        },
+                        {
+                            "range": [109, 145],
+                            "name": "light_frost"
+                        },
+                        {
+                            "range": [146, 181],
+                            "name": "heavy_frost"
+                        },
+                        {
+                            "range": [182, 217],
+                            "name": "prism"
+                        },
+                        {
+                            "range": [218, 254],
+                            "name": "UV"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "Lightblue",
+                            "color": "#add8e6"
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "7-channel Mode",
+                    "shortName": "7ch",
+                    "channels": [
+                        "Color",
+                        "Gobo.Rot",
+                        "Gobo",
+                        "Shutter",
+                        "Pan",
+                        "Tilt",
+                        "Effects"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Clay Paky",
+            "name": "Pin Scan",
+            "shortName": "PScan",
+            "comment": "http://www.claypaky.it/media/documents/PinScan_Manual-Channels_EN_Rev3.pdf",
+            "physical": {
+                "dimensions": [230, 230, 325],
+                "weight": 5.8,
+                "power": 150
+            },
+            "availableChannels": {
+                "Shutter": {
+                    "type": "Shutter",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "narrow"
+                        },
+                        {
+                            "range": [128, 139],
+                            "name": "wide"
+                        },
+                        {
+                            "range": [140, 243],
+                            "name": "strobe"
+                        },
+                        {
+                            "range": [244, 255],
+                            "name": "open"
+                        }
+                    ]
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "3-channel Mode",
+                    "shortName": "3ch",
+                    "channels": [
+                        "Shutter",
+                        "Pan",
+                        "Tilt"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Clay Paky",
+            "name": "Scan Zoom",
+            "shortName": "ScanZoom",
+            "comment": "http://www.claypaky.it/media/documents/SuperScanZoom_Manual_EN_Rev3.pdf",
+            "physical": {
+                "dimensions": [435, 435, 1470],
+                "weight": 44.5,
+                "power": 1200
+            },
+            "availableChannels": {
+                "Iris": {
+                    "type": "Beam",
+                    "defaultValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Color": {
+                    "type": "MultiColor",
+                    "capabilities": [
+                        {
+                            "range": [0, 7],
+                            "name": "open"
+                        },
+                        {
+                            "range": [8, 24],
+                            "name": "Red",
+                            "color": "#ff0000"
+                        },
+                        {
+                            "range": [25, 41],
+                            "name": "Yellow",
+                            "color": "#ffff00"
+                        },
+                        {
+                            "range": [42, 58],
+                            "name": "Magenta",
+                            "color": "#ca1f7b"
+                        },
+                        {
+                            "range": [59, 74],
+                            "name": "Green",
+                            "color": "#00ff00"
+                        },
+                        {
+                            "range": [75, 89],
+                            "name": "Orange",
+                            "color": "#ff7f00"
+                        },
+                        {
+                            "range": [90, 107],
+                            "name": "Blue",
+                            "color": "#0000ff"
+                        },
+                        {
+                            "range": [108, 127],
+                            "name": "Pink",
+                            "color": "#ffc0cb"
+                        },
+                        {
+                            "range": [128, 255],
+                            "name": "Rotation"
+                        }
+                    ]
+                },
+                "Gobo": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [16, 29],
+                            "name": "Radial"
+                        },
+                        {
+                            "range": [30, 42],
+                            "name": "Grid"
+                        },
+                        {
+                            "range": [43, 55],
+                            "name": "Stars"
+                        },
+                        {
+                            "range": [56, 65],
+                            "name": "Leafy"
+                        },
+                        {
+                            "range": [66, 82],
+                            "name": "Dot+Grid"
+                        },
+                        {
+                            "range": [83, 98],
+                            "name": "Cone+Grid"
+                        },
+                        {
+                            "range": [99, 116],
+                            "name": "Star+Grid"
+                        },
+                        {
+                            "range": [117, 137],
+                            "name": "Swirl+Grid"
+                        },
+                        {
+                            "range": [138, 153],
+                            "name": "Swirl+Radial"
+                        },
+                        {
+                            "range": [154, 172],
+                            "name": "Star+Radial"
+                        },
+                        {
+                            "range": [173, 189],
+                            "name": "Cone+Radial"
+                        },
+                        {
+                            "range": [190, 197],
+                            "name": "Phone+Radial"
+                        },
+                        {
+                            "range": [198, 209],
+                            "name": "Phone"
+                        },
+                        {
+                            "range": [210, 223],
+                            "name": "Cone"
+                        },
+                        {
+                            "range": [224, 236],
+                            "name": "Star"
+                        },
+                        {
+                            "range": [237, 254],
+                            "name": "Swirl",
+                            "color": "#d3cdc5"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "Open"
+                        }
+                    ]
+                },
+                "Strobe": {
+                    "type": "Strobe",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Prism": {
+                    "type": "Prism",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 63],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [64, 149],
+                            "name": "Prism1"
+                        },
+                        {
+                            "range": [150, 254],
+                            "name": "Prism2"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "Prism3"
+                        }
+                    ]
+                },
+                "Focus": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "12-channel Mode",
+                    "shortName": "12ch",
+                    "channels": [
+                        "Iris",
+                        "Color",
+                        "Gobo",
+                        "Strobe",
+                        "Pan",
+                        "Tilt",
+                        "Intensity",
+                        "Prism",
+                        "Focus",
+                        "Red",
+                        "Green",
+                        "Blue"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Clay Paky",
+            "name": "Stage Color 1000",
+            "shortName": "StageCl1000",
+            "comment": "16 bit PAN + TILT (DIP 4 ON) http://www.claypaky.it/media/documents/StageColor1000_manual_Rev1.pdf",
+            "physical": {
+                "dimensions": [590, 590, 710],
+                "weight": 35.8,
+                "power": 1200
+            },
+            "availableChannels": {
+                "Cyan": {
+                    "type": "SingleColor",
+                    "color": "Cyan",
+                    "invert": true,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Magenta": {
+                    "type": "SingleColor",
+                    "color": "Magenta",
+                    "invert": true,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Yellow": {
+                    "type": "SingleColor",
+                    "color": "Yellow",
+                    "invert": true,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Strobe": {
+                    "type": "Strobe",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "capabilities": [
+                        {
+                            "range": [0, 25],
+                            "name": "Close"
+                        },
+                        {
+                            "range": [26, 230],
+                            "name": "Speed"
+                        },
+                        {
+                            "range": [231, 255],
+                            "name": "Open"
+                        }
+                    ]
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Colour FX": {
+                    "type": "MultiColor",
+                    "capabilities": [
+                        {
+                            "range": [0, 42],
+                            "name": "White",
+                            "color": "#ffffff"
+                        },
+                        {
+                            "range": [43, 85],
+                            "name": "Blue Hole"
+                        },
+                        {
+                            "range": [86, 128],
+                            "name": "Yellow Hole"
+                        },
+                        {
+                            "range": [129, 171],
+                            "name": "Green Hole"
+                        },
+                        {
+                            "range": [172, 214],
+                            "name": "Magenta Hole"
+                        },
+                        {
+                            "range": [215, 255],
+                            "name": "UV Filter"
+                        }
+                    ]
+                },
+                "Frost/Oval": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 84],
+                            "name": "White",
+                            "color": "#ffffff"
+                        },
+                        {
+                            "range": [85, 171],
+                            "name": "Ovalizer 1"
+                        },
+                        {
+                            "range": [172, 254],
+                            "name": "Ovalizer 2"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "Frost",
+                            "color": "#edf5dd"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "11-channel Mode",
+                    "shortName": "11ch",
+                    "channels": [
+                        "Cyan",
+                        "Magenta",
+                        "Yellow",
+                        "Strobe",
+                        "Pan",
+                        "Tilt",
+                        "Colour FX",
+                        "Frost/Oval",
+                        "Intensity",
+                        "Pan fine",
+                        "Tilt fine"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Clay Paky",
+            "name": "Stage Color 1200",
+            "shortName": "StageCl1200",
+            "comment": "16bit PAN + TILT (DIP 4 ON)",
+            "physical": {
+                "dimensions": [590, 590, 710],
+                "weight": 55,
+                "power": 2200
+            },
+            "availableChannels": {
+                "Cyan": {
+                    "type": "SingleColor",
+                    "color": "Cyan",
+                    "invert": true,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Magenta": {
+                    "type": "SingleColor",
+                    "color": "Magenta",
+                    "invert": true,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Yellow": {
+                    "type": "SingleColor",
+                    "color": "Yellow",
+                    "invert": true,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Strobe": {
+                    "type": "Strobe",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "capabilities": [
+                        {
+                            "range": [0, 25],
+                            "name": "Close"
+                        },
+                        {
+                            "range": [26, 230],
+                            "name": "Speed"
+                        },
+                        {
+                            "range": [231, 255],
+                            "name": "Open"
+                        }
+                    ]
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Colour FX": {
+                    "type": "MultiColor",
+                    "capabilities": [
+                        {
+                            "range": [0, 42],
+                            "name": "White",
+                            "color": "#ffffff"
+                        },
+                        {
+                            "range": [43, 85],
+                            "name": "Blue Hole"
+                        },
+                        {
+                            "range": [86, 128],
+                            "name": "Yellow Hole"
+                        },
+                        {
+                            "range": [129, 171],
+                            "name": "Green Hole"
+                        },
+                        {
+                            "range": [172, 214],
+                            "name": "Magenta Hole"
+                        },
+                        {
+                            "range": [215, 255],
+                            "name": "UV Filter"
+                        }
+                    ]
+                },
+                "Ovalizer": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Frost": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 83],
+                            "name": "White",
+                            "color": "#ffffff"
+                        },
+                        {
+                            "range": [84, 255],
+                            "name": "Frost %"
+                        }
+                    ]
+                },
+                "Warm": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Lamp Ctrl": {
+                    "type": "Beam",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "off"
+                        },
+                        {
+                            "range": [128, 255],
+                            "name": "on"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "14-channel Mode",
+                    "shortName": "14ch",
+                    "channels": [
+                        "Cyan",
+                        "Magenta",
+                        "Yellow",
+                        "Strobe",
+                        "Pan",
+                        "Tilt",
+                        "Colour FX",
+                        "Ovalizer",
+                        "Frost",
+                        "Warm",
+                        "Intensity",
+                        "Lamp Ctrl",
+                        "Pan fine",
+                        "Tilt fine"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Clay Paky",
+            "name": "Stage Color 300",
+            "shortName": "StageCl300",
+            "comment": "16bit PAN + TILT (DIP 4 ON)",
+            "physical": {
+                "dimensions": [400, 400, 520],
+                "weight": 24,
+                "power": 900
+            },
+            "availableChannels": {
+                "Cyan": {
+                    "type": "SingleColor",
+                    "color": "Cyan",
+                    "invert": true,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Magenta": {
+                    "type": "SingleColor",
+                    "color": "Magenta",
+                    "invert": true,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Yellow": {
+                    "type": "SingleColor",
+                    "color": "Yellow",
+                    "invert": true,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Strobe": {
+                    "type": "Strobe",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "capabilities": [
+                        {
+                            "range": [0, 25],
+                            "name": "Close"
+                        },
+                        {
+                            "range": [26, 230],
+                            "name": "Speed"
+                        },
+                        {
+                            "range": [244, 255],
+                            "name": "Open"
+                        }
+                    ]
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Frost": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 83],
+                            "name": "White",
+                            "color": "#ffffff"
+                        },
+                        {
+                            "range": [84, 255],
+                            "name": "Frost %"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "10-channel Mode",
+                    "shortName": "10ch",
+                    "channels": [
+                        "Cyan",
+                        "Magenta",
+                        "Yellow",
+                        "Strobe",
+                        "Pan",
+                        "Tilt",
+                        "Intensity",
+                        "Frost",
+                        "Pan fine",
+                        "Tilt fine"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Clay Paky",
+            "name": "Stage Color 575",
+            "shortName": "StageCl575",
+            "comment": "16bit PAN + TILT (DIP 4 ON)",
+            "physical": {
+                "dimensions": [590, 590, 710],
+                "weight": 48,
+                "power": 1200
+            },
+            "availableChannels": {
+                "Cyan": {
+                    "type": "SingleColor",
+                    "color": "Cyan",
+                    "invert": true,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Magenta": {
+                    "type": "SingleColor",
+                    "color": "Magenta",
+                    "invert": true,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Yellow": {
+                    "type": "SingleColor",
+                    "color": "Yellow",
+                    "invert": true,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Strobe": {
+                    "type": "Strobe",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "capabilities": [
+                        {
+                            "range": [0, 25],
+                            "name": "Close"
+                        },
+                        {
+                            "range": [26, 230],
+                            "name": "Speed"
+                        },
+                        {
+                            "range": [231, 255],
+                            "name": "Open"
+                        }
+                    ]
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Colour FX": {
+                    "type": "MultiColor",
+                    "capabilities": [
+                        {
+                            "range": [0, 42],
+                            "name": "White",
+                            "color": "#ffffff"
+                        },
+                        {
+                            "range": [43, 85],
+                            "name": "Blue Hole"
+                        },
+                        {
+                            "range": [86, 128],
+                            "name": "Yellow Hole"
+                        },
+                        {
+                            "range": [129, 171],
+                            "name": "Green Hole"
+                        },
+                        {
+                            "range": [172, 214],
+                            "name": "Magenta Hole"
+                        },
+                        {
+                            "range": [215, 255],
+                            "name": "UV Filter"
+                        }
+                    ]
+                },
+                "Ovalizer": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Frost": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 83],
+                            "name": "White",
+                            "color": "#ffffff"
+                        },
+                        {
+                            "range": [84, 255],
+                            "name": "Frost %"
+                        }
+                    ]
+                },
+                "Warm": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Lamp Ctrl": {
+                    "type": "Beam",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "off"
+                        },
+                        {
+                            "range": [128, 255],
+                            "name": "on"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "14-channel Mode",
+                    "shortName": "14ch",
+                    "channels": [
+                        "Cyan",
+                        "Magenta",
+                        "Yellow",
+                        "Strobe",
+                        "Pan",
+                        "Tilt",
+                        "Colour FX",
+                        "Ovalizer",
+                        "Frost",
+                        "Warm",
+                        "Intensity",
+                        "Lamp Ctrl",
+                        "Pan fine",
+                        "Tilt fine"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Clay Paky",
+            "name": "Stage Light 300",
+            "shortName": "StageL300",
+            "comment": "16bit PAN + TILT (DIP 4 ON)",
+            "physical": {
+                "dimensions": [400, 400, 480],
+                "weight": 24,
+                "power": 900
+            },
+            "availableChannels": {
+                "Colour": {
+                    "type": "MultiColor",
+                    "capabilities": [
+                        {
+                            "range": [0, 31],
+                            "name": "White",
+                            "color": "#ffffff",
+                            "center": true
+                        },
+                        {
+                            "range": [32, 63],
+                            "name": "Red",
+                            "color": "#ff0000",
+                            "center": true
+                        },
+                        {
+                            "range": [64, 95],
+                            "name": "Yellow",
+                            "color": "#ffff00",
+                            "center": true
+                        },
+                        {
+                            "range": [96, 127],
+                            "name": "Violet",
+                            "color": "#7f00ff",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 159],
+                            "name": "Green",
+                            "color": "#00ff00",
+                            "center": true
+                        },
+                        {
+                            "range": [160, 191],
+                            "name": "Orange",
+                            "color": "#ff7f00",
+                            "center": true
+                        },
+                        {
+                            "range": [192, 223],
+                            "name": "Blue",
+                            "color": "#0000ff",
+                            "center": true
+                        },
+                        {
+                            "range": [224, 254],
+                            "name": "Pink",
+                            "color": "#ffc0cb",
+                            "center": true
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "White",
+                            "color": "#ffffff",
+                            "center": true
+                        }
+                    ]
+                },
+                "Gobo Rot": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "Gobo Pos"
+                        },
+                        {
+                            "range": [128, 190],
+                            "name": "Rot Left",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [191, 192],
+                            "name": "Gobo Stop"
+                        },
+                        {
+                            "range": [193, 255],
+                            "name": "Rot Right",
+                            "showInMenu": false,
+                            "center": true
+                        }
+                    ]
+                },
+                "Gobo": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 36],
+                            "name": "No Gobo"
+                        },
+                        {
+                            "range": [37, 73],
+                            "name": "Gobo 1"
+                        },
+                        {
+                            "range": [74, 110],
+                            "name": "Gobo 2"
+                        },
+                        {
+                            "range": [111, 147],
+                            "name": "Gobo 3"
+                        },
+                        {
+                            "range": [148, 184],
+                            "name": "Gobo 4"
+                        },
+                        {
+                            "range": [185, 221],
+                            "name": "Gobo 5"
+                        },
+                        {
+                            "range": [222, 255],
+                            "name": "Gobo 6"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "Closed"
+                        },
+                        {
+                            "range": [128, 139],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [140, 243],
+                            "name": "Strobe"
+                        },
+                        {
+                            "range": [244, 255],
+                            "name": "Open"
+                        }
+                    ]
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Effects": {
+                    "type": "Effect",
+                    "capabilities": [
+                        {
+                            "range": [0, 36],
+                            "name": "White",
+                            "color": "#ffffff"
+                        },
+                        {
+                            "range": [37, 74],
+                            "name": "Warm"
+                        },
+                        {
+                            "range": [75, 111],
+                            "name": "Cold"
+                        },
+                        {
+                            "range": [112, 183],
+                            "name": "Frost",
+                            "color": "#edf5dd"
+                        },
+                        {
+                            "range": [184, 218],
+                            "name": "Prism"
+                        },
+                        {
+                            "range": [219, 254],
+                            "name": "UV"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "Light Blue",
+                            "color": "#add8e6"
+                        }
+                    ]
+                },
+                "Focus": {
+                    "type": "Beam",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "Distance"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "10-channel Mode",
+                    "shortName": "10ch",
+                    "channels": [
+                        "Colour",
+                        "Gobo Rot",
+                        "Gobo",
+                        "Intensity",
+                        "Pan",
+                        "Tilt",
+                        "Effects",
+                        "Focus",
+                        "Pan fine",
+                        "Tilt fine"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Clay Paky",
+            "name": "Stage Profile 1200 SV",
+            "shortName": "SProfile1200",
+            "physical": {
+                "dimensions": [590, 590, 710],
+                "weight": 58.7,
+                "power": 1700
+            },
+            "availableChannels": {
+                "Iris": {
+                    "type": "Beam",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Zoom": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Focus": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [128, 139],
+                            "name": "open"
+                        },
+                        {
+                            "range": [140, 243],
+                            "name": "Strobe"
+                        },
+                        {
+                            "range": [244, 255],
+                            "name": "open"
+                        }
+                    ]
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 0,
+                    "highlightValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 0,
+                    "highlightValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Blade 1A": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Blade 1B": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Blade 2A": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Blade 2B": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Blade 3A": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Blade 3B": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Blade 4A": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Blade 4B": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Beam Rot": {
+                    "type": "Beam",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "Position"
+                        }
+                    ]
+                },
+                "Color": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "white",
+                            "color": "#ffffff"
+                        },
+                        {
+                            "range": [16, 31],
+                            "name": "warm filter"
+                        },
+                        {
+                            "range": [32, 47],
+                            "name": "amber",
+                            "color": "#ffbf00"
+                        },
+                        {
+                            "range": [48, 63],
+                            "name": "orange",
+                            "color": "#ff7f00"
+                        },
+                        {
+                            "range": [64, 79],
+                            "name": "pink",
+                            "color": "#ffc0cb"
+                        },
+                        {
+                            "range": [80, 95],
+                            "name": "cold"
+                        },
+                        {
+                            "range": [96, 111],
+                            "name": "cyan",
+                            "color": "#00ffff"
+                        },
+                        {
+                            "range": [112, 127],
+                            "name": "blue",
+                            "color": "#0000ff"
+                        },
+                        {
+                            "range": [128, 255],
+                            "name": "Rotation"
+                        }
+                    ]
+                },
+                "Control": {
+                    "type": "Beam",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "capabilities": [
+                        {
+                            "range": [0, 63],
+                            "name": "lamp_off"
+                        },
+                        {
+                            "range": [64, 127],
+                            "name": "lamp_on half"
+                        },
+                        {
+                            "range": [128, 255],
+                            "name": "lamp_on full"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "19-channel Mode",
+                    "shortName": "19ch",
+                    "channels": [
+                        "Iris",
+                        "Zoom",
+                        "Focus",
+                        "Intensity",
+                        "Pan",
+                        "Tilt",
+                        "Blade 1A",
+                        "Blade 1B",
+                        "Blade 2A",
+                        "Blade 2B",
+                        "Blade 3A",
+                        "Blade 3B",
+                        "Blade 4A",
+                        "Blade 4B",
+                        "Beam Rot",
+                        "Color",
+                        "Control",
+                        "Pan fine",
+                        "Tilt fine"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Clay Paky",
+            "name": "Stage Profile Plus SV",
+            "shortName": "SProfile+",
+            "comment": "DIP 8 ON",
+            "physical": {
+                "dimensions": [590, 590, 710],
+                "weight": 62,
+                "power": 1700
+            },
+            "availableChannels": {
+                "Iris": {
+                    "type": "Beam",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Zoom": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Focus": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 0,
+                    "highlightValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 0,
+                    "highlightValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Blade 1A": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Blade 1B": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Blade 2A": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Blade 2B": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Blade 3A": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Blade 3B": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Blade 4A": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Blade 4B": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Frame Rot": {
+                    "type": "Beam",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Shutter": {
+                    "type": "Shutter",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "capabilities": [
+                        {
+                            "range": [0, 25],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [26, 230],
+                            "name": "strobe"
+                        },
+                        {
+                            "range": [231, 255],
+                            "name": "open"
+                        }
+                    ]
+                },
+                "Color adj.": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 86],
+                            "name": "white",
+                            "color": "#ffffff"
+                        },
+                        {
+                            "range": [87, 171],
+                            "name": "warm filter"
+                        },
+                        {
+                            "range": [172, 255],
+                            "name": "cold filter"
+                        }
+                    ]
+                },
+                "Prism/Frost": {
+                    "type": "Prism",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 51],
+                            "name": "white",
+                            "color": "#ffffff"
+                        },
+                        {
+                            "range": [52, 103],
+                            "name": "5 faces prism"
+                        },
+                        {
+                            "range": [104, 157],
+                            "name": "9 faces prism"
+                        },
+                        {
+                            "range": [158, 207],
+                            "name": "4 faces prism 3"
+                        },
+                        {
+                            "range": [208, 255],
+                            "name": "light frost"
+                        }
+                    ]
+                },
+                "Frost": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "5"
+                        }
+                    ]
+                },
+                "FocusLens": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "framing/nolens"
+                        },
+                        {
+                            "range": [128, 255],
+                            "name": "gobofocus/lens"
+                        }
+                    ]
+                },
+                "Gobo 1": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 51],
+                            "name": "white",
+                            "color": "#ffffff"
+                        },
+                        {
+                            "range": [52, 103],
+                            "name": "gobo 1"
+                        },
+                        {
+                            "range": [104, 155],
+                            "name": "gobo 2"
+                        },
+                        {
+                            "range": [156, 207],
+                            "name": "gobo 3"
+                        },
+                        {
+                            "range": [208, 255],
+                            "name": "gobo 4"
+                        }
+                    ]
+                },
+                "Gobo Rot 1": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "position"
+                        },
+                        {
+                            "range": [128, 190],
+                            "name": "rotation"
+                        },
+                        {
+                            "range": [191, 192],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [193, 255],
+                            "name": "rotation"
+                        }
+                    ]
+                },
+                "Gobo 2": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 51],
+                            "name": "white",
+                            "color": "#ffffff"
+                        },
+                        {
+                            "range": [52, 103],
+                            "name": "gobo 1"
+                        },
+                        {
+                            "range": [104, 155],
+                            "name": "gobo 2"
+                        },
+                        {
+                            "range": [156, 207],
+                            "name": "gobo 3"
+                        },
+                        {
+                            "range": [208, 255],
+                            "name": "gobo 4"
+                        }
+                    ]
+                },
+                "Gobo Rot 2": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "position"
+                        },
+                        {
+                            "range": [128, 190],
+                            "name": "rotation"
+                        },
+                        {
+                            "range": [191, 192],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [193, 255],
+                            "name": "rotation"
+                        }
+                    ]
+                },
+                "Cyan": {
+                    "type": "SingleColor",
+                    "color": "Cyan",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Magenta": {
+                    "type": "SingleColor",
+                    "color": "Magenta",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Yellow": {
+                    "type": "SingleColor",
+                    "color": "Yellow",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Control": {
+                    "type": "Beam",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 63],
+                            "name": "lamp off"
+                        },
+                        {
+                            "range": [64, 127],
+                            "name": "lamp on half"
+                        },
+                        {
+                            "range": [128, 255],
+                            "name": "lamp on full"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "30-channel Mode",
+                    "shortName": "30ch",
+                    "channels": [
+                        "Iris",
+                        "Zoom",
+                        "Focus",
+                        "Intensity",
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "Blade 1A",
+                        "Blade 1B",
+                        "Blade 2A",
+                        "Blade 2B",
+                        "Blade 3A",
+                        "Blade 3B",
+                        "Blade 4A",
+                        "Blade 4B",
+                        "Frame Rot",
+                        "Shutter",
+                        "Color adj.",
+                        "Prism/Frost",
+                        "Frost",
+                        "FocusLens",
+                        "Gobo 1",
+                        "Gobo Rot 1",
+                        "Gobo 2",
+                        "Gobo Rot 2",
+                        "Cyan",
+                        "Magenta",
+                        "Yellow",
+                        "Control"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Clay Paky",
+            "name": "Stage Scan",
+            "shortName": "StageScan",
+            "comment": "http://www.claypaky.it/media/documents/StageScan_Manual_EN.pdf",
+            "physical": {
+                "dimensions": [330, 330, 1230],
+                "weight": 40,
+                "power": 1500
+            },
+            "availableChannels": {
+                "Iris": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Color FX": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "white",
+                            "color": "#ffffff"
+                        },
+                        {
+                            "range": [16, 31],
+                            "name": "hotfilter"
+                        },
+                        {
+                            "range": [32, 47],
+                            "name": "coldfilter"
+                        },
+                        {
+                            "range": [48, 63],
+                            "name": "red",
+                            "color": "#ff0000"
+                        },
+                        {
+                            "range": [64, 79],
+                            "name": "yellow / hole"
+                        },
+                        {
+                            "range": [80, 95],
+                            "name": "blue / hole"
+                        },
+                        {
+                            "range": [96, 111],
+                            "name": "UV Filter"
+                        },
+                        {
+                            "range": [112, 127],
+                            "name": "4 colors"
+                        },
+                        {
+                            "range": [128, 255],
+                            "name": "rainbow"
+                        }
+                    ]
+                },
+                "Frost/Prism": {
+                    "type": "Prism",
+                    "capabilities": [
+                        {
+                            "range": [0, 47],
+                            "name": "white",
+                            "color": "#ffffff"
+                        },
+                        {
+                            "range": [48, 99],
+                            "name": "frost / hole"
+                        },
+                        {
+                            "range": [100, 151],
+                            "name": "light frost"
+                        },
+                        {
+                            "range": [152, 203],
+                            "name": "heavy frost"
+                        },
+                        {
+                            "range": [204, 255],
+                            "name": "5 face prism"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [128, 139],
+                            "name": "open"
+                        },
+                        {
+                            "range": [140, 243],
+                            "name": "strobe"
+                        },
+                        {
+                            "range": [244, 255],
+                            "name": "open"
+                        }
+                    ]
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Zoom": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Focus": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "RotPrismSel": {
+                    "type": "Prism",
+                    "capabilities": [
+                        {
+                            "range": [0, 51],
+                            "name": "white",
+                            "color": "#ffffff"
+                        },
+                        {
+                            "range": [52, 103],
+                            "name": "4 face prism"
+                        },
+                        {
+                            "range": [104, 155],
+                            "name": "2 face prism"
+                        },
+                        {
+                            "range": [156, 207],
+                            "name": "cylindrical pri"
+                        },
+                        {
+                            "range": [208, 255],
+                            "name": "8 face prism"
+                        }
+                    ]
+                },
+                "RotPrism": {
+                    "type": "Prism",
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "Position"
+                        },
+                        {
+                            "range": [128, 190],
+                            "name": "Rotation"
+                        },
+                        {
+                            "range": [191, 192],
+                            "name": "Stop"
+                        },
+                        {
+                            "range": [193, 255],
+                            "name": "Rotation"
+                        }
+                    ]
+                },
+                "GoboSel": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 47],
+                            "name": "white",
+                            "color": "#ffffff"
+                        },
+                        {
+                            "range": [48, 99],
+                            "name": "gobo 1"
+                        },
+                        {
+                            "range": [100, 151],
+                            "name": "gobo 2"
+                        },
+                        {
+                            "range": [152, 203],
+                            "name": "gobo 3"
+                        },
+                        {
+                            "range": [204, 255],
+                            "name": "gobo 4"
+                        }
+                    ]
+                },
+                "RotGoboSel": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 51],
+                            "name": "open"
+                        },
+                        {
+                            "range": [52, 103],
+                            "name": "gobo 1"
+                        },
+                        {
+                            "range": [104, 155],
+                            "name": "gobo 2"
+                        },
+                        {
+                            "range": [156, 207],
+                            "name": "gobo 3"
+                        },
+                        {
+                            "range": [208, 255],
+                            "name": "gobo 4"
+                        }
+                    ]
+                },
+                "Gobo Rot": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "Position"
+                        },
+                        {
+                            "range": [128, 190],
+                            "name": "Rotation"
+                        },
+                        {
+                            "range": [191, 192],
+                            "name": "Stop"
+                        },
+                        {
+                            "range": [193, 255],
+                            "name": "Rotation"
+                        }
+                    ]
+                },
+                "Cyan": {
+                    "type": "SingleColor",
+                    "color": "Cyan",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Magenta": {
+                    "type": "SingleColor",
+                    "color": "Magenta",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Yellow": {
+                    "type": "SingleColor",
+                    "color": "Yellow",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Control": {
+                    "type": "Beam",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "lamp_off"
+                        },
+                        {
+                            "range": [128, 255],
+                            "name": "lamp_on"
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "17-channel Mode",
+                    "shortName": "17ch",
+                    "channels": [
+                        "Iris",
+                        "Color FX",
+                        "Frost/Prism",
+                        "Intensity",
+                        "Pan",
+                        "Tilt",
+                        "Zoom",
+                        "Focus",
+                        "RotPrismSel",
+                        "RotPrism",
+                        "GoboSel",
+                        "RotGoboSel",
+                        "Gobo Rot",
+                        "Cyan",
+                        "Magenta",
+                        "Yellow",
+                        "Control"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Clay Paky",
+            "name": "Stage Zoom 1200",
+            "shortName": "StageZ1200",
+            "comment": "16bit PAN + TILT (DIP 4 ON)",
+            "physical": {
+                "dimensions": [590, 590, 780],
+                "weight": 58.7,
+                "power": 2200
+            },
+            "availableChannels": {
+                "Iris": {
+                    "type": "Beam",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "Iris",
+                            "color": "#5a4fcf"
+                        }
+                    ]
+                },
+                "Colour FX": {
+                    "type": "MultiColor",
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "White",
+                            "color": "#ffffff",
+                            "center": true
+                        },
+                        {
+                            "range": [16, 31],
+                            "name": "Warm"
+                        },
+                        {
+                            "range": [32, 47],
+                            "name": "Cold"
+                        },
+                        {
+                            "range": [48, 63],
+                            "name": "Blue Hole"
+                        },
+                        {
+                            "range": [64, 80],
+                            "name": "Yellow Hole@"
+                        },
+                        {
+                            "range": [81, 96],
+                            "name": "Red",
+                            "color": "#ff0000",
+                            "center": true
+                        },
+                        {
+                            "range": [97, 112],
+                            "name": "4 Colour"
+                        },
+                        {
+                            "range": [113, 127],
+                            "name": "U.V. Filter"
+                        },
+                        {
+                            "range": [128, 255],
+                            "name": "Rotation"
+                        }
+                    ]
+                },
+                "Frost": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "Frost %"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "Closed"
+                        },
+                        {
+                            "range": [128, 139],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [140, 243],
+                            "name": "Strobe"
+                        },
+                        {
+                            "range": [244, 255],
+                            "name": "Open"
+                        }
+                    ]
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Zoom": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "Beam"
+                        }
+                    ]
+                },
+                "Focus": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "Distance"
+                        }
+                    ]
+                },
+                "Prism": {
+                    "type": "Prism",
+                    "capabilities": [
+                        {
+                            "range": [0, 51],
+                            "name": "White",
+                            "color": "#ffffff"
+                        },
+                        {
+                            "range": [52, 103],
+                            "name": "4 Face Prism",
+                            "center": true
+                        },
+                        {
+                            "range": [104, 155],
+                            "name": "2 Face Prism",
+                            "center": true
+                        },
+                        {
+                            "range": [156, 207],
+                            "name": "5 Face Prism",
+                            "center": true
+                        },
+                        {
+                            "range": [208, 255],
+                            "name": "5 Prism 3D"
+                        }
+                    ]
+                },
+                "Prism rot": {
+                    "type": "Prism",
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "Prism Pos"
+                        },
+                        {
+                            "range": [128, 190],
+                            "name": "Rot Left",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [191, 192],
+                            "name": "Rot Stop"
+                        },
+                        {
+                            "range": [193, 255],
+                            "name": "Rot Right",
+                            "showInMenu": false,
+                            "center": true
+                        }
+                    ]
+                },
+                "Fixed Gobo": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 63],
+                            "name": "White",
+                            "color": "#ffffff"
+                        },
+                        {
+                            "range": [64, 127],
+                            "name": "Gobo 1"
+                        },
+                        {
+                            "range": [128, 191],
+                            "name": "Gobo 2"
+                        },
+                        {
+                            "range": [192, 254],
+                            "name": "Gobo 3"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "Gobo 4"
+                        }
+                    ]
+                },
+                "RotGoboSel": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 51],
+                            "name": "White",
+                            "color": "#ffffff",
+                            "center": true
+                        },
+                        {
+                            "range": [52, 103],
+                            "name": "Gobo 1",
+                            "center": true
+                        },
+                        {
+                            "range": [104, 155],
+                            "name": "Gobo 2",
+                            "center": true
+                        },
+                        {
+                            "range": [156, 207],
+                            "name": "Gobo 3",
+                            "center": true
+                        },
+                        {
+                            "range": [208, 255],
+                            "name": "Gobo 4",
+                            "center": true
+                        }
+                    ]
+                },
+                "Gobo Rot": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "Position"
+                        },
+                        {
+                            "range": [128, 190],
+                            "name": "Rot Left",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [191, 192],
+                            "name": "Rot Stop"
+                        },
+                        {
+                            "range": [193, 255],
+                            "name": "Rot Right",
+                            "showInMenu": false,
+                            "center": true
+                        }
+                    ]
+                },
+                "Cyan": {
+                    "type": "SingleColor",
+                    "color": "Cyan",
+                    "invert": true,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Magenta": {
+                    "type": "SingleColor",
+                    "color": "Magenta",
+                    "invert": true,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Yellow": {
+                    "type": "SingleColor",
+                    "color": "Yellow",
+                    "invert": true,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Lamp Ctrl": {
+                    "type": "Beam",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "Lamp Off"
+                        },
+                        {
+                            "range": [128, 255],
+                            "name": "Lamp On"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "19-channel Mode",
+                    "shortName": "19ch",
+                    "channels": [
+                        "Iris",
+                        "Colour FX",
+                        "Frost",
+                        "Intensity",
+                        "Pan",
+                        "Tilt",
+                        "Zoom",
+                        "Focus",
+                        "Prism",
+                        "Prism rot",
+                        "Fixed Gobo",
+                        "RotGoboSel",
+                        "Gobo Rot",
+                        "Cyan",
+                        "Magenta",
+                        "Yellow",
+                        "Lamp Ctrl",
+                        "Pan fine",
+                        "Tilt fine"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Clay Paky",
+            "name": "Super Scan Zoom",
+            "shortName": "SScanZoom",
+            "physical": {
+                "dimensions": [440, 440, 1470],
+                "weight": 44.5,
+                "power": 1500
+            },
+            "availableChannels": {
+                "Iris/Gobo": {
+                    "type": "Gobo",
+                    "defaultValue": 191,
+                    "highlightValue": 191,
+                    "capabilities": [
+                        {
+                            "range": [0, 64],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [65, 191],
+                            "name": "open"
+                        },
+                        {
+                            "range": [192, 254],
+                            "name": "index"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "rotation"
+                        }
+                    ]
+                },
+                "Color": {
+                    "type": "MultiColor",
+                    "capabilities": [
+                        {
+                            "range": [0, 7],
+                            "name": "white",
+                            "color": "#ffffff"
+                        },
+                        {
+                            "range": [8, 24],
+                            "name": "split colors"
+                        },
+                        {
+                            "range": [25, 41],
+                            "name": "red",
+                            "color": "#ff0000"
+                        },
+                        {
+                            "range": [42, 58],
+                            "name": "congo"
+                        },
+                        {
+                            "range": [59, 74],
+                            "name": "blue",
+                            "color": "#0000ff"
+                        },
+                        {
+                            "range": [75, 89],
+                            "name": "yellow",
+                            "color": "#ffff00"
+                        },
+                        {
+                            "range": [90, 107],
+                            "name": "warm"
+                        },
+                        {
+                            "range": [108, 127],
+                            "name": "cold"
+                        },
+                        {
+                            "range": [128, 255],
+                            "name": "rotation"
+                        }
+                    ]
+                },
+                "gobo": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 18],
+                            "name": "open"
+                        },
+                        {
+                            "range": [19, 31],
+                            "name": "radial"
+                        },
+                        {
+                            "range": [32, 44],
+                            "name": "triangle"
+                        },
+                        {
+                            "range": [45, 56],
+                            "name": "cog"
+                        },
+                        {
+                            "range": [57, 63],
+                            "name": "line"
+                        },
+                        {
+                            "range": [64, 79],
+                            "name": "swirl",
+                            "color": "#d3cdc5"
+                        },
+                        {
+                            "range": [80, 95],
+                            "name": "star"
+                        },
+                        {
+                            "range": [96, 111],
+                            "name": "cone"
+                        },
+                        {
+                            "range": [112, 127],
+                            "name": "radical+triangl"
+                        },
+                        {
+                            "range": [128, 143],
+                            "name": "radical+radial"
+                        },
+                        {
+                            "range": [144, 159],
+                            "name": "cone+radial"
+                        },
+                        {
+                            "range": [160, 175],
+                            "name": "star+radial"
+                        },
+                        {
+                            "range": [176, 197],
+                            "name": "swirl+radial"
+                        },
+                        {
+                            "range": [198, 209],
+                            "name": "swirl",
+                            "color": "#d3cdc5"
+                        },
+                        {
+                            "range": [210, 222],
+                            "name": "cone"
+                        },
+                        {
+                            "range": [223, 255],
+                            "name": "radical"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 129],
+                            "name": "%"
+                        },
+                        {
+                            "range": [140, 241],
+                            "name": "open"
+                        },
+                        {
+                            "range": [242, 254],
+                            "name": "strobe"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "open"
+                        }
+                    ]
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Effects": {
+                    "type": "Effect",
+                    "capabilities": [
+                        {
+                            "range": [0, 25],
+                            "name": "open"
+                        },
+                        {
+                            "range": [26, 50],
+                            "name": "frost",
+                            "color": "#edf5dd"
+                        },
+                        {
+                            "range": [51, 75],
+                            "name": "Heavy Frost"
+                        },
+                        {
+                            "range": [76, 95],
+                            "name": "prism 1"
+                        },
+                        {
+                            "range": [96, 178],
+                            "name": "prism 1 rotatio"
+                        },
+                        {
+                            "range": [179, 195],
+                            "name": "prism 2"
+                        },
+                        {
+                            "range": [196, 255],
+                            "name": "prism 2 rotatio"
+                        }
+                    ]
+                },
+                "Zoom": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Focus": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Cyan": {
+                    "type": "SingleColor",
+                    "color": "Cyan",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Magenta": {
+                    "type": "SingleColor",
+                    "color": "Magenta",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Yellow": {
+                    "type": "SingleColor",
+                    "color": "Yellow",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "12-channel Mode",
+                    "shortName": "12ch",
+                    "channels": [
+                        "Iris/Gobo",
+                        "Color",
+                        "gobo",
+                        "Intensity",
+                        "Pan",
+                        "Tilt",
+                        "Effects",
+                        "Zoom",
+                        "Focus",
+                        "Cyan",
+                        "Magenta",
+                        "Yellow"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Clay Paky",
+            "name": "Tornado",
+            "shortName": "Tornado",
+            "physical": {
+                "dimensions": [1000, 1000, 500],
+                "weight": 35,
+                "power": 1500
+            },
+            "availableChannels": {
+                "Color": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "Colors"
+                        },
+                        {
+                            "range": [128, 255],
+                            "name": "Rotation"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 128],
+                            "name": "Intensity"
+                        },
+                        {
+                            "range": [129, 255],
+                            "name": "strobe"
+                        }
+                    ]
+                },
+                "Pan 1+4": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Tilt 1+4": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Pan 2+5": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Tilt 2+5": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Pan 3+6": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Tilt 3+6": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "8-channel Mode",
+                    "shortName": "8ch",
+                    "channels": [
+                        "Color",
+                        "Intensity",
+                        "Pan 1+4",
+                        "Tilt 1+4",
+                        "Pan 2+5",
+                        "Tilt 2+5",
+                        "Pan 3+6",
+                        "Tilt 3+6"
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/fixtures/imports/ecue-MainLibrary/Coemar.json
+++ b/fixtures/imports/ecue-MainLibrary/Coemar.json
@@ -1,0 +1,6023 @@
+{
+    "manufacturers": {
+        "Coemar": {
+            "name": "Coemar",
+            "website": "www.coemar.it"
+        }
+    },
+    "fixtures": [
+        {
+            "manufacturer": "Coemar",
+            "name": "CF1200",
+            "shortName": "CF1200",
+            "physical": {
+                "dimensions": [550, 550, 750]
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Strobe": {
+                    "type": "Strobe",
+                    "defaultValue": 255,
+                    "capabilities": [
+                        {
+                            "range": [0, 9],
+                            "name": "Closed"
+                        },
+                        {
+                            "range": [10, 127],
+                            "name": "Speed"
+                        },
+                        {
+                            "range": [128, 247],
+                            "name": "Random"
+                        },
+                        {
+                            "range": [248, 255],
+                            "name": "Open"
+                        }
+                    ]
+                },
+                "Iris": {
+                    "type": "Beam",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 9],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [10, 255],
+                            "name": "Size"
+                        }
+                    ]
+                },
+                "Filter": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [16, 217],
+                            "name": "Filter 1"
+                        },
+                        {
+                            "range": [218, 255],
+                            "name": "Filter 2"
+                        }
+                    ]
+                },
+                "Colour": {
+                    "type": "MultiColor",
+                    "capabilities": [
+                        {
+                            "range": [0, 24],
+                            "name": "Open",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [25, 49],
+                            "name": "Colour 1",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [50, 73],
+                            "name": "Colour 2",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [74, 99],
+                            "name": "Colour 3",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [100, 123],
+                            "name": "Colour 4",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [124, 151],
+                            "name": "Colour 5",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [152, 255],
+                            "name": "Rotation",
+                            "showInMenu": false,
+                            "center": true
+                        }
+                    ]
+                },
+                "Cyan": {
+                    "type": "SingleColor",
+                    "color": "Cyan",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Magenta": {
+                    "type": "SingleColor",
+                    "color": "Magenta",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Yellow": {
+                    "type": "SingleColor",
+                    "color": "Yellow",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Control": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 19],
+                            "name": "Lamp On"
+                        },
+                        {
+                            "range": [20, 100],
+                            "name": "Home"
+                        },
+                        {
+                            "range": [101, 240],
+                            "name": "Reset"
+                        },
+                        {
+                            "range": [241, 255],
+                            "name": "Lamp On"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "13-channel Mode",
+                    "shortName": "13ch",
+                    "channels": [
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "Intensity",
+                        "Strobe",
+                        "Iris",
+                        "Filter",
+                        "Colour",
+                        "Cyan",
+                        "Magenta",
+                        "Yellow",
+                        "Control"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Coemar",
+            "name": "CF1200 Hard Edge",
+            "shortName": "CF1200HE",
+            "physical": {
+                "dimensions": [650, 650, 990]
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Strobe": {
+                    "type": "Strobe",
+                    "defaultValue": 255,
+                    "capabilities": [
+                        {
+                            "range": [0, 9],
+                            "name": "Closed"
+                        },
+                        {
+                            "range": [10, 127],
+                            "name": "Speed"
+                        },
+                        {
+                            "range": [128, 247],
+                            "name": "Random"
+                        },
+                        {
+                            "range": [248, 255],
+                            "name": "Open"
+                        }
+                    ]
+                },
+                "Iris": {
+                    "type": "Beam",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [16, 115],
+                            "name": "Size"
+                        },
+                        {
+                            "range": [116, 192],
+                            "name": "Small"
+                        },
+                        {
+                            "range": [193, 251],
+                            "name": "Pulse"
+                        },
+                        {
+                            "range": [252, 255],
+                            "name": "Maximum"
+                        }
+                    ]
+                },
+                "Zoom": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "Beam"
+                        }
+                    ]
+                },
+                "Focus": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "Distance"
+                        }
+                    ]
+                },
+                "Gobo 1": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 30],
+                            "name": "Open",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [31, 61],
+                            "name": "Gobo 1",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [62, 91],
+                            "name": "Gobo 2",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [92, 123],
+                            "name": "Gobo 3",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [124, 151],
+                            "name": "Gobo 4",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [152, 255],
+                            "name": "Rotation",
+                            "showInMenu": false,
+                            "center": true
+                        }
+                    ]
+                },
+                "Gobo 1 Pos": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "Position"
+                        }
+                    ]
+                },
+                "Gobo 1 Rot": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 100],
+                            "name": "Fine Pos"
+                        },
+                        {
+                            "range": [101, 176],
+                            "name": "Rot Right",
+                            "center": true
+                        },
+                        {
+                            "range": [177, 179],
+                            "name": "Stop"
+                        },
+                        {
+                            "range": [180, 255],
+                            "name": "Rot Left",
+                            "center": true
+                        }
+                    ]
+                },
+                "Gobo 2": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 23],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [24, 49],
+                            "name": "Gobo 1"
+                        },
+                        {
+                            "range": [50, 73],
+                            "name": "Gobo 2"
+                        },
+                        {
+                            "range": [74, 99],
+                            "name": "Gobo 3"
+                        },
+                        {
+                            "range": [100, 123],
+                            "name": "Gobo 4"
+                        },
+                        {
+                            "range": [124, 151],
+                            "name": "Gobo 5"
+                        },
+                        {
+                            "range": [152, 255],
+                            "name": "Rotation",
+                            "center": true
+                        }
+                    ]
+                },
+                "FX": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 62],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [63, 126],
+                            "name": "FX 1"
+                        },
+                        {
+                            "range": [127, 190],
+                            "name": "FX 2"
+                        },
+                        {
+                            "range": [191, 255],
+                            "name": "FX 3"
+                        }
+                    ]
+                },
+                "FX Rot": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "Speed"
+                        }
+                    ]
+                },
+                "Colour": {
+                    "type": "MultiColor",
+                    "capabilities": [
+                        {
+                            "range": [0, 23],
+                            "name": "Open",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [24, 49],
+                            "name": "Colour 1",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [50, 73],
+                            "name": "Colour 2",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [74, 99],
+                            "name": "Colour 3",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [100, 123],
+                            "name": "Colour 4",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [124, 151],
+                            "name": "Colour 5",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [152, 255],
+                            "name": "Rotation",
+                            "showInMenu": false,
+                            "center": true
+                        }
+                    ]
+                },
+                "Cyan": {
+                    "type": "SingleColor",
+                    "color": "Cyan",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Magenta": {
+                    "type": "SingleColor",
+                    "color": "Magenta",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Yellow": {
+                    "type": "SingleColor",
+                    "color": "Yellow",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Control": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 19],
+                            "name": "Lamp On"
+                        },
+                        {
+                            "range": [20, 100],
+                            "name": "Home"
+                        },
+                        {
+                            "range": [101, 240],
+                            "name": "Reset"
+                        },
+                        {
+                            "range": [241, 255],
+                            "name": "Lamp On"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "20-channel Mode",
+                    "shortName": "20ch",
+                    "channels": [
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "Intensity",
+                        "Strobe",
+                        "Iris",
+                        "Zoom",
+                        "Focus",
+                        "Gobo 1",
+                        "Gobo 1 Pos",
+                        "Gobo 1 Rot",
+                        "Gobo 2",
+                        "FX",
+                        "FX Rot",
+                        "Colour",
+                        "Cyan",
+                        "Magenta",
+                        "Yellow",
+                        "Control"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Coemar",
+            "name": "CF7 HEX",
+            "shortName": "CF7",
+            "comment": "cd",
+            "physical": {
+                "dimensions": [525, 525, 900]
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Shutter": {
+                    "type": "Shutter",
+                    "highlightValue": 255,
+                    "capabilities": [
+                        {
+                            "range": [0, 9],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [10, 127],
+                            "name": "strobe"
+                        },
+                        {
+                            "range": [128, 247],
+                            "name": "random strobe"
+                        },
+                        {
+                            "range": [248, 255],
+                            "name": "open"
+                        }
+                    ]
+                },
+                "Iris": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "open"
+                        },
+                        {
+                            "range": [16, 115],
+                            "name": "%"
+                        },
+                        {
+                            "range": [116, 192],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [193, 251],
+                            "name": "pulse"
+                        },
+                        {
+                            "range": [252, 255],
+                            "name": "open"
+                        }
+                    ]
+                },
+                "Zoom": {
+                    "type": "Beam",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Focus": {
+                    "type": "Beam",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Gobo1": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 20],
+                            "name": "open"
+                        },
+                        {
+                            "range": [21, 42],
+                            "name": "slot1"
+                        },
+                        {
+                            "range": [43, 64],
+                            "name": "slot2"
+                        },
+                        {
+                            "range": [65, 86],
+                            "name": "slot3"
+                        },
+                        {
+                            "range": [87, 108],
+                            "name": "slot4"
+                        },
+                        {
+                            "range": [109, 130],
+                            "name": "slot5"
+                        },
+                        {
+                            "range": [131, 151],
+                            "name": "slot6"
+                        },
+                        {
+                            "range": [152, 255],
+                            "name": ">>"
+                        }
+                    ]
+                },
+                "Gobo1 ind.": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 10],
+                            "name": "0"
+                        },
+                        {
+                            "range": [11, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Gobo1 rot.": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 100],
+                            "name": "ind. fine"
+                        },
+                        {
+                            "range": [101, 176],
+                            "name": ">>"
+                        },
+                        {
+                            "range": [177, 179],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [180, 255],
+                            "name": "<<"
+                        }
+                    ]
+                },
+                "Gobo2": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 20],
+                            "name": "open"
+                        },
+                        {
+                            "range": [21, 42],
+                            "name": "slot1"
+                        },
+                        {
+                            "range": [43, 64],
+                            "name": "slot2"
+                        },
+                        {
+                            "range": [65, 86],
+                            "name": "slot3"
+                        },
+                        {
+                            "range": [87, 108],
+                            "name": "slot4"
+                        },
+                        {
+                            "range": [109, 130],
+                            "name": "slot5"
+                        },
+                        {
+                            "range": [131, 151],
+                            "name": "slot6"
+                        },
+                        {
+                            "range": [152, 255],
+                            "name": ">>"
+                        }
+                    ]
+                },
+                "Prisma/Lens": {
+                    "type": "Prism",
+                    "capabilities": [
+                        {
+                            "range": [0, 83],
+                            "name": "open"
+                        },
+                        {
+                            "range": [84, 171],
+                            "name": "slot1"
+                        },
+                        {
+                            "range": [172, 255],
+                            "name": "slot2"
+                        }
+                    ]
+                },
+                "Prisma/Lens rot": {
+                    "type": "Prism",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 128],
+                            "name": "ind."
+                        },
+                        {
+                            "range": [129, 189],
+                            "name": ">>"
+                        },
+                        {
+                            "range": [190, 192],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [193, 255],
+                            "name": "<<"
+                        }
+                    ]
+                },
+                "Focal lens": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 85],
+                            "name": "iris focal lens"
+                        },
+                        {
+                            "range": [86, 170],
+                            "name": "gobo focal lens"
+                        },
+                        {
+                            "range": [171, 255],
+                            "name": "narrow angle"
+                        }
+                    ]
+                },
+                "Cyan": {
+                    "type": "SingleColor",
+                    "color": "Cyan",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Magenta": {
+                    "type": "SingleColor",
+                    "color": "Magenta",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Yellow": {
+                    "type": "SingleColor",
+                    "color": "Yellow",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Reset": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 10],
+                            "name": "lamp off"
+                        },
+                        {
+                            "range": [11, 29],
+                            "name": "idle"
+                        },
+                        {
+                            "range": [30, 100],
+                            "name": "home"
+                        },
+                        {
+                            "range": [101, 170],
+                            "name": "reset"
+                        },
+                        {
+                            "range": [171, 200],
+                            "name": "zoom free"
+                        },
+                        {
+                            "range": [201, 240],
+                            "name": "fast autofocus"
+                        },
+                        {
+                            "range": [241, 249],
+                            "name": "prog. autofocus"
+                        },
+                        {
+                            "range": [250, 255],
+                            "name": "lamp on"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "20-channel Mode",
+                    "shortName": "20ch",
+                    "channels": [
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "Intensity",
+                        "Shutter",
+                        "Iris",
+                        "Zoom",
+                        "Focus",
+                        "Gobo1",
+                        "Gobo1 ind.",
+                        "Gobo1 rot.",
+                        "Gobo2",
+                        "Prisma/Lens",
+                        "Prisma/Lens rot",
+                        "Focal lens",
+                        "Cyan",
+                        "Magenta",
+                        "Yellow",
+                        "Reset"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Coemar",
+            "name": "iSpot 150",
+            "shortName": "iSpot 150",
+            "physical": {
+                "dimensions": [350, 350, 470]
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 0,
+                    "highlightValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 0,
+                    "highlightValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Speed": {
+                    "type": "Speed",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 10],
+                            "name": "Standard"
+                        },
+                        {
+                            "range": [11, 25],
+                            "name": "Ultra Fast"
+                        },
+                        {
+                            "range": [26, 127],
+                            "name": "Vector"
+                        },
+                        {
+                            "range": [128, 247],
+                            "name": "Tracking"
+                        },
+                        {
+                            "range": [248, 255],
+                            "name": "Track Slow"
+                        }
+                    ]
+                },
+                "Shutter": {
+                    "type": "Shutter",
+                    "capabilities": [
+                        {
+                            "range": [0, 9],
+                            "name": "Closed"
+                        },
+                        {
+                            "range": [10, 127],
+                            "name": "Syncro"
+                        },
+                        {
+                            "range": [128, 130],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [131, 248],
+                            "name": "Random"
+                        },
+                        {
+                            "range": [249, 255],
+                            "name": "Open"
+                        }
+                    ]
+                },
+                "Focus": {
+                    "type": "Beam",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Gobo": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 10],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [11, 30],
+                            "name": "Gobo 1",
+                            "center": true
+                        },
+                        {
+                            "range": [31, 50],
+                            "name": "Gobo 2",
+                            "center": true
+                        },
+                        {
+                            "range": [51, 70],
+                            "name": "Gobo 3",
+                            "center": true
+                        },
+                        {
+                            "range": [71, 90],
+                            "name": "Gobo 4",
+                            "center": true
+                        },
+                        {
+                            "range": [91, 110],
+                            "name": "Gobo 5",
+                            "center": true
+                        },
+                        {
+                            "range": [111, 127],
+                            "name": "Gobo 6",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 192],
+                            "name": "Continuous"
+                        },
+                        {
+                            "range": [193, 255],
+                            "name": "Rotation"
+                        }
+                    ]
+                },
+                "Gobo Indexing": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 10],
+                            "name": "no effect",
+                            "center": true
+                        },
+                        {
+                            "range": [11, 255],
+                            "name": "gobo position"
+                        }
+                    ]
+                },
+                "Gobo Rotation": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 10],
+                            "name": "no effect",
+                            "center": true
+                        },
+                        {
+                            "range": [11, 131],
+                            "name": "fast to slow"
+                        },
+                        {
+                            "range": [132, 134],
+                            "name": "gobo stop",
+                            "center": true
+                        },
+                        {
+                            "range": [135, 255],
+                            "name": "slow to fast"
+                        }
+                    ]
+                },
+                "Color": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 5],
+                            "name": "Open",
+                            "center": true
+                        },
+                        {
+                            "range": [6, 13],
+                            "name": "Color 1",
+                            "center": true
+                        },
+                        {
+                            "range": [14, 20],
+                            "name": "Color 2",
+                            "center": true
+                        },
+                        {
+                            "range": [21, 27],
+                            "name": "Color 3"
+                        },
+                        {
+                            "range": [28, 34],
+                            "name": "Color 4",
+                            "center": true
+                        },
+                        {
+                            "range": [35, 41],
+                            "name": "Color 5",
+                            "center": true
+                        },
+                        {
+                            "range": [42, 48],
+                            "name": "Color 6",
+                            "center": true
+                        },
+                        {
+                            "range": [49, 59],
+                            "name": "Color 7",
+                            "center": true
+                        },
+                        {
+                            "range": [60, 127],
+                            "name": "Continuous"
+                        },
+                        {
+                            "range": [128, 190],
+                            "name": "Color Roll Fwd"
+                        },
+                        {
+                            "range": [191, 192],
+                            "name": "no rotation",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [193, 255],
+                            "name": "Color Roll Bkwd"
+                        }
+                    ]
+                },
+                "Gobo Shake": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 9],
+                            "name": "No effect",
+                            "center": true
+                        },
+                        {
+                            "range": [10, 249],
+                            "name": "Gobo shake",
+                            "center": true
+                        },
+                        {
+                            "range": [250, 255],
+                            "name": "Black out",
+                            "center": true
+                        }
+                    ]
+                },
+                "Control": {
+                    "type": "Beam",
+                    "defaultValue": 50,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 19],
+                            "name": "Lamp Off",
+                            "center": true
+                        },
+                        {
+                            "range": [20, 100],
+                            "name": "Idle",
+                            "center": true
+                        },
+                        {
+                            "range": [101, 170],
+                            "name": "Effect Rst",
+                            "center": true
+                        },
+                        {
+                            "range": [171, 200],
+                            "name": "Mtr Reset",
+                            "center": true
+                        },
+                        {
+                            "range": [201, 240],
+                            "name": "Silent",
+                            "center": true
+                        },
+                        {
+                            "range": [241, 255],
+                            "name": "Lamp On",
+                            "center": true
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "13-channel Mode",
+                    "shortName": "13ch",
+                    "channels": [
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "Speed",
+                        "Shutter",
+                        "Focus",
+                        "Gobo",
+                        "Gobo Indexing",
+                        "Gobo Rotation",
+                        "Color",
+                        "Gobo Shake",
+                        "Control"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Coemar",
+            "name": "iSpot 575",
+            "shortName": "iSpot575",
+            "physical": {
+                "dimensions": [525, 525, 680]
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Shutter": {
+                    "type": "Shutter",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 9],
+                            "name": "closed",
+                            "center": true
+                        },
+                        {
+                            "range": [10, 66],
+                            "name": "synchro"
+                        },
+                        {
+                            "range": [67, 68],
+                            "name": "open"
+                        },
+                        {
+                            "range": [69, 125],
+                            "name": "pulse_sl"
+                        },
+                        {
+                            "range": [126, 127],
+                            "name": "open"
+                        },
+                        {
+                            "range": [128, 184],
+                            "name": "pulse_ff"
+                        },
+                        {
+                            "range": [185, 187],
+                            "name": "open"
+                        },
+                        {
+                            "range": [188, 244],
+                            "name": "random"
+                        },
+                        {
+                            "range": [245, 255],
+                            "name": "open"
+                        }
+                    ]
+                },
+                "Iris": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 9],
+                            "name": "open"
+                        },
+                        {
+                            "range": [10, 124],
+                            "name": "L->S"
+                        },
+                        {
+                            "range": [125, 129],
+                            "name": "small"
+                        },
+                        {
+                            "range": [130, 189],
+                            "name": "pulse"
+                        },
+                        {
+                            "range": [190, 192],
+                            "name": "open"
+                        },
+                        {
+                            "range": [193, 251],
+                            "name": "pulse_flash"
+                        },
+                        {
+                            "range": [252, 255],
+                            "name": "open"
+                        }
+                    ]
+                },
+                "Zoom": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Focus": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Gobo1_Sel": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Gobo1_Adj": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Gobo1_Rot": {
+                    "type": "Gobo",
+                    "defaultValue": 178,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Gobo2_Sel": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Gobo2_Adj": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Gobo2_Rot": {
+                    "type": "Gobo",
+                    "defaultValue": 178,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Prism_Sel": {
+                    "type": "Prism",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 10],
+                            "name": "no_Prism",
+                            "center": true
+                        },
+                        {
+                            "range": [11, 20],
+                            "name": "Prism"
+                        },
+                        {
+                            "range": [21, 136],
+                            "name": "Prism_R"
+                        },
+                        {
+                            "range": [137, 139],
+                            "name": "Stop",
+                            "center": true
+                        },
+                        {
+                            "range": [140, 255],
+                            "name": "Prism L"
+                        }
+                    ]
+                },
+                "Color 1": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 7],
+                            "name": "open",
+                            "center": true
+                        },
+                        {
+                            "range": [8, 27],
+                            "name": "color 1"
+                        },
+                        {
+                            "range": [28, 47],
+                            "name": "color 2"
+                        },
+                        {
+                            "range": [48, 67],
+                            "name": "color 3"
+                        },
+                        {
+                            "range": [68, 87],
+                            "name": "color 4"
+                        },
+                        {
+                            "range": [88, 107],
+                            "name": "color 5"
+                        },
+                        {
+                            "range": [108, 127],
+                            "name": "color 6"
+                        },
+                        {
+                            "range": [128, 190],
+                            "name": "rainbow"
+                        },
+                        {
+                            "range": [191, 192],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [193, 255],
+                            "name": "rainbow"
+                        }
+                    ]
+                },
+                "Color 2": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 7],
+                            "name": "open",
+                            "center": true
+                        },
+                        {
+                            "range": [8, 27],
+                            "name": "color 1"
+                        },
+                        {
+                            "range": [28, 47],
+                            "name": "color 2"
+                        },
+                        {
+                            "range": [48, 67],
+                            "name": "color 3"
+                        },
+                        {
+                            "range": [68, 87],
+                            "name": "color 4"
+                        },
+                        {
+                            "range": [88, 107],
+                            "name": "color 5"
+                        },
+                        {
+                            "range": [108, 127],
+                            "name": "color 6"
+                        },
+                        {
+                            "range": [128, 190],
+                            "name": "rainbow"
+                        },
+                        {
+                            "range": [191, 192],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [193, 255],
+                            "name": "rainbow"
+                        }
+                    ]
+                },
+                "mode": {
+                    "type": "Beam",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Lamp": {
+                    "type": "Beam",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 10],
+                            "name": "off"
+                        },
+                        {
+                            "range": [11, 29],
+                            "name": "park"
+                        },
+                        {
+                            "range": [30, 65],
+                            "name": "focus_reset",
+                            "center": true
+                        },
+                        {
+                            "range": [66, 170],
+                            "name": "all_reset"
+                        },
+                        {
+                            "range": [171, 249],
+                            "name": "inhibit_autolen"
+                        },
+                        {
+                            "range": [250, 255],
+                            "name": "On"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "20-channel Mode",
+                    "shortName": "20ch",
+                    "channels": [
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "Intensity",
+                        "Shutter",
+                        "Iris",
+                        "Zoom",
+                        "Focus",
+                        "Gobo1_Sel",
+                        "Gobo1_Adj",
+                        "Gobo1_Rot",
+                        "Gobo2_Sel",
+                        "Gobo2_Adj",
+                        "Gobo2_Rot",
+                        "Prism_Sel",
+                        "Color 1",
+                        "Color 2",
+                        "mode",
+                        "Lamp"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Coemar",
+            "name": "iSpot 575 EB",
+            "shortName": "iSpot575 EB",
+            "physical": {
+                "dimensions": [525, 525, 680]
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "P/T Speed": {
+                    "type": "Speed",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Shutter": {
+                    "type": "Shutter",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 9],
+                            "name": "closed",
+                            "center": true
+                        },
+                        {
+                            "range": [10, 66],
+                            "name": "synchro"
+                        },
+                        {
+                            "range": [67, 68],
+                            "name": "open"
+                        },
+                        {
+                            "range": [69, 125],
+                            "name": "pulse_sl"
+                        },
+                        {
+                            "range": [126, 127],
+                            "name": "open"
+                        },
+                        {
+                            "range": [128, 184],
+                            "name": "pulse_ff"
+                        },
+                        {
+                            "range": [185, 187],
+                            "name": "open"
+                        },
+                        {
+                            "range": [188, 244],
+                            "name": "random"
+                        },
+                        {
+                            "range": [245, 255],
+                            "name": "open"
+                        }
+                    ]
+                },
+                "Iris": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 9],
+                            "name": "open"
+                        },
+                        {
+                            "range": [10, 124],
+                            "name": "L->S"
+                        },
+                        {
+                            "range": [125, 129],
+                            "name": "small"
+                        },
+                        {
+                            "range": [130, 189],
+                            "name": "pulse"
+                        },
+                        {
+                            "range": [190, 192],
+                            "name": "open"
+                        },
+                        {
+                            "range": [193, 251],
+                            "name": "pulse_flash"
+                        },
+                        {
+                            "range": [252, 255],
+                            "name": "open"
+                        }
+                    ]
+                },
+                "Zoom": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Focus": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Gobo1_Sel": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Gobo1_Adj": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Gobo1_Rot": {
+                    "type": "Gobo",
+                    "defaultValue": 178,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Gobo2_Sel": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Gobo2_Adj": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Gobo2_Rot": {
+                    "type": "Gobo",
+                    "defaultValue": 178,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Prism_Sel": {
+                    "type": "Prism",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 10],
+                            "name": "no_Prism",
+                            "center": true
+                        },
+                        {
+                            "range": [11, 20],
+                            "name": "Prism"
+                        },
+                        {
+                            "range": [21, 136],
+                            "name": "Prism_R"
+                        },
+                        {
+                            "range": [137, 139],
+                            "name": "Stop",
+                            "center": true
+                        },
+                        {
+                            "range": [140, 255],
+                            "name": "Prism L"
+                        }
+                    ]
+                },
+                "Color 1": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 7],
+                            "name": "open",
+                            "center": true
+                        },
+                        {
+                            "range": [8, 27],
+                            "name": "color 1"
+                        },
+                        {
+                            "range": [28, 47],
+                            "name": "color 2"
+                        },
+                        {
+                            "range": [48, 67],
+                            "name": "color 3"
+                        },
+                        {
+                            "range": [68, 87],
+                            "name": "color 4"
+                        },
+                        {
+                            "range": [88, 107],
+                            "name": "color 5"
+                        },
+                        {
+                            "range": [108, 127],
+                            "name": "color 6"
+                        },
+                        {
+                            "range": [128, 190],
+                            "name": "rainbow"
+                        },
+                        {
+                            "range": [191, 192],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [193, 255],
+                            "name": "rainbow"
+                        }
+                    ]
+                },
+                "Color 2": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 7],
+                            "name": "open",
+                            "center": true
+                        },
+                        {
+                            "range": [8, 27],
+                            "name": "color 1"
+                        },
+                        {
+                            "range": [28, 47],
+                            "name": "color 2"
+                        },
+                        {
+                            "range": [48, 67],
+                            "name": "color 3"
+                        },
+                        {
+                            "range": [68, 87],
+                            "name": "color 4"
+                        },
+                        {
+                            "range": [88, 107],
+                            "name": "color 5"
+                        },
+                        {
+                            "range": [108, 127],
+                            "name": "color 6"
+                        },
+                        {
+                            "range": [128, 190],
+                            "name": "rainbow"
+                        },
+                        {
+                            "range": [191, 192],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [193, 255],
+                            "name": "rainbow"
+                        }
+                    ]
+                },
+                "mode": {
+                    "type": "Beam",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Zap": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Control": {
+                    "type": "Beam",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 10],
+                            "name": "off"
+                        },
+                        {
+                            "range": [11, 29],
+                            "name": "park"
+                        },
+                        {
+                            "range": [30, 65],
+                            "name": "focus_reset",
+                            "center": true
+                        },
+                        {
+                            "range": [66, 170],
+                            "name": "all_reset"
+                        },
+                        {
+                            "range": [171, 249],
+                            "name": "inhibit_autolen"
+                        },
+                        {
+                            "range": [250, 255],
+                            "name": "On"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "22-channel Mode",
+                    "shortName": "22ch",
+                    "channels": [
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "P/T Speed",
+                        "Intensity",
+                        "Shutter",
+                        "Iris",
+                        "Zoom",
+                        "Focus",
+                        "Gobo1_Sel",
+                        "Gobo1_Adj",
+                        "Gobo1_Rot",
+                        "Gobo2_Sel",
+                        "Gobo2_Adj",
+                        "Gobo2_Rot",
+                        "Prism_Sel",
+                        "Color 1",
+                        "Color 2",
+                        "mode",
+                        "Zap",
+                        "Control"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Coemar",
+            "name": "IWash575",
+            "shortName": "IWash575",
+            "physical": {
+                "dimensions": [500, 500, 650]
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "crossfade": true,
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "crossfade": true,
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "crossfade": true,
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "crossfade": true,
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "Speed": {
+                    "type": "Speed",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 10],
+                            "name": "standard"
+                        },
+                        {
+                            "range": [11, 25],
+                            "name": "fast"
+                        },
+                        {
+                            "range": [26, 127],
+                            "name": "vector"
+                        },
+                        {
+                            "range": [128, 255],
+                            "name": "Tracking"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Shutter": {
+                    "type": "Shutter",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 9],
+                            "name": "blackout"
+                        },
+                        {
+                            "range": [10, 66],
+                            "name": "strobe"
+                        },
+                        {
+                            "range": [67, 68],
+                            "name": "open"
+                        },
+                        {
+                            "range": [69, 125],
+                            "name": "pulse"
+                        },
+                        {
+                            "range": [126, 127],
+                            "name": "open"
+                        },
+                        {
+                            "range": [128, 184],
+                            "name": "pulse"
+                        },
+                        {
+                            "range": [185, 187],
+                            "name": "open"
+                        },
+                        {
+                            "range": [188, 244],
+                            "name": "random strobe"
+                        },
+                        {
+                            "range": [245, 255],
+                            "name": "open"
+                        }
+                    ]
+                },
+                "Beam": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Filter": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 9],
+                            "name": "none"
+                        },
+                        {
+                            "range": [10, 230],
+                            "name": "Oval"
+                        },
+                        {
+                            "range": [231, 255],
+                            "name": "CTO"
+                        }
+                    ]
+                },
+                "Color": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 7],
+                            "name": "open"
+                        },
+                        {
+                            "range": [8, 27],
+                            "name": "Colour 1"
+                        },
+                        {
+                            "range": [28, 47],
+                            "name": "Colour 2"
+                        },
+                        {
+                            "range": [48, 67],
+                            "name": "Colour 3"
+                        },
+                        {
+                            "range": [68, 87],
+                            "name": "Colour 4"
+                        },
+                        {
+                            "range": [88, 107],
+                            "name": "Colour 5"
+                        },
+                        {
+                            "range": [108, 127],
+                            "name": "Colour 6"
+                        },
+                        {
+                            "range": [128, 190],
+                            "name": "rainbow cw"
+                        },
+                        {
+                            "range": [191, 192],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [192, 255],
+                            "name": "rainbow ccw"
+                        }
+                    ]
+                },
+                "Cyan": {
+                    "type": "SingleColor",
+                    "color": "Cyan",
+                    "crossfade": true
+                },
+                "Magenta": {
+                    "type": "SingleColor",
+                    "color": "Magenta",
+                    "crossfade": true
+                },
+                "Yellow": {
+                    "type": "SingleColor",
+                    "color": "Yellow",
+                    "crossfade": true
+                },
+                "CPosition": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 125],
+                            "name": "125",
+                            "center": true
+                        },
+                        {
+                            "range": [126, 255],
+                            "name": "proportional"
+                        }
+                    ]
+                },
+                "zap": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 10],
+                            "name": "none"
+                        },
+                        {
+                            "range": [11, 30],
+                            "name": "sync strobe"
+                        },
+                        {
+                            "range": [31, 249],
+                            "name": "flicker"
+                        },
+                        {
+                            "range": [250, 255],
+                            "name": "dbo move"
+                        }
+                    ]
+                },
+                "control": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 10],
+                            "name": "no function"
+                        },
+                        {
+                            "range": [11, 29],
+                            "name": "lamp off"
+                        },
+                        {
+                            "range": [30, 65],
+                            "name": "move reset"
+                        },
+                        {
+                            "range": [66, 100],
+                            "name": "reset motors wo"
+                        },
+                        {
+                            "range": [101, 135],
+                            "name": "reset motors wo"
+                        },
+                        {
+                            "range": [136, 170],
+                            "name": "reset motors"
+                        },
+                        {
+                            "range": [171, 249],
+                            "name": "fan max"
+                        },
+                        {
+                            "range": [250, 255],
+                            "name": "lamp on"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "16-channel Mode",
+                    "shortName": "16ch",
+                    "channels": [
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "Speed",
+                        "Intensity",
+                        "Shutter",
+                        "Beam",
+                        "Filter",
+                        "Color",
+                        "Cyan",
+                        "Magenta",
+                        "Yellow",
+                        "CPosition",
+                        "zap",
+                        "control"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Coemar",
+            "name": "NAT MM Zoom 1200",
+            "shortName": "NATMMZ1200",
+            "physical": {
+                "dimensions": [500, 500, 700]
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Strobe": {
+                    "type": "Strobe",
+                    "defaultValue": 80,
+                    "highlightValue": 80,
+                    "capabilities": [
+                        {
+                            "range": [0, 79],
+                            "name": "Closed"
+                        },
+                        {
+                            "range": [80, 127],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [128, 255],
+                            "name": "Speed"
+                        }
+                    ]
+                },
+                "Iris": {
+                    "type": "Beam",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 35],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [36, 115],
+                            "name": "Size"
+                        },
+                        {
+                            "range": [116, 192],
+                            "name": "Small"
+                        },
+                        {
+                            "range": [193, 251],
+                            "name": "Pulse"
+                        },
+                        {
+                            "range": [252, 255],
+                            "name": "Maximum"
+                        }
+                    ]
+                },
+                "Zoom": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "Beam"
+                        }
+                    ]
+                },
+                "Focus": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "Distance"
+                        }
+                    ]
+                },
+                "Gobo 1": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 24],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [25, 50],
+                            "name": "Gobo 1"
+                        },
+                        {
+                            "range": [51, 73],
+                            "name": "Gobo 2"
+                        },
+                        {
+                            "range": [74, 99],
+                            "name": "Gobo 3"
+                        },
+                        {
+                            "range": [100, 123],
+                            "name": "Gobo 4"
+                        },
+                        {
+                            "range": [124, 151],
+                            "name": "Gobo 5"
+                        },
+                        {
+                            "range": [152, 255],
+                            "name": "Rotation",
+                            "center": true
+                        }
+                    ]
+                },
+                "Gobo 1 Rot": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 128],
+                            "name": "Position"
+                        },
+                        {
+                            "range": [129, 190],
+                            "name": "Rot Right",
+                            "center": true
+                        },
+                        {
+                            "range": [191, 191],
+                            "name": "Stop"
+                        },
+                        {
+                            "range": [192, 255],
+                            "name": "Rot Left",
+                            "center": true
+                        }
+                    ]
+                },
+                "Gobo 2": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 24],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [25, 50],
+                            "name": "Gobo 1"
+                        },
+                        {
+                            "range": [51, 73],
+                            "name": "Gobo 2"
+                        },
+                        {
+                            "range": [74, 99],
+                            "name": "Gobo 3"
+                        },
+                        {
+                            "range": [100, 123],
+                            "name": "Gobo 4"
+                        },
+                        {
+                            "range": [124, 151],
+                            "name": "Gobo 5"
+                        },
+                        {
+                            "range": [152, 255],
+                            "name": "Rotation",
+                            "center": true
+                        }
+                    ]
+                },
+                "Gobo 2 Rot": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 128],
+                            "name": "Position"
+                        },
+                        {
+                            "range": [129, 190],
+                            "name": "Rot Right",
+                            "center": true
+                        },
+                        {
+                            "range": [191, 191],
+                            "name": "Stop"
+                        },
+                        {
+                            "range": [192, 255],
+                            "name": "Rot Left",
+                            "center": true
+                        }
+                    ]
+                },
+                "FX": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 41],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [42, 85],
+                            "name": "FX 1"
+                        },
+                        {
+                            "range": [86, 125],
+                            "name": "FX 2"
+                        },
+                        {
+                            "range": [126, 169],
+                            "name": "FX 3"
+                        },
+                        {
+                            "range": [170, 209],
+                            "name": "FX 4"
+                        },
+                        {
+                            "range": [210, 255],
+                            "name": "FX 5"
+                        }
+                    ]
+                },
+                "FX Rot": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 128],
+                            "name": "Position"
+                        },
+                        {
+                            "range": [129, 190],
+                            "name": "Rot Right",
+                            "center": true
+                        },
+                        {
+                            "range": [191, 191],
+                            "name": "Stop"
+                        },
+                        {
+                            "range": [192, 255],
+                            "name": "Rot Left",
+                            "center": true
+                        }
+                    ]
+                },
+                "Colour": {
+                    "type": "MultiColor",
+                    "capabilities": [
+                        {
+                            "range": [0, 23],
+                            "name": "Open",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [24, 49],
+                            "name": "Colour 1",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [50, 73],
+                            "name": "Colour 2",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [74, 99],
+                            "name": "Colour 3",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [100, 123],
+                            "name": "Colour 4",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [124, 151],
+                            "name": "Colour 5",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [152, 255],
+                            "name": "Rotation",
+                            "showInMenu": false,
+                            "center": true
+                        }
+                    ]
+                },
+                "Cyan": {
+                    "type": "SingleColor",
+                    "color": "Cyan",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Magenta": {
+                    "type": "SingleColor",
+                    "color": "Magenta",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Yellow": {
+                    "type": "SingleColor",
+                    "color": "Yellow",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Control": {
+                    "type": "Beam",
+                    "defaultValue": 255,
+                    "capabilities": [
+                        {
+                            "range": [0, 114],
+                            "name": "Lamp Off"
+                        },
+                        {
+                            "range": [115, 140],
+                            "name": "Reset"
+                        },
+                        {
+                            "range": [141, 255],
+                            "name": "Lamp On"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "20-channel Mode",
+                    "shortName": "20ch",
+                    "channels": [
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "Intensity",
+                        "Strobe",
+                        "Iris",
+                        "Zoom",
+                        "Focus",
+                        "Gobo 1",
+                        "Gobo 1 Rot",
+                        "Gobo 2",
+                        "Gobo 2 Rot",
+                        "FX",
+                        "FX Rot",
+                        "Colour",
+                        "Cyan",
+                        "Magenta",
+                        "Yellow",
+                        "Control"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Coemar",
+            "name": "NAT MM Zoom 2500",
+            "shortName": "NATMMZ2500",
+            "physical": {
+                "dimensions": [500, 500, 700]
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Strobe": {
+                    "type": "Strobe",
+                    "defaultValue": 80,
+                    "highlightValue": 80,
+                    "capabilities": [
+                        {
+                            "range": [0, 79],
+                            "name": "Closed"
+                        },
+                        {
+                            "range": [80, 127],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [128, 255],
+                            "name": "Speed"
+                        }
+                    ]
+                },
+                "Iris": {
+                    "type": "Beam",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 35],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [36, 115],
+                            "name": "Size"
+                        },
+                        {
+                            "range": [116, 192],
+                            "name": "Small"
+                        },
+                        {
+                            "range": [193, 251],
+                            "name": "Pulse"
+                        },
+                        {
+                            "range": [252, 255],
+                            "name": "Maximum"
+                        }
+                    ]
+                },
+                "Zoom": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "Beam"
+                        }
+                    ]
+                },
+                "Focus": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "Distance"
+                        }
+                    ]
+                },
+                "Gobo 1": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 24],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [25, 50],
+                            "name": "Gobo 1"
+                        },
+                        {
+                            "range": [51, 73],
+                            "name": "Gobo 2"
+                        },
+                        {
+                            "range": [74, 99],
+                            "name": "Gobo 3"
+                        },
+                        {
+                            "range": [100, 123],
+                            "name": "Gobo 4"
+                        },
+                        {
+                            "range": [124, 151],
+                            "name": "Gobo 5"
+                        },
+                        {
+                            "range": [152, 255],
+                            "name": "Rotation",
+                            "center": true
+                        }
+                    ]
+                },
+                "Gobo 1 Rot": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 128],
+                            "name": "Position"
+                        },
+                        {
+                            "range": [129, 190],
+                            "name": "Rot Right",
+                            "center": true
+                        },
+                        {
+                            "range": [191, 191],
+                            "name": "Stop"
+                        },
+                        {
+                            "range": [192, 255],
+                            "name": "Rot Left",
+                            "center": true
+                        }
+                    ]
+                },
+                "Gobo 2": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 24],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [25, 50],
+                            "name": "Gobo 1"
+                        },
+                        {
+                            "range": [51, 73],
+                            "name": "Gobo 2"
+                        },
+                        {
+                            "range": [74, 99],
+                            "name": "Gobo 3"
+                        },
+                        {
+                            "range": [100, 123],
+                            "name": "Gobo 4"
+                        },
+                        {
+                            "range": [124, 151],
+                            "name": "Gobo 5"
+                        },
+                        {
+                            "range": [152, 255],
+                            "name": "Rotation",
+                            "center": true
+                        }
+                    ]
+                },
+                "Gobo 2 Rot": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 128],
+                            "name": "Position"
+                        },
+                        {
+                            "range": [129, 190],
+                            "name": "Rot Right",
+                            "center": true
+                        },
+                        {
+                            "range": [191, 191],
+                            "name": "Stop"
+                        },
+                        {
+                            "range": [192, 255],
+                            "name": "Rot Left",
+                            "center": true
+                        }
+                    ]
+                },
+                "FX": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 41],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [42, 85],
+                            "name": "FX 1"
+                        },
+                        {
+                            "range": [86, 125],
+                            "name": "FX 2"
+                        },
+                        {
+                            "range": [126, 169],
+                            "name": "FX 3"
+                        },
+                        {
+                            "range": [170, 209],
+                            "name": "FX 4"
+                        },
+                        {
+                            "range": [210, 255],
+                            "name": "FX 5"
+                        }
+                    ]
+                },
+                "FX Rot": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 128],
+                            "name": "Position"
+                        },
+                        {
+                            "range": [129, 190],
+                            "name": "Rot Right",
+                            "center": true
+                        },
+                        {
+                            "range": [191, 191],
+                            "name": "Stop"
+                        },
+                        {
+                            "range": [192, 255],
+                            "name": "Rot Left",
+                            "center": true
+                        }
+                    ]
+                },
+                "Colour": {
+                    "type": "MultiColor",
+                    "capabilities": [
+                        {
+                            "range": [0, 23],
+                            "name": "Open",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [24, 49],
+                            "name": "Colour 1",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [50, 73],
+                            "name": "Colour 2",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [74, 97],
+                            "name": "Colour 3",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [98, 123],
+                            "name": "Colour 4",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [124, 151],
+                            "name": "Colour 5",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [152, 255],
+                            "name": "Rotation",
+                            "showInMenu": false,
+                            "center": true
+                        }
+                    ]
+                },
+                "Cyan": {
+                    "type": "SingleColor",
+                    "color": "Cyan",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Magenta": {
+                    "type": "SingleColor",
+                    "color": "Magenta",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Yellow": {
+                    "type": "SingleColor",
+                    "color": "Yellow",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Control": {
+                    "type": "Beam",
+                    "defaultValue": 255,
+                    "capabilities": [
+                        {
+                            "range": [0, 114],
+                            "name": "Lamp Off"
+                        },
+                        {
+                            "range": [115, 140],
+                            "name": "Reset"
+                        },
+                        {
+                            "range": [141, 255],
+                            "name": "Lamp On"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "20-channel Mode",
+                    "shortName": "20ch",
+                    "channels": [
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "Intensity",
+                        "Strobe",
+                        "Iris",
+                        "Zoom",
+                        "Focus",
+                        "Gobo 1",
+                        "Gobo 1 Rot",
+                        "Gobo 2",
+                        "Gobo 2 Rot",
+                        "FX",
+                        "FX Rot",
+                        "Colour",
+                        "Cyan",
+                        "Magenta",
+                        "Yellow",
+                        "Control"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Coemar",
+            "name": "NAT TM 4000",
+            "shortName": "NATTM4000",
+            "physical": {
+                "dimensions": [500, 500, 700]
+            },
+            "availableChannels": {
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 0,
+                    "highlightValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 0,
+                    "highlightValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Movement": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 31],
+                            "name": "No FX"
+                        },
+                        {
+                            "range": [32, 63],
+                            "name": "X rot CCW"
+                        },
+                        {
+                            "range": [64, 95],
+                            "name": "X rot CW"
+                        },
+                        {
+                            "range": [96, 127],
+                            "name": "Y rot CW"
+                        },
+                        {
+                            "range": [128, 159],
+                            "name": "Y rot CCW"
+                        },
+                        {
+                            "range": [160, 191],
+                            "name": "Y->CW X->CCW"
+                        },
+                        {
+                            "range": [192, 223],
+                            "name": "X->CW Y->CCW"
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "2x Speed"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Strobe": {
+                    "type": "Strobe",
+                    "defaultValue": 80,
+                    "highlightValue": 80,
+                    "capabilities": [
+                        {
+                            "range": [0, 79],
+                            "name": "Closed"
+                        },
+                        {
+                            "range": [80, 127],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [128, 255],
+                            "name": "Speed"
+                        }
+                    ]
+                },
+                "Iris": {
+                    "type": "Beam",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 35],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [36, 115],
+                            "name": "Size"
+                        },
+                        {
+                            "range": [116, 192],
+                            "name": "Small"
+                        },
+                        {
+                            "range": [193, 251],
+                            "name": "Pulse"
+                        },
+                        {
+                            "range": [252, 255],
+                            "name": "Maximum"
+                        }
+                    ]
+                },
+                "Focus": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "Distance"
+                        }
+                    ]
+                },
+                "Gobo 1": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 24],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [25, 50],
+                            "name": "Gobo 1"
+                        },
+                        {
+                            "range": [51, 73],
+                            "name": "Gobo 2"
+                        },
+                        {
+                            "range": [74, 99],
+                            "name": "Gobo 3"
+                        },
+                        {
+                            "range": [100, 123],
+                            "name": "Gobo 4"
+                        },
+                        {
+                            "range": [124, 151],
+                            "name": "Gobo 5"
+                        },
+                        {
+                            "range": [152, 255],
+                            "name": "Rotation",
+                            "center": true
+                        }
+                    ]
+                },
+                "Gobo 1 Rot": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 128],
+                            "name": "Position"
+                        },
+                        {
+                            "range": [129, 190],
+                            "name": "Rot Right",
+                            "center": true
+                        },
+                        {
+                            "range": [191, 191],
+                            "name": "Stop"
+                        },
+                        {
+                            "range": [192, 255],
+                            "name": "Rot Left",
+                            "center": true
+                        }
+                    ]
+                },
+                "Gobo 2": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 24],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [25, 50],
+                            "name": "Gobo 1"
+                        },
+                        {
+                            "range": [51, 73],
+                            "name": "Gobo 2"
+                        },
+                        {
+                            "range": [74, 99],
+                            "name": "Gobo 3"
+                        },
+                        {
+                            "range": [100, 123],
+                            "name": "Gobo 4"
+                        },
+                        {
+                            "range": [124, 151],
+                            "name": "Gobo 5"
+                        },
+                        {
+                            "range": [152, 255],
+                            "name": "Rotation",
+                            "center": true
+                        }
+                    ]
+                },
+                "Gobo 2 Rot": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 128],
+                            "name": "Position"
+                        },
+                        {
+                            "range": [129, 190],
+                            "name": "Rot Right",
+                            "center": true
+                        },
+                        {
+                            "range": [191, 191],
+                            "name": "Stop"
+                        },
+                        {
+                            "range": [192, 255],
+                            "name": "Rot Left",
+                            "center": true
+                        }
+                    ]
+                },
+                "FX": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 41],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [42, 85],
+                            "name": "FX 1"
+                        },
+                        {
+                            "range": [86, 125],
+                            "name": "FX 2"
+                        },
+                        {
+                            "range": [126, 169],
+                            "name": "FX 3"
+                        },
+                        {
+                            "range": [170, 209],
+                            "name": "FX 4"
+                        },
+                        {
+                            "range": [210, 255],
+                            "name": "FX 5"
+                        }
+                    ]
+                },
+                "FX Rot": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 128],
+                            "name": "Position"
+                        },
+                        {
+                            "range": [129, 190],
+                            "name": "Rot Right",
+                            "center": true
+                        },
+                        {
+                            "range": [191, 191],
+                            "name": "Stop"
+                        },
+                        {
+                            "range": [192, 255],
+                            "name": "Rot Left",
+                            "center": true
+                        }
+                    ]
+                },
+                "Colour": {
+                    "type": "MultiColor",
+                    "capabilities": [
+                        {
+                            "range": [0, 23],
+                            "name": "Open",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [24, 49],
+                            "name": "Colour 1",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [50, 73],
+                            "name": "Colour 2",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [74, 99],
+                            "name": "Colour 3",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [100, 123],
+                            "name": "Colour 4",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [124, 151],
+                            "name": "Colour 5",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [152, 255],
+                            "name": "Rotation",
+                            "showInMenu": false,
+                            "center": true
+                        }
+                    ]
+                },
+                "Cyan": {
+                    "type": "SingleColor",
+                    "color": "Cyan",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Magenta": {
+                    "type": "SingleColor",
+                    "color": "Magenta",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Yellow": {
+                    "type": "SingleColor",
+                    "color": "Yellow",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Control": {
+                    "type": "Beam",
+                    "defaultValue": 255,
+                    "capabilities": [
+                        {
+                            "range": [0, 114],
+                            "name": "Lamp Off"
+                        },
+                        {
+                            "range": [115, 140],
+                            "name": "Reset"
+                        },
+                        {
+                            "range": [141, 255],
+                            "name": "Lamp On"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ],
+                [
+                    "Pan",
+                    "Pan fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "20-channel Mode",
+                    "shortName": "20ch",
+                    "channels": [
+                        "Tilt",
+                        "Tilt fine",
+                        "Pan",
+                        "Pan fine",
+                        "Movement",
+                        "Intensity",
+                        "Strobe",
+                        "Iris",
+                        "Focus",
+                        "Gobo 1",
+                        "Gobo 1 Rot",
+                        "Gobo 2",
+                        "Gobo 2 Rot",
+                        "FX",
+                        "FX Rot",
+                        "Colour",
+                        "Cyan",
+                        "Magenta",
+                        "Yellow",
+                        "Control"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Coemar",
+            "name": "Panorama Beam 1200 T bbi",
+            "shortName": "PB1200bbi",
+            "comment": "Back panel can modify funtion channel (no DMX lamp off)",
+            "physical": {
+                "dimensions": [600, 500, 700]
+            },
+            "availableChannels": {
+                "Dimmer": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 7],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [8, 255],
+                            "name": "open"
+                        }
+                    ]
+                },
+                "Cyan": {
+                    "type": "SingleColor",
+                    "color": "Cyan",
+                    "crossfade": true
+                },
+                "Magenta": {
+                    "type": "SingleColor",
+                    "color": "Magenta",
+                    "crossfade": true
+                },
+                "Yellow": {
+                    "type": "SingleColor",
+                    "color": "Yellow",
+                    "crossfade": true
+                },
+                "Function": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 114],
+                            "name": "lamp off"
+                        },
+                        {
+                            "range": [115, 140],
+                            "name": "motor reset",
+                            "center": true
+                        },
+                        {
+                            "range": [141, 255],
+                            "name": "lamp on",
+                            "center": true
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "5-channel Mode",
+                    "shortName": "5ch",
+                    "channels": [
+                        "Dimmer",
+                        "Cyan",
+                        "Magenta",
+                        "Yellow",
+                        "Function"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Coemar",
+            "name": "Panorama Cyc 1800 T",
+            "shortName": "PC1800T",
+            "comment": "Back panel can modify funtion channel (no DMX lamp off)",
+            "physical": {
+                "dimensions": [600, 500, 700]
+            },
+            "availableChannels": {
+                "Dimmer": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 7],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [8, 255],
+                            "name": "open"
+                        }
+                    ]
+                },
+                "Cyan": {
+                    "type": "SingleColor",
+                    "color": "Cyan",
+                    "crossfade": true
+                },
+                "Magenta": {
+                    "type": "SingleColor",
+                    "color": "Magenta",
+                    "crossfade": true
+                },
+                "Yellow": {
+                    "type": "SingleColor",
+                    "color": "Yellow",
+                    "crossfade": true
+                },
+                "Function": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 114],
+                            "name": "lamp off"
+                        },
+                        {
+                            "range": [115, 140],
+                            "name": "motor reset",
+                            "center": true
+                        },
+                        {
+                            "range": [141, 255],
+                            "name": "lamp on",
+                            "center": true
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "5-channel Mode",
+                    "shortName": "5ch",
+                    "channels": [
+                        "Dimmer",
+                        "Cyan",
+                        "Magenta",
+                        "Yellow",
+                        "Function"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Coemar",
+            "name": "Panorama Power",
+            "shortName": "PanPwr",
+            "physical": {
+                "dimensions": [600, 500, 700]
+            },
+            "availableChannels": {
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Cyan": {
+                    "type": "SingleColor",
+                    "color": "Cyan",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Magenta": {
+                    "type": "SingleColor",
+                    "color": "Magenta",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Yellow": {
+                    "type": "SingleColor",
+                    "color": "Yellow",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Lamp Right": {
+                    "type": "Beam",
+                    "defaultValue": 255,
+                    "capabilities": [
+                        {
+                            "range": [0, 140],
+                            "name": "lamp off"
+                        },
+                        {
+                            "range": [141, 255],
+                            "name": "lamp on",
+                            "center": true
+                        }
+                    ]
+                },
+                "Lamp Left / Res": {
+                    "type": "Beam",
+                    "defaultValue": 255,
+                    "capabilities": [
+                        {
+                            "range": [0, 10],
+                            "name": "Lamp Off"
+                        },
+                        {
+                            "range": [11, 114],
+                            "name": "Park"
+                        },
+                        {
+                            "range": [115, 140],
+                            "name": "Reset"
+                        },
+                        {
+                            "range": [141, 255],
+                            "name": "Lamp On"
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "6-channel Mode",
+                    "shortName": "6ch",
+                    "channels": [
+                        "Intensity",
+                        "Cyan",
+                        "Magenta",
+                        "Yellow",
+                        "Lamp Right",
+                        "Lamp Left / Res"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Coemar",
+            "name": "Pro Spot 250LX",
+            "shortName": "ProSp250LX",
+            "comment": "cd",
+            "physical": {
+                "dimensions": [400, 400, 510]
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "P/T speed": {
+                    "type": "Speed",
+                    "capabilities": [
+                        {
+                            "range": [0, 10],
+                            "name": "standard"
+                        },
+                        {
+                            "range": [11, 25],
+                            "name": "ultra fast"
+                        },
+                        {
+                            "range": [26, 127],
+                            "name": "speed"
+                        },
+                        {
+                            "range": [128, 247],
+                            "name": "track speed"
+                        },
+                        {
+                            "range": [248, 255],
+                            "name": "track slow"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 7],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [8, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Shutter": {
+                    "type": "Shutter",
+                    "highlightValue": 67,
+                    "capabilities": [
+                        {
+                            "range": [0, 9],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [10, 66],
+                            "name": "strobe"
+                        },
+                        {
+                            "range": [67, 68],
+                            "name": "open"
+                        },
+                        {
+                            "range": [69, 125],
+                            "name": "pulse closed"
+                        },
+                        {
+                            "range": [126, 127],
+                            "name": "open"
+                        },
+                        {
+                            "range": [128, 184],
+                            "name": "pulse open"
+                        },
+                        {
+                            "range": [185, 187],
+                            "name": "open"
+                        },
+                        {
+                            "range": [188, 244],
+                            "name": "random strobe"
+                        },
+                        {
+                            "range": [245, 255],
+                            "name": "open"
+                        }
+                    ]
+                },
+                "Focus": {
+                    "type": "Beam",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Gobo": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 10],
+                            "name": "open"
+                        },
+                        {
+                            "range": [11, 30],
+                            "name": "slot1"
+                        },
+                        {
+                            "range": [31, 50],
+                            "name": "slot2"
+                        },
+                        {
+                            "range": [51, 70],
+                            "name": "slot3"
+                        },
+                        {
+                            "range": [71, 90],
+                            "name": "slot4"
+                        },
+                        {
+                            "range": [91, 110],
+                            "name": "slot5"
+                        },
+                        {
+                            "range": [111, 127],
+                            "name": "slot6"
+                        },
+                        {
+                            "range": [128, 192],
+                            "name": "scroll"
+                        },
+                        {
+                            "range": [193, 255],
+                            "name": ">>"
+                        }
+                    ]
+                },
+                "Gobo ind.": {
+                    "type": "Gobo",
+                    "highlightValue": 138,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 10],
+                            "name": "no effect"
+                        },
+                        {
+                            "range": [11, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Gobo rot.": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 10],
+                            "name": "no effect"
+                        },
+                        {
+                            "range": [11, 131],
+                            "name": ">>"
+                        },
+                        {
+                            "range": [132, 134],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [135, 255],
+                            "name": "<<"
+                        }
+                    ]
+                },
+                "Prisma": {
+                    "type": "Prism",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 10],
+                            "name": "open"
+                        },
+                        {
+                            "range": [11, 20],
+                            "name": "prisma"
+                        },
+                        {
+                            "range": [21, 136],
+                            "name": ">>"
+                        },
+                        {
+                            "range": [137, 139],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [140, 255],
+                            "name": "<<"
+                        }
+                    ]
+                },
+                "Color": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 4],
+                            "name": "open"
+                        },
+                        {
+                            "range": [5, 9],
+                            "name": "color1"
+                        },
+                        {
+                            "range": [10, 14],
+                            "name": "color2"
+                        },
+                        {
+                            "range": [15, 19],
+                            "name": "color3"
+                        },
+                        {
+                            "range": [20, 24],
+                            "name": "color4"
+                        },
+                        {
+                            "range": [25, 29],
+                            "name": "color5"
+                        },
+                        {
+                            "range": [30, 34],
+                            "name": "color6"
+                        },
+                        {
+                            "range": [35, 39],
+                            "name": "color7"
+                        },
+                        {
+                            "range": [40, 44],
+                            "name": "color8"
+                        },
+                        {
+                            "range": [45, 49],
+                            "name": "color9"
+                        },
+                        {
+                            "range": [50, 54],
+                            "name": "color10"
+                        },
+                        {
+                            "range": [55, 59],
+                            "name": "color11"
+                        },
+                        {
+                            "range": [60, 127],
+                            "name": "scroll"
+                        },
+                        {
+                            "range": [128, 190],
+                            "name": ">>"
+                        },
+                        {
+                            "range": [191, 192],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [193, 255],
+                            "name": "<<"
+                        }
+                    ]
+                },
+                "Gobo sh./MIB": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 9],
+                            "name": "no effect"
+                        },
+                        {
+                            "range": [10, 249],
+                            "name": "shake"
+                        },
+                        {
+                            "range": [250, 255],
+                            "name": "MIB"
+                        }
+                    ]
+                },
+                "Gobo sh. int.": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Reset": {
+                    "type": "Beam",
+                    "defaultValue": 50,
+                    "highlightValue": 50,
+                    "capabilities": [
+                        {
+                            "range": [0, 19],
+                            "name": "lamp off"
+                        },
+                        {
+                            "range": [20, 100],
+                            "name": "idle"
+                        },
+                        {
+                            "range": [101, 170],
+                            "name": "fx reset"
+                        },
+                        {
+                            "range": [171, 200],
+                            "name": "reset"
+                        },
+                        {
+                            "range": [201, 240],
+                            "name": "silent fan"
+                        },
+                        {
+                            "range": [241, 255],
+                            "name": "lamp on"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "16-channel Mode",
+                    "shortName": "16ch",
+                    "channels": [
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "P/T speed",
+                        "Intensity",
+                        "Shutter",
+                        "Focus",
+                        "Gobo",
+                        "Gobo ind.",
+                        "Gobo rot.",
+                        "Prisma",
+                        "Color",
+                        "Gobo sh./MIB",
+                        "Gobo sh. int.",
+                        "Reset"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Coemar",
+            "name": "Pro Spot 575 LX",
+            "shortName": "PSpot575LX",
+            "physical": {
+                "dimensions": [525, 525, 680]
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Shutter": {
+                    "type": "Shutter",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 9],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [10, 66],
+                            "name": "strobe"
+                        },
+                        {
+                            "range": [67, 68],
+                            "name": "open"
+                        },
+                        {
+                            "range": [69, 125],
+                            "name": "pulse"
+                        },
+                        {
+                            "range": [126, 127],
+                            "name": "open"
+                        },
+                        {
+                            "range": [128, 184],
+                            "name": "pulse"
+                        },
+                        {
+                            "range": [185, 187],
+                            "name": "open"
+                        },
+                        {
+                            "range": [188, 244],
+                            "name": "random"
+                        },
+                        {
+                            "range": [245, 255],
+                            "name": "open"
+                        }
+                    ]
+                },
+                "Iris": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 9],
+                            "name": "open"
+                        },
+                        {
+                            "range": [10, 124],
+                            "name": "size"
+                        },
+                        {
+                            "range": [125, 129],
+                            "name": "small"
+                        },
+                        {
+                            "range": [130, 189],
+                            "name": "pulse"
+                        },
+                        {
+                            "range": [190, 192],
+                            "name": "open"
+                        },
+                        {
+                            "range": [193, 251],
+                            "name": "pulse"
+                        },
+                        {
+                            "range": [252, 255],
+                            "name": "open"
+                        }
+                    ]
+                },
+                "Focus": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "gobo.rot": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 10],
+                            "name": "open"
+                        },
+                        {
+                            "range": [11, 40],
+                            "name": "gobo 1",
+                            "center": true
+                        },
+                        {
+                            "range": [41, 70],
+                            "name": "gobo 2",
+                            "center": true
+                        },
+                        {
+                            "range": [71, 100],
+                            "name": "gobo 3",
+                            "center": true
+                        },
+                        {
+                            "range": [101, 130],
+                            "name": "gobo 4",
+                            "center": true
+                        },
+                        {
+                            "range": [131, 160],
+                            "name": "gobo 5",
+                            "center": true
+                        },
+                        {
+                            "range": [161, 192],
+                            "name": "gobo 6",
+                            "center": true
+                        },
+                        {
+                            "range": [193, 255],
+                            "name": "prop"
+                        }
+                    ]
+                },
+                "gobo.rot.pos1": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 10],
+                            "name": "no effect"
+                        },
+                        {
+                            "range": [11, 255],
+                            "name": "index"
+                        }
+                    ]
+                },
+                "gobo.rot.pos2": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 100],
+                            "name": "index"
+                        },
+                        {
+                            "range": [101, 176],
+                            "name": "rotation cw"
+                        },
+                        {
+                            "range": [177, 179],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [180, 255],
+                            "name": "rotation ccw"
+                        }
+                    ]
+                },
+                "gobo": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 10],
+                            "name": "open"
+                        },
+                        {
+                            "range": [11, 40],
+                            "name": "gobo 1",
+                            "center": true
+                        },
+                        {
+                            "range": [41, 70],
+                            "name": "gobo 2",
+                            "center": true
+                        },
+                        {
+                            "range": [71, 100],
+                            "name": "gobo 3",
+                            "center": true
+                        },
+                        {
+                            "range": [101, 130],
+                            "name": "gobo 4",
+                            "center": true
+                        },
+                        {
+                            "range": [131, 160],
+                            "name": "gobo 5",
+                            "center": true
+                        },
+                        {
+                            "range": [161, 192],
+                            "name": "gobo 6",
+                            "center": true
+                        },
+                        {
+                            "range": [193, 255],
+                            "name": "prop"
+                        }
+                    ]
+                },
+                "Prism": {
+                    "type": "Prism",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 10],
+                            "name": "open"
+                        },
+                        {
+                            "range": [11, 20],
+                            "name": "prism"
+                        },
+                        {
+                            "range": [21, 136],
+                            "name": "rotation cw"
+                        },
+                        {
+                            "range": [137, 139],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [140, 255],
+                            "name": "rotation ccw"
+                        }
+                    ]
+                },
+                "Color": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 7],
+                            "name": "open"
+                        },
+                        {
+                            "range": [8, 27],
+                            "name": "color 1",
+                            "center": true
+                        },
+                        {
+                            "range": [28, 47],
+                            "name": "color 2"
+                        },
+                        {
+                            "range": [48, 67],
+                            "name": "color 3",
+                            "center": true
+                        },
+                        {
+                            "range": [68, 87],
+                            "name": "color 4",
+                            "center": true
+                        },
+                        {
+                            "range": [88, 107],
+                            "name": "color 5",
+                            "center": true
+                        },
+                        {
+                            "range": [108, 127],
+                            "name": "color 6"
+                        },
+                        {
+                            "range": [128, 190],
+                            "name": "rainbow"
+                        },
+                        {
+                            "range": [191, 192],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [193, 255],
+                            "name": "rainbow"
+                        }
+                    ]
+                },
+                "position": {
+                    "type": "Beam",
+                    "defaultValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 10],
+                            "name": "gobo/color"
+                        },
+                        {
+                            "range": [11, 125],
+                            "name": "gobo"
+                        },
+                        {
+                            "range": [126, 239],
+                            "name": "color"
+                        },
+                        {
+                            "range": [240, 255],
+                            "name": "proportional"
+                        }
+                    ]
+                },
+                "Control": {
+                    "type": "Beam",
+                    "defaultValue": 11,
+                    "capabilities": [
+                        {
+                            "range": [0, 10],
+                            "name": "lamp.off"
+                        },
+                        {
+                            "range": [11, 29],
+                            "name": "park"
+                        },
+                        {
+                            "range": [30, 65],
+                            "name": "reset.focus"
+                        },
+                        {
+                            "range": [66, 100],
+                            "name": "wheel.reset"
+                        },
+                        {
+                            "range": [101, 135],
+                            "name": "motor.reset"
+                        },
+                        {
+                            "range": [136, 170],
+                            "name": "reset.all"
+                        },
+                        {
+                            "range": [171, 249],
+                            "name": "autolens"
+                        },
+                        {
+                            "range": [250, 255],
+                            "name": "lamp.on"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "16-channel Mode",
+                    "shortName": "16ch",
+                    "channels": [
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "Intensity",
+                        "Shutter",
+                        "Iris",
+                        "Focus",
+                        "gobo.rot",
+                        "gobo.rot.pos1",
+                        "gobo.rot.pos2",
+                        "gobo",
+                        "Prism",
+                        "Color",
+                        "position",
+                        "Control"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Coemar",
+            "name": "Pro Wash 250LX",
+            "shortName": "ProWash250LX",
+            "comment": "cd",
+            "physical": {
+                "dimensions": [400, 400, 510]
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "P/T speed": {
+                    "type": "Speed",
+                    "capabilities": [
+                        {
+                            "range": [0, 10],
+                            "name": "standard"
+                        },
+                        {
+                            "range": [11, 25],
+                            "name": "ultra fast"
+                        },
+                        {
+                            "range": [26, 127],
+                            "name": "speed"
+                        },
+                        {
+                            "range": [128, 247],
+                            "name": "track speed"
+                        },
+                        {
+                            "range": [248, 255],
+                            "name": "track slow"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 7],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [8, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Shutter": {
+                    "type": "Shutter",
+                    "highlightValue": 67,
+                    "capabilities": [
+                        {
+                            "range": [0, 9],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [10, 66],
+                            "name": "strobe"
+                        },
+                        {
+                            "range": [67, 68],
+                            "name": "open"
+                        },
+                        {
+                            "range": [69, 125],
+                            "name": "pulse closed"
+                        },
+                        {
+                            "range": [126, 127],
+                            "name": "open"
+                        },
+                        {
+                            "range": [128, 184],
+                            "name": "pulse open"
+                        },
+                        {
+                            "range": [185, 187],
+                            "name": "open"
+                        },
+                        {
+                            "range": [188, 244],
+                            "name": "random strobe"
+                        },
+                        {
+                            "range": [245, 255],
+                            "name": "open"
+                        }
+                    ]
+                },
+                "MIB": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 249],
+                            "name": "off"
+                        },
+                        {
+                            "range": [250, 255],
+                            "name": "on"
+                        }
+                    ]
+                },
+                "Focus FX": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 9],
+                            "name": "normal"
+                        },
+                        {
+                            "range": [10, 230],
+                            "name": "beam shape"
+                        },
+                        {
+                            "range": [231, 255],
+                            "name": "wide angle"
+                        }
+                    ]
+                },
+                "Color": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 5],
+                            "name": "open"
+                        },
+                        {
+                            "range": [6, 14],
+                            "name": "color1"
+                        },
+                        {
+                            "range": [15, 23],
+                            "name": "color2"
+                        },
+                        {
+                            "range": [24, 32],
+                            "name": "color3"
+                        },
+                        {
+                            "range": [33, 41],
+                            "name": "color4"
+                        },
+                        {
+                            "range": [42, 50],
+                            "name": "color5"
+                        },
+                        {
+                            "range": [51, 60],
+                            "name": "color6"
+                        },
+                        {
+                            "range": [61, 127],
+                            "name": "scroll"
+                        },
+                        {
+                            "range": [128, 190],
+                            "name": ">>"
+                        },
+                        {
+                            "range": [191, 192],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [193, 255],
+                            "name": "<<"
+                        }
+                    ]
+                },
+                "Cyan": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 9],
+                            "name": "open"
+                        },
+                        {
+                            "range": [10, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Magenta": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 9],
+                            "name": "open"
+                        },
+                        {
+                            "range": [10, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Yellow": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 9],
+                            "name": "open"
+                        },
+                        {
+                            "range": [10, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Reset": {
+                    "type": "Beam",
+                    "defaultValue": 50,
+                    "highlightValue": 50,
+                    "capabilities": [
+                        {
+                            "range": [0, 19],
+                            "name": "lamp off"
+                        },
+                        {
+                            "range": [20, 100],
+                            "name": "idle"
+                        },
+                        {
+                            "range": [101, 170],
+                            "name": "fx reset"
+                        },
+                        {
+                            "range": [171, 200],
+                            "name": "reset"
+                        },
+                        {
+                            "range": [201, 240],
+                            "name": "silent fan"
+                        },
+                        {
+                            "range": [241, 255],
+                            "name": "lamp on"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "14-channel Mode",
+                    "shortName": "14ch",
+                    "channels": [
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "P/T speed",
+                        "Intensity",
+                        "Shutter",
+                        "MIB",
+                        "Focus FX",
+                        "Color",
+                        "Cyan",
+                        "Magenta",
+                        "Yellow",
+                        "Reset"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Coemar",
+            "name": "Pro Wash 575LX",
+            "shortName": "ProWash575LX",
+            "comment": "cd",
+            "physical": {
+                "dimensions": [525, 525, 680]
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "P/T speed": {
+                    "type": "Speed",
+                    "capabilities": [
+                        {
+                            "range": [0, 10],
+                            "name": "standard"
+                        },
+                        {
+                            "range": [11, 25],
+                            "name": "ultra fast"
+                        },
+                        {
+                            "range": [26, 127],
+                            "name": "speed"
+                        },
+                        {
+                            "range": [128, 247],
+                            "name": "track speed"
+                        },
+                        {
+                            "range": [248, 255],
+                            "name": "track slow"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 7],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [8, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Shutter": {
+                    "type": "Shutter",
+                    "highlightValue": 67,
+                    "capabilities": [
+                        {
+                            "range": [0, 9],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [10, 66],
+                            "name": "strobe"
+                        },
+                        {
+                            "range": [67, 68],
+                            "name": "open"
+                        },
+                        {
+                            "range": [69, 125],
+                            "name": "pulse closed"
+                        },
+                        {
+                            "range": [126, 127],
+                            "name": "open"
+                        },
+                        {
+                            "range": [128, 184],
+                            "name": "pulse open"
+                        },
+                        {
+                            "range": [185, 187],
+                            "name": "open"
+                        },
+                        {
+                            "range": [188, 244],
+                            "name": "random strobe"
+                        },
+                        {
+                            "range": [245, 255],
+                            "name": "open"
+                        }
+                    ]
+                },
+                "Zoom": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Beam FX": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 9],
+                            "name": "normal"
+                        },
+                        {
+                            "range": [10, 230],
+                            "name": "beam shape"
+                        },
+                        {
+                            "range": [231, 255],
+                            "name": "CTO"
+                        }
+                    ]
+                },
+                "Color": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 7],
+                            "name": "open"
+                        },
+                        {
+                            "range": [8, 27],
+                            "name": "color1"
+                        },
+                        {
+                            "range": [28, 47],
+                            "name": "color2"
+                        },
+                        {
+                            "range": [48, 67],
+                            "name": "color3"
+                        },
+                        {
+                            "range": [68, 87],
+                            "name": "color4"
+                        },
+                        {
+                            "range": [88, 107],
+                            "name": "color5"
+                        },
+                        {
+                            "range": [108, 127],
+                            "name": "color6"
+                        },
+                        {
+                            "range": [128, 190],
+                            "name": ">>"
+                        },
+                        {
+                            "range": [191, 192],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [193, 255],
+                            "name": "<<"
+                        }
+                    ]
+                },
+                "Cyan": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 9],
+                            "name": "open"
+                        },
+                        {
+                            "range": [10, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Magenta": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 9],
+                            "name": "open"
+                        },
+                        {
+                            "range": [10, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Yellow": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 9],
+                            "name": "open"
+                        },
+                        {
+                            "range": [10, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Color mode": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 125],
+                            "name": "125",
+                            "center": true
+                        },
+                        {
+                            "range": [126, 255],
+                            "name": "proportional"
+                        }
+                    ]
+                },
+                "MIB": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 249],
+                            "name": "off"
+                        },
+                        {
+                            "range": [250, 255],
+                            "name": "on"
+                        }
+                    ]
+                },
+                "Reset": {
+                    "type": "Beam",
+                    "defaultValue": 50,
+                    "highlightValue": 50,
+                    "capabilities": [
+                        {
+                            "range": [0, 19],
+                            "name": "lamp off"
+                        },
+                        {
+                            "range": [20, 100],
+                            "name": "idle"
+                        },
+                        {
+                            "range": [101, 170],
+                            "name": "fx reset"
+                        },
+                        {
+                            "range": [171, 200],
+                            "name": "reset"
+                        },
+                        {
+                            "range": [201, 240],
+                            "name": "silent fan"
+                        },
+                        {
+                            "range": [241, 255],
+                            "name": "lamp on"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "16-channel Mode",
+                    "shortName": "16ch",
+                    "channels": [
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "P/T speed",
+                        "Intensity",
+                        "Shutter",
+                        "Zoom",
+                        "Beam FX",
+                        "Color",
+                        "Cyan",
+                        "Magenta",
+                        "Yellow",
+                        "Color mode",
+                        "MIB",
+                        "Reset"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Coemar",
+            "name": "Super Cyc 24",
+            "shortName": "SuperCyc",
+            "comment": "Dual 1200 Watt",
+            "physical": {
+                "dimensions": [700, 700, 885]
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 0,
+                    "highlightValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 0,
+                    "highlightValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Speed": {
+                    "type": "Speed",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "New Range"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 10],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [11, 255],
+                            "name": "open"
+                        }
+                    ]
+                },
+                "Cyan": {
+                    "type": "SingleColor",
+                    "color": "Cyan",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "5"
+                        }
+                    ]
+                },
+                "Magenta": {
+                    "type": "SingleColor",
+                    "color": "Magenta",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "5"
+                        }
+                    ]
+                },
+                "Yellow": {
+                    "type": "SingleColor",
+                    "color": "Yellow",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Lamp Right": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 100],
+                            "name": "lamp off"
+                        },
+                        {
+                            "range": [241, 255],
+                            "name": "lamp on",
+                            "center": true
+                        }
+                    ]
+                },
+                "Lamp Left / Res": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 10],
+                            "name": "Lamp Off"
+                        },
+                        {
+                            "range": [11, 30],
+                            "name": "Park"
+                        },
+                        {
+                            "range": [241, 255],
+                            "name": "Lamp On"
+                        },
+                        {
+                            "range": [31, 99],
+                            "name": "LampHSReset"
+                        },
+                        {
+                            "range": [100, 240],
+                            "name": "Motor Reset"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "11-channel Mode",
+                    "shortName": "11ch",
+                    "channels": [
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "Speed",
+                        "Intensity",
+                        "Cyan",
+                        "Magenta",
+                        "Yellow",
+                        "Lamp Right",
+                        "Lamp Left / Res"
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/fixtures/imports/ecue-MainLibrary/Coolux.json
+++ b/fixtures/imports/ecue-MainLibrary/Coolux.json
@@ -1,0 +1,245 @@
+{
+    "manufacturers": {
+        "Coolux": {
+            "name": "Coolux",
+            "website": "www.coolux.de"
+        }
+    },
+    "fixtures": [
+        {
+            "manufacturer": "Coolux",
+            "name": "Media Player",
+            "shortName": "MediaPlayer",
+            "physical": {
+                "dimensions": [100, 100, 100]
+            },
+            "availableChannels": {
+                "Dimmer": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 100,
+                    "crossfade": true
+                },
+                "Crossfader": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "crossfade": true
+                },
+                "G1": {
+                    "type": "Beam",
+                    "defaultValue": 1,
+                    "crossfade": true
+                },
+                "G1 Ctrl": {
+                    "type": "Beam",
+                    "defaultValue": 192,
+                    "crossfade": true
+                },
+                "G1 Mode": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "G1 Pos X": {
+                    "type": "Beam",
+                    "defaultValue": 127,
+                    "crossfade": true,
+                    "highlightValue": null
+                },
+                "G1 Pos X fine": {
+                    "type": "Beam",
+                    "defaultValue": 255,
+                    "crossfade": true,
+                    "highlightValue": null
+                },
+                "G1 Pos Y": {
+                    "type": "Beam",
+                    "defaultValue": 127,
+                    "crossfade": true,
+                    "highlightValue": null
+                },
+                "G1 Pos Y fine": {
+                    "type": "Beam",
+                    "defaultValue": 255,
+                    "crossfade": true,
+                    "highlightValue": null
+                },
+                "G1 Zoom": {
+                    "type": "Beam",
+                    "defaultValue": 127,
+                    "crossfade": true,
+                    "highlightValue": null
+                },
+                "G1 Zoom fine": {
+                    "type": "Beam",
+                    "defaultValue": 255,
+                    "crossfade": true,
+                    "highlightValue": null
+                },
+                "G1 Rot": {
+                    "type": "Beam",
+                    "defaultValue": 127,
+                    "crossfade": true,
+                    "highlightValue": null
+                },
+                "G1 Rot fine": {
+                    "type": "Beam",
+                    "defaultValue": 255,
+                    "crossfade": true,
+                    "highlightValue": null
+                },
+                "G2": {
+                    "type": "Beam",
+                    "defaultValue": 1,
+                    "crossfade": true
+                },
+                "G2 Ctrl": {
+                    "type": "Beam",
+                    "defaultValue": 192,
+                    "crossfade": true
+                },
+                "G2 Mode": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "G2 Pos X": {
+                    "type": "Beam",
+                    "defaultValue": 127,
+                    "crossfade": true,
+                    "highlightValue": null
+                },
+                "G2 Pos X fine": {
+                    "type": "Beam",
+                    "defaultValue": 255,
+                    "crossfade": true,
+                    "highlightValue": null
+                },
+                "G2 Pos Y": {
+                    "type": "Beam",
+                    "defaultValue": 127,
+                    "crossfade": true,
+                    "highlightValue": null
+                },
+                "G2 Pos Y fine": {
+                    "type": "Beam",
+                    "defaultValue": 255,
+                    "crossfade": true,
+                    "highlightValue": null
+                },
+                "G2 Zoom": {
+                    "type": "Beam",
+                    "defaultValue": 127,
+                    "crossfade": true,
+                    "highlightValue": null
+                },
+                "G2 Zoom fine": {
+                    "type": "Beam",
+                    "defaultValue": 255,
+                    "crossfade": true,
+                    "highlightValue": null
+                },
+                "G2 Rot": {
+                    "type": "Beam",
+                    "defaultValue": 127,
+                    "crossfade": true,
+                    "highlightValue": null
+                },
+                "G2 Rot fine": {
+                    "type": "Beam",
+                    "defaultValue": 255,
+                    "crossfade": true,
+                    "highlightValue": null
+                },
+                "Colormix1": {
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "crossfade": true
+                },
+                "Colormix2": {
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "crossfade": true
+                },
+                "Colormix3": {
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "crossfade": true
+                },
+                "ColTr Mode": {
+                    "type": "Beam",
+                    "defaultValue": 2,
+                    "crossfade": true
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "G1 Pos X",
+                    "G1 Pos X fine"
+                ],
+                [
+                    "G1 Pos Y",
+                    "G1 Pos Y fine"
+                ],
+                [
+                    "G1 Zoom",
+                    "G1 Zoom fine"
+                ],
+                [
+                    "G1 Rot",
+                    "G1 Rot fine"
+                ],
+                [
+                    "G2 Pos X",
+                    "G2 Pos X fine"
+                ],
+                [
+                    "G2 Pos Y",
+                    "G2 Pos Y fine"
+                ],
+                [
+                    "G2 Zoom",
+                    "G2 Zoom fine"
+                ],
+                [
+                    "G2 Rot",
+                    "G2 Rot fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "28-channel Mode",
+                    "shortName": "28ch",
+                    "channels": [
+                        "Dimmer",
+                        "Crossfader",
+                        "G1",
+                        "G1 Ctrl",
+                        "G1 Mode",
+                        "G1 Pos X",
+                        "G1 Pos X fine",
+                        "G1 Pos Y",
+                        "G1 Pos Y fine",
+                        "G1 Zoom",
+                        "G1 Zoom fine",
+                        "G1 Rot",
+                        "G1 Rot fine",
+                        "G2",
+                        "G2 Ctrl",
+                        "G2 Mode",
+                        "G2 Pos X",
+                        "G2 Pos X fine",
+                        "G2 Pos Y",
+                        "G2 Pos Y fine",
+                        "G2 Zoom",
+                        "G2 Zoom fine",
+                        "G2 Rot",
+                        "G2 Rot fine",
+                        "Colormix1",
+                        "Colormix2",
+                        "Colormix3",
+                        "ColTr Mode"
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/fixtures/imports/ecue-MainLibrary/DTS.json
+++ b/fixtures/imports/ecue-MainLibrary/DTS.json
@@ -1,0 +1,2151 @@
+{
+    "manufacturers": {
+        "DTS": {
+            "name": "DTS",
+            "website": "http://www.dts-lighting.it"
+        }
+    },
+    "fixtures": [
+        {
+            "manufacturer": "DTS",
+            "name": "ARC 575",
+            "shortName": "ARC5",
+            "physical": {
+                "dimensions": [620, 480, 730],
+                "weight": 50,
+                "power": 575
+            },
+            "availableChannels": {
+                "Intesity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Shutter": {
+                    "type": "Shutter",
+                    "defaultValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 9],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [10, 23],
+                            "name": "random"
+                        },
+                        {
+                            "range": [24, 107],
+                            "name": "speed"
+                        },
+                        {
+                            "range": [108, 219],
+                            "name": "pulse"
+                        },
+                        {
+                            "range": [220, 227],
+                            "name": "color_gobo"
+                        },
+                        {
+                            "range": [228, 233],
+                            "name": "pan_tilt"
+                        },
+                        {
+                            "range": [234, 255],
+                            "name": "open"
+                        }
+                    ]
+                },
+                "CYAN": {
+                    "type": "SingleColor",
+                    "color": "Cyan",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "MAGENTA": {
+                    "type": "SingleColor",
+                    "color": "Magenta",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "YELLOW": {
+                    "type": "SingleColor",
+                    "color": "Yellow",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "MACRO COL": {
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "NO Function": {
+                    "type": "Intensity",
+                    "warning": "Please check type!"
+                },
+                "Reset": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 29],
+                            "name": "no function"
+                        },
+                        {
+                            "range": [30, 85],
+                            "name": "lamp off"
+                        },
+                        {
+                            "range": [86, 170],
+                            "name": "int. reset"
+                        },
+                        {
+                            "range": [171, 235],
+                            "name": "reset"
+                        },
+                        {
+                            "range": [236, 255],
+                            "name": "lamp on"
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "8-channel Mode",
+                    "shortName": "8ch",
+                    "channels": [
+                        "Intesity",
+                        "Shutter",
+                        "CYAN",
+                        "MAGENTA",
+                        "YELLOW",
+                        "MACRO COL",
+                        "NO Function",
+                        "Reset"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "DTS",
+            "name": "DeltaR",
+            "shortName": "DeltaR",
+            "comment": "cd",
+            "physical": {
+                "dimensions": [430, 300, 570],
+                "weight": 30
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 0,
+                    "highlightValue": 0,
+                    "crossfade": true
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 0,
+                    "highlightValue": 0,
+                    "crossfade": true
+                },
+                "P/T speed": {
+                    "type": "Speed",
+                    "crossfade": true
+                },
+                "Shutter": {
+                    "type": "Shutter",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 9],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [10, 19],
+                            "name": "open"
+                        },
+                        {
+                            "range": [20, 29],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [30, 119],
+                            "name": "strobe"
+                        },
+                        {
+                            "range": [120, 149],
+                            "name": "pulse open"
+                        },
+                        {
+                            "range": [150, 179],
+                            "name": "pulse closed"
+                        },
+                        {
+                            "range": [180, 229],
+                            "name": "random"
+                        },
+                        {
+                            "range": [230, 244],
+                            "name": "MIB"
+                        },
+                        {
+                            "range": [245, 255],
+                            "name": "open"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "crossfade": true
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "crossfade": true
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "crossfade": true
+                },
+                "White": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "crossfade": true
+                },
+                "CTC": {
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "crossfade": true
+                },
+                "Macro": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Function": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 79],
+                            "name": "recall"
+                        },
+                        {
+                            "range": [80, 160],
+                            "name": "create"
+                        },
+                        {
+                            "range": [161, 255],
+                            "name": "store"
+                        }
+                    ]
+                },
+                "Reset": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "idle"
+                        },
+                        {
+                            "range": [16, 255],
+                            "name": "reset"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "15-channel Mode",
+                    "shortName": "15ch",
+                    "channels": [
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "P/T speed",
+                        "Shutter",
+                        "Intensity",
+                        "Red",
+                        "Green",
+                        "Blue",
+                        "White",
+                        "CTC",
+                        "Macro",
+                        "Function",
+                        "Reset"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "DTS",
+            "name": "DTS XR7",
+            "shortName": "XR7",
+            "physical": {
+                "dimensions": [450, 450, 870],
+                "weight": 26,
+                "power": 575
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "crossfade": true
+                },
+                "Pan Fine": {
+                    "type": "Pan"
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "crossfade": true
+                },
+                "Tilt Fine": {
+                    "type": "Tilt"
+                },
+                "Speed1": {
+                    "type": "Speed",
+                    "crossfade": true
+                },
+                "Dimmer": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Shutter": {
+                    "type": "Shutter",
+                    "crossfade": true
+                },
+                "Color1": {
+                    "type": "SingleColor",
+                    "color": "Generic"
+                },
+                "Color2": {
+                    "type": "SingleColor",
+                    "color": "Generic"
+                },
+                "Gobo fest": {
+                    "type": "Gobo"
+                },
+                "Gobo rot.": {
+                    "type": "Gobo"
+                },
+                "Prisma rot.": {
+                    "type": "Prism",
+                    "crossfade": true
+                },
+                "Focus": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Iris": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Frost": {
+                    "type": "Beam"
+                },
+                "Special": {
+                    "type": "Intensity",
+                    "warning": "Please check type!"
+                }
+            },
+            "modes": [
+                {
+                    "name": "16-channel Mode",
+                    "shortName": "16ch",
+                    "channels": [
+                        "Pan",
+                        "Pan Fine",
+                        "Tilt",
+                        "Tilt Fine",
+                        "Speed1",
+                        "Dimmer",
+                        "Shutter",
+                        "Color1",
+                        "Color2",
+                        "Gobo fest",
+                        "Gobo rot.",
+                        "Prisma rot.",
+                        "Focus",
+                        "Iris",
+                        "Frost",
+                        "Special"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "DTS",
+            "name": "X-Scan 575",
+            "shortName": "X-Scan",
+            "comment": "15 channel mode",
+            "physical": {
+                "dimensions": [330, 440, 900]
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "Speed": {
+                    "type": "Speed",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Shutter": {
+                    "type": "Shutter",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 9],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [10, 23],
+                            "name": "random"
+                        },
+                        {
+                            "range": [24, 107],
+                            "name": "speed"
+                        },
+                        {
+                            "range": [108, 219],
+                            "name": "pulse"
+                        },
+                        {
+                            "range": [220, 227],
+                            "name": "color_gobo"
+                        },
+                        {
+                            "range": [228, 233],
+                            "name": "pan_tilt"
+                        },
+                        {
+                            "range": [234, 255],
+                            "name": "open"
+                        },
+                        {
+                            "range": [0, 0],
+                            "name": "New Range"
+                        }
+                    ]
+                },
+                "Color": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 10],
+                            "name": "Color 1"
+                        },
+                        {
+                            "range": [22, 32],
+                            "name": "Color 2"
+                        },
+                        {
+                            "range": [44, 54],
+                            "name": "Color 3"
+                        },
+                        {
+                            "range": [6, 76],
+                            "name": "Color 4"
+                        },
+                        {
+                            "range": [88, 98],
+                            "name": "Color 5"
+                        },
+                        {
+                            "range": [110, 120],
+                            "name": "Color 6"
+                        },
+                        {
+                            "range": [132, 142],
+                            "name": "Color 7"
+                        },
+                        {
+                            "range": [154, 164],
+                            "name": "Color 8"
+                        },
+                        {
+                            "range": [176, 186],
+                            "name": "Color 9"
+                        },
+                        {
+                            "range": [198, 224],
+                            "name": "rot cw"
+                        },
+                        {
+                            "range": [225, 228],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [229, 255],
+                            "name": "rot ccw"
+                        }
+                    ]
+                },
+                "ColorP": {
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Gobo": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 25],
+                            "name": "open"
+                        },
+                        {
+                            "range": [26, 51],
+                            "name": "Gobo 1"
+                        },
+                        {
+                            "range": [52, 77],
+                            "name": "Gobo 2"
+                        },
+                        {
+                            "range": [78, 103],
+                            "name": "Gobo 3"
+                        },
+                        {
+                            "range": [104, 129],
+                            "name": "Gobo 4"
+                        },
+                        {
+                            "range": [130, 155],
+                            "name": "Gobo 5"
+                        },
+                        {
+                            "range": [156, 181],
+                            "name": "Gobo 6"
+                        },
+                        {
+                            "range": [182, 207],
+                            "name": "Gobo 7"
+                        },
+                        {
+                            "range": [208, 255],
+                            "name": "Speed rot"
+                        }
+                    ]
+                },
+                "GoboRot": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "index"
+                        },
+                        {
+                            "range": [128, 180],
+                            "name": "rot left"
+                        },
+                        {
+                            "range": [181, 202],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [203, 255],
+                            "name": "rot right"
+                        }
+                    ]
+                },
+                "Prism": {
+                    "type": "Prism",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 63],
+                            "name": "open"
+                        },
+                        {
+                            "range": [64, 127],
+                            "name": "prism"
+                        },
+                        {
+                            "range": [128, 191],
+                            "name": "rot left"
+                        },
+                        {
+                            "range": [192, 255],
+                            "name": "rot right"
+                        }
+                    ]
+                },
+                "Focus": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "GoboF": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "open"
+                        },
+                        {
+                            "range": [16, 31],
+                            "name": "Gobo 1"
+                        },
+                        {
+                            "range": [32, 47],
+                            "name": "Gobo 2"
+                        },
+                        {
+                            "range": [48, 63],
+                            "name": "Gobo 3"
+                        },
+                        {
+                            "range": [64, 79],
+                            "name": "Gobo 4"
+                        },
+                        {
+                            "range": [80, 95],
+                            "name": "Gobo 5"
+                        },
+                        {
+                            "range": [96, 111],
+                            "name": "Gobo 6"
+                        },
+                        {
+                            "range": [112, 127],
+                            "name": "Gobo 7"
+                        },
+                        {
+                            "range": [128, 143],
+                            "name": "Gobo 8"
+                        },
+                        {
+                            "range": [144, 159],
+                            "name": "Gobo 9"
+                        },
+                        {
+                            "range": [160, 175],
+                            "name": "Gobo 10"
+                        },
+                        {
+                            "range": [176, 191],
+                            "name": "Gobo 11"
+                        },
+                        {
+                            "range": [192, 255],
+                            "name": "speed"
+                        }
+                    ]
+                },
+                "Reset": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 29],
+                            "name": "no function"
+                        },
+                        {
+                            "range": [30, 85],
+                            "name": "lamp off"
+                        },
+                        {
+                            "range": [86, 170],
+                            "name": "int. reset"
+                        },
+                        {
+                            "range": [171, 235],
+                            "name": "reset"
+                        },
+                        {
+                            "range": [236, 255],
+                            "name": "lamp on"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "15-channel Mode",
+                    "shortName": "15ch",
+                    "channels": [
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "Speed",
+                        "Intensity",
+                        "Shutter",
+                        "Color",
+                        "ColorP",
+                        "Gobo",
+                        "GoboRot",
+                        "Prism",
+                        "Focus",
+                        "GoboF",
+                        "Reset"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "DTS",
+            "name": "XR7WASH",
+            "shortName": "XR7W",
+            "physical": {
+                "dimensions": [450, 450, 660],
+                "weight": 26,
+                "power": 575
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Speed1": {
+                    "type": "Speed",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Dimmer": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Shutter": {
+                    "type": "Shutter",
+                    "defaultValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 9],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [10, 23],
+                            "name": "random"
+                        },
+                        {
+                            "range": [24, 107],
+                            "name": "speed"
+                        },
+                        {
+                            "range": [108, 219],
+                            "name": "pulse"
+                        },
+                        {
+                            "range": [220, 227],
+                            "name": "color_gobo"
+                        },
+                        {
+                            "range": [228, 233],
+                            "name": "pan_tilt"
+                        },
+                        {
+                            "range": [234, 255],
+                            "name": "open"
+                        }
+                    ]
+                },
+                "Color": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 12],
+                            "name": "Color 1"
+                        },
+                        {
+                            "range": [13, 25],
+                            "name": "Color 2"
+                        },
+                        {
+                            "range": [26, 38],
+                            "name": "Color 3"
+                        },
+                        {
+                            "range": [39, 51],
+                            "name": "Color 4"
+                        },
+                        {
+                            "range": [52, 64],
+                            "name": "Color 5"
+                        },
+                        {
+                            "range": [65, 77],
+                            "name": "Color 6"
+                        },
+                        {
+                            "range": [78, 90],
+                            "name": "Color 7"
+                        },
+                        {
+                            "range": [91, 103],
+                            "name": "Color 8"
+                        },
+                        {
+                            "range": [104, 116],
+                            "name": "Color 9"
+                        },
+                        {
+                            "range": [117, 129],
+                            "name": "Color 10"
+                        },
+                        {
+                            "range": [130, 142],
+                            "name": "Color 11"
+                        },
+                        {
+                            "range": [143, 155],
+                            "name": "Color 12"
+                        },
+                        {
+                            "range": [156, 168],
+                            "name": "Color 13"
+                        },
+                        {
+                            "range": [169, 181],
+                            "name": "Color 14"
+                        },
+                        {
+                            "range": [182, 197],
+                            "name": "Color 15"
+                        },
+                        {
+                            "range": [198, 255],
+                            "name": "Color Speed"
+                        }
+                    ]
+                },
+                "CYAN": {
+                    "type": "SingleColor",
+                    "color": "Cyan",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "MAGENTA": {
+                    "type": "SingleColor",
+                    "color": "Magenta",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "YELLOW": {
+                    "type": "SingleColor",
+                    "color": "Yellow",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "CMY SPEED": {
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "COL MACRO": {
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "FROST BEAM": {
+                    "type": "Intensity",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 19],
+                            "name": "NO"
+                        },
+                        {
+                            "range": [20, 39],
+                            "name": "FROST",
+                            "color": "#edf5dd"
+                        },
+                        {
+                            "range": [40, 255],
+                            "name": "BEAM SHAPE"
+                        }
+                    ]
+                },
+                "ZOOM": {
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "defaultValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Reset": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 29],
+                            "name": "no function"
+                        },
+                        {
+                            "range": [30, 85],
+                            "name": "lamp off"
+                        },
+                        {
+                            "range": [86, 170],
+                            "name": "int. reset"
+                        },
+                        {
+                            "range": [171, 235],
+                            "name": "reset"
+                        },
+                        {
+                            "range": [236, 255],
+                            "name": "lamp on"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "16-channel Mode",
+                    "shortName": "16ch",
+                    "channels": [
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "Speed1",
+                        "Dimmer",
+                        "Shutter",
+                        "Color",
+                        "CYAN",
+                        "MAGENTA",
+                        "YELLOW",
+                        "CMY SPEED",
+                        "COL MACRO",
+                        "FROST BEAM",
+                        "ZOOM",
+                        "Reset"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "DTS",
+            "name": "XR9 Spot 18ch",
+            "shortName": "XR9 Spot",
+            "comment": "18ch. Mode                         cd",
+            "physical": {
+                "dimensions": [470, 470, 670],
+                "weight": 29,
+                "power": 575
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 0,
+                    "highlightValue": 0,
+                    "crossfade": true
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 0,
+                    "highlightValue": 0,
+                    "crossfade": true
+                },
+                "P/T speed": {
+                    "type": "Speed",
+                    "crossfade": true
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Shutter": {
+                    "type": "Shutter",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 9],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [10, 19],
+                            "name": "open"
+                        },
+                        {
+                            "range": [20, 29],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [30, 119],
+                            "name": "strobe"
+                        },
+                        {
+                            "range": [120, 149],
+                            "name": "pulse open"
+                        },
+                        {
+                            "range": [150, 179],
+                            "name": "pulse closed"
+                        },
+                        {
+                            "range": [180, 229],
+                            "name": "random"
+                        },
+                        {
+                            "range": [230, 244],
+                            "name": "MIB"
+                        },
+                        {
+                            "range": [245, 255],
+                            "name": "open"
+                        }
+                    ]
+                },
+                "Color1": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 21],
+                            "name": "open",
+                            "center": true
+                        },
+                        {
+                            "range": [22, 43],
+                            "name": "color1",
+                            "center": true
+                        },
+                        {
+                            "range": [44, 65],
+                            "name": "color2",
+                            "center": true
+                        },
+                        {
+                            "range": [66, 87],
+                            "name": "color3"
+                        },
+                        {
+                            "range": [88, 109],
+                            "name": "color4"
+                        },
+                        {
+                            "range": [110, 131],
+                            "name": "color5"
+                        },
+                        {
+                            "range": [132, 153],
+                            "name": "color6"
+                        },
+                        {
+                            "range": [154, 175],
+                            "name": "color7"
+                        },
+                        {
+                            "range": [176, 197],
+                            "name": "color8"
+                        },
+                        {
+                            "range": [198, 224],
+                            "name": ">>"
+                        },
+                        {
+                            "range": [225, 228],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [229, 255],
+                            "name": "<<"
+                        }
+                    ]
+                },
+                "Color2": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 21],
+                            "name": "open",
+                            "center": true
+                        },
+                        {
+                            "range": [22, 43],
+                            "name": "color1",
+                            "center": true
+                        },
+                        {
+                            "range": [44, 65],
+                            "name": "color2",
+                            "center": true
+                        },
+                        {
+                            "range": [66, 87],
+                            "name": "color3"
+                        },
+                        {
+                            "range": [88, 109],
+                            "name": "color4"
+                        },
+                        {
+                            "range": [110, 131],
+                            "name": "color5"
+                        },
+                        {
+                            "range": [132, 153],
+                            "name": "color6"
+                        },
+                        {
+                            "range": [154, 175],
+                            "name": "color7"
+                        },
+                        {
+                            "range": [176, 197],
+                            "name": "color8"
+                        },
+                        {
+                            "range": [198, 224],
+                            "name": ">>"
+                        },
+                        {
+                            "range": [225, 228],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [229, 255],
+                            "name": "<<"
+                        }
+                    ]
+                },
+                "Gobo1": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 25],
+                            "name": "open"
+                        },
+                        {
+                            "range": [26, 51],
+                            "name": "slot1"
+                        },
+                        {
+                            "range": [52, 77],
+                            "name": "slot2"
+                        },
+                        {
+                            "range": [78, 103],
+                            "name": "slot3"
+                        },
+                        {
+                            "range": [104, 129],
+                            "name": "slot4"
+                        },
+                        {
+                            "range": [130, 155],
+                            "name": "slot5"
+                        },
+                        {
+                            "range": [156, 181],
+                            "name": "slot6"
+                        },
+                        {
+                            "range": [182, 207],
+                            "name": "slot7"
+                        },
+                        {
+                            "range": [208, 255],
+                            "name": ">>"
+                        }
+                    ]
+                },
+                "Gobo1 rot.": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "ind."
+                        },
+                        {
+                            "range": [128, 180],
+                            "name": ">>"
+                        },
+                        {
+                            "range": [181, 202],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [203, 255],
+                            "name": "<<"
+                        }
+                    ]
+                },
+                "Gobo2": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "open"
+                        },
+                        {
+                            "range": [16, 31],
+                            "name": "slot1"
+                        },
+                        {
+                            "range": [32, 47],
+                            "name": "slot2"
+                        },
+                        {
+                            "range": [48, 63],
+                            "name": "slot3"
+                        },
+                        {
+                            "range": [64, 79],
+                            "name": "slot4"
+                        },
+                        {
+                            "range": [80, 95],
+                            "name": "slot5"
+                        },
+                        {
+                            "range": [96, 111],
+                            "name": "slot6"
+                        },
+                        {
+                            "range": [112, 127],
+                            "name": "slot7"
+                        },
+                        {
+                            "range": [128, 143],
+                            "name": "slot8"
+                        },
+                        {
+                            "range": [144, 159],
+                            "name": "slot9"
+                        },
+                        {
+                            "range": [160, 175],
+                            "name": "slot10"
+                        },
+                        {
+                            "range": [176, 191],
+                            "name": "slot11"
+                        },
+                        {
+                            "range": [192, 255],
+                            "name": ">>"
+                        }
+                    ]
+                },
+                "Iris": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 9],
+                            "name": "open"
+                        },
+                        {
+                            "range": [10, 160],
+                            "name": "%"
+                        },
+                        {
+                            "range": [161, 171],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [172, 255],
+                            "name": "pulse"
+                        }
+                    ]
+                },
+                "Prisma": {
+                    "type": "Prism",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 63],
+                            "name": "open"
+                        },
+                        {
+                            "range": [64, 127],
+                            "name": "in"
+                        },
+                        {
+                            "range": [128, 191],
+                            "name": "<<"
+                        },
+                        {
+                            "range": [192, 255],
+                            "name": ">>"
+                        }
+                    ]
+                },
+                "Focus": {
+                    "type": "Beam",
+                    "defaultValue": 128,
+                    "crossfade": true
+                },
+                "Zoom": {
+                    "type": "Beam",
+                    "defaultValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 84],
+                            "name": "11"
+                        },
+                        {
+                            "range": [85, 170],
+                            "name": "15"
+                        },
+                        {
+                            "range": [171, 255],
+                            "name": "18"
+                        }
+                    ]
+                },
+                "Frost": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 84],
+                            "name": "open"
+                        },
+                        {
+                            "range": [85, 169],
+                            "name": "frost1"
+                        },
+                        {
+                            "range": [170, 255],
+                            "name": "frost2"
+                        }
+                    ]
+                },
+                "Reset": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 9],
+                            "name": "idle"
+                        },
+                        {
+                            "range": [10, 60],
+                            "name": "lamp off"
+                        },
+                        {
+                            "range": [61, 129],
+                            "name": "idle"
+                        },
+                        {
+                            "range": [130, 179],
+                            "name": "lamp on"
+                        },
+                        {
+                            "range": [180, 200],
+                            "name": "idle"
+                        },
+                        {
+                            "range": [201, 239],
+                            "name": "stepper reset"
+                        },
+                        {
+                            "range": [240, 255],
+                            "name": "reset"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "18-channel Mode",
+                    "shortName": "18ch",
+                    "channels": [
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "P/T speed",
+                        "Intensity",
+                        "Shutter",
+                        "Color1",
+                        "Color2",
+                        "Gobo1",
+                        "Gobo1 rot.",
+                        "Gobo2",
+                        "Iris",
+                        "Prisma",
+                        "Focus",
+                        "Zoom",
+                        "Frost",
+                        "Reset"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "DTS",
+            "name": "XR9 Spot 26ch",
+            "shortName": "XR9 Spot.1",
+            "comment": "26ch. Mode                         cd",
+            "physical": {
+                "dimensions": [470, 470, 670],
+                "weight": 29,
+                "power": 575
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 0,
+                    "highlightValue": 0,
+                    "crossfade": true
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 0,
+                    "highlightValue": 0,
+                    "crossfade": true
+                },
+                "P/T speed": {
+                    "type": "Speed",
+                    "crossfade": true
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Shutter": {
+                    "type": "Shutter",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 9],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [10, 19],
+                            "name": "open"
+                        },
+                        {
+                            "range": [20, 29],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [30, 119],
+                            "name": "strobe"
+                        },
+                        {
+                            "range": [120, 149],
+                            "name": "pulse open"
+                        },
+                        {
+                            "range": [150, 179],
+                            "name": "pulse closed"
+                        },
+                        {
+                            "range": [180, 229],
+                            "name": "random"
+                        },
+                        {
+                            "range": [230, 244],
+                            "name": "MIB"
+                        },
+                        {
+                            "range": [245, 255],
+                            "name": "open"
+                        }
+                    ]
+                },
+                "Color1": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 21],
+                            "name": "open",
+                            "center": true
+                        },
+                        {
+                            "range": [22, 43],
+                            "name": "color1",
+                            "center": true
+                        },
+                        {
+                            "range": [44, 65],
+                            "name": "color2",
+                            "center": true
+                        },
+                        {
+                            "range": [66, 87],
+                            "name": "color3"
+                        },
+                        {
+                            "range": [88, 109],
+                            "name": "color4"
+                        },
+                        {
+                            "range": [110, 131],
+                            "name": "color5"
+                        },
+                        {
+                            "range": [132, 153],
+                            "name": "color6"
+                        },
+                        {
+                            "range": [154, 175],
+                            "name": "color7"
+                        },
+                        {
+                            "range": [176, 197],
+                            "name": "color8"
+                        },
+                        {
+                            "range": [198, 224],
+                            "name": ">>"
+                        },
+                        {
+                            "range": [225, 228],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [229, 255],
+                            "name": "<<"
+                        }
+                    ]
+                },
+                "Color2": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 21],
+                            "name": "open",
+                            "center": true
+                        },
+                        {
+                            "range": [22, 43],
+                            "name": "color1",
+                            "center": true
+                        },
+                        {
+                            "range": [44, 65],
+                            "name": "color2",
+                            "center": true
+                        },
+                        {
+                            "range": [66, 87],
+                            "name": "color3"
+                        },
+                        {
+                            "range": [88, 109],
+                            "name": "color4"
+                        },
+                        {
+                            "range": [110, 131],
+                            "name": "color5"
+                        },
+                        {
+                            "range": [132, 153],
+                            "name": "color6"
+                        },
+                        {
+                            "range": [154, 175],
+                            "name": "color7"
+                        },
+                        {
+                            "range": [176, 197],
+                            "name": "color8"
+                        },
+                        {
+                            "range": [198, 224],
+                            "name": ">>"
+                        },
+                        {
+                            "range": [225, 228],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [229, 255],
+                            "name": "<<"
+                        }
+                    ]
+                },
+                "Color1 mode": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Color2 mode": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Gobo1": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 25],
+                            "name": "open"
+                        },
+                        {
+                            "range": [26, 51],
+                            "name": "slot1"
+                        },
+                        {
+                            "range": [52, 77],
+                            "name": "slot2"
+                        },
+                        {
+                            "range": [78, 103],
+                            "name": "slot3"
+                        },
+                        {
+                            "range": [104, 129],
+                            "name": "slot4"
+                        },
+                        {
+                            "range": [130, 155],
+                            "name": "slot5"
+                        },
+                        {
+                            "range": [156, 181],
+                            "name": "slot6"
+                        },
+                        {
+                            "range": [182, 207],
+                            "name": "slot7"
+                        },
+                        {
+                            "range": [208, 255],
+                            "name": ">>"
+                        }
+                    ]
+                },
+                "Gobo1 rot.": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "ind."
+                        },
+                        {
+                            "range": [128, 180],
+                            "name": ">>"
+                        },
+                        {
+                            "range": [181, 202],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [203, 255],
+                            "name": "<<"
+                        }
+                    ]
+                },
+                "Gobo2": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "open"
+                        },
+                        {
+                            "range": [16, 31],
+                            "name": "slot1"
+                        },
+                        {
+                            "range": [32, 47],
+                            "name": "slot2"
+                        },
+                        {
+                            "range": [48, 63],
+                            "name": "slot3"
+                        },
+                        {
+                            "range": [64, 79],
+                            "name": "slot4"
+                        },
+                        {
+                            "range": [80, 95],
+                            "name": "slot5"
+                        },
+                        {
+                            "range": [96, 111],
+                            "name": "slot6"
+                        },
+                        {
+                            "range": [112, 127],
+                            "name": "slot7"
+                        },
+                        {
+                            "range": [128, 143],
+                            "name": "slot8"
+                        },
+                        {
+                            "range": [144, 159],
+                            "name": "slot9"
+                        },
+                        {
+                            "range": [160, 175],
+                            "name": "slot10"
+                        },
+                        {
+                            "range": [176, 191],
+                            "name": "slot11"
+                        },
+                        {
+                            "range": [192, 255],
+                            "name": ">>"
+                        }
+                    ]
+                },
+                "Iris": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 9],
+                            "name": "open"
+                        },
+                        {
+                            "range": [10, 160],
+                            "name": "%"
+                        },
+                        {
+                            "range": [161, 171],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [172, 255],
+                            "name": "pulse"
+                        }
+                    ]
+                },
+                "Prisma": {
+                    "type": "Prism",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 63],
+                            "name": "open"
+                        },
+                        {
+                            "range": [64, 127],
+                            "name": "in"
+                        },
+                        {
+                            "range": [128, 191],
+                            "name": "<<"
+                        },
+                        {
+                            "range": [192, 255],
+                            "name": ">>"
+                        }
+                    ]
+                },
+                "Focus": {
+                    "type": "Beam",
+                    "defaultValue": 128,
+                    "crossfade": true
+                },
+                "Zoom": {
+                    "type": "Beam",
+                    "defaultValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 84],
+                            "name": "11"
+                        },
+                        {
+                            "range": [85, 170],
+                            "name": "15"
+                        },
+                        {
+                            "range": [171, 255],
+                            "name": "18"
+                        }
+                    ]
+                },
+                "Frost": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 84],
+                            "name": "open"
+                        },
+                        {
+                            "range": [85, 169],
+                            "name": "frost1"
+                        },
+                        {
+                            "range": [170, 255],
+                            "name": "frost2"
+                        }
+                    ]
+                },
+                "Reset": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 9],
+                            "name": "idle"
+                        },
+                        {
+                            "range": [10, 60],
+                            "name": "lamp off"
+                        },
+                        {
+                            "range": [61, 129],
+                            "name": "idle"
+                        },
+                        {
+                            "range": [130, 179],
+                            "name": "lamp on"
+                        },
+                        {
+                            "range": [180, 200],
+                            "name": "idle"
+                        },
+                        {
+                            "range": [201, 239],
+                            "name": "stepper reset"
+                        },
+                        {
+                            "range": [240, 255],
+                            "name": "reset"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "18-channel Mode",
+                    "shortName": "18ch",
+                    "channels": [
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "P/T speed",
+                        "Intensity",
+                        "Shutter",
+                        "Color1",
+                        "Color1 mode",
+                        "Gobo1",
+                        "Gobo1 rot.",
+                        "Gobo2",
+                        "Iris",
+                        "Prisma",
+                        "Focus",
+                        "Zoom",
+                        "Frost",
+                        "Reset"
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/fixtures/imports/ecue-MainLibrary/Deemagix.json
+++ b/fixtures/imports/ecue-MainLibrary/Deemagix.json
@@ -1,0 +1,1313 @@
+{
+    "manufacturers": {
+        "Deemagix": {
+            "name": "Deemagix",
+            "website": "http://www.laseranimation.com/products/deemag_d.html"
+        }
+    },
+    "fixtures": [
+        {
+            "manufacturer": "Deemagix",
+            "name": "DaeMoniX",
+            "shortName": "DaeMoniX",
+            "comment": "control Lasershow like Moving Head",
+            "physical": {
+                "dimensions": [100, 100, 100]
+            },
+            "availableChannels": {
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 198,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [1, 198],
+                            "name": "%"
+                        },
+                        {
+                            "range": [216, 228],
+                            "name": "Pulse opening"
+                        },
+                        {
+                            "range": [229, 241],
+                            "name": "Pulse closing"
+                        },
+                        {
+                            "range": [242, 246],
+                            "name": "Random pulse op"
+                        },
+                        {
+                            "range": [249, 253],
+                            "name": "Random pulse cl"
+                        }
+                    ]
+                },
+                "Cyan": {
+                    "type": "SingleColor",
+                    "color": "Cyan",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Magenta": {
+                    "type": "SingleColor",
+                    "color": "Magenta",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Yellow": {
+                    "type": "SingleColor",
+                    "color": "Yellow",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Wheel Select": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 253],
+                            "name": "Wheels"
+                        },
+                        {
+                            "range": [254, 254],
+                            "name": "Test Picture"
+                        }
+                    ]
+                },
+                "Wheel Gobo": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 24],
+                            "name": "Gobo 1"
+                        },
+                        {
+                            "range": [25, 49],
+                            "name": "Gobo 2"
+                        },
+                        {
+                            "range": [50, 75],
+                            "name": "Gobo 3"
+                        },
+                        {
+                            "range": [76, 100],
+                            "name": "Gobo 4"
+                        },
+                        {
+                            "range": [101, 126],
+                            "name": "Gobo 5"
+                        },
+                        {
+                            "range": [127, 151],
+                            "name": "Gobo 6"
+                        },
+                        {
+                            "range": [152, 177],
+                            "name": "Gobo 7"
+                        },
+                        {
+                            "range": [178, 202],
+                            "name": "Gobo 8"
+                        },
+                        {
+                            "range": [203, 228],
+                            "name": "Gobo 9"
+                        },
+                        {
+                            "range": [229, 255],
+                            "name": "Gobo 10"
+                        }
+                    ]
+                },
+                "Effect Move": {
+                    "type": "Effect",
+                    "capabilities": [
+                        {
+                            "range": [0, 121],
+                            "name": "%"
+                        },
+                        {
+                            "range": [122, 182],
+                            "name": "Saw"
+                        },
+                        {
+                            "range": [183, 192],
+                            "name": "Stop"
+                        },
+                        {
+                            "range": [193, 255],
+                            "name": "Triangle"
+                        }
+                    ]
+                },
+                "Effect Rotation": {
+                    "type": "Effect",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 121],
+                            "name": "0"
+                        },
+                        {
+                            "range": [122, 182],
+                            "name": "Saw"
+                        },
+                        {
+                            "range": [183, 192],
+                            "name": "Stop"
+                        },
+                        {
+                            "range": [193, 255],
+                            "name": "Triangle"
+                        }
+                    ]
+                },
+                "Rotation X": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 126],
+                            "name": "0"
+                        },
+                        {
+                            "range": [127, 190],
+                            "name": "Continous =>"
+                        },
+                        {
+                            "range": [191, 192],
+                            "name": "Stop"
+                        },
+                        {
+                            "range": [193, 255],
+                            "name": "Continous <="
+                        }
+                    ]
+                },
+                "Rotation Y": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 126],
+                            "name": "0"
+                        },
+                        {
+                            "range": [127, 190],
+                            "name": "Continous =>"
+                        },
+                        {
+                            "range": [191, 192],
+                            "name": "Stop"
+                        },
+                        {
+                            "range": [193, 255],
+                            "name": "Continous <="
+                        }
+                    ]
+                },
+                "Rotation Z": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 126],
+                            "name": "0"
+                        },
+                        {
+                            "range": [127, 190],
+                            "name": "Continous =>"
+                        },
+                        {
+                            "range": [191, 192],
+                            "name": "Stop"
+                        },
+                        {
+                            "range": [193, 255],
+                            "name": "Continous <="
+                        }
+                    ]
+                },
+                "Zoom X": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "Size"
+                        }
+                    ]
+                },
+                "Zoom Y": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "Size"
+                        }
+                    ]
+                },
+                "Zoom Z": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "Size"
+                        }
+                    ]
+                },
+                "Effects": {
+                    "type": "Effect",
+                    "capabilities": [
+                        {
+                            "range": [0, 24],
+                            "name": "No Effect"
+                        },
+                        {
+                            "range": [25, 49],
+                            "name": "Color Cycle"
+                        },
+                        {
+                            "range": [50, 74],
+                            "name": "Pattern"
+                        },
+                        {
+                            "range": [75, 99],
+                            "name": "Visible Mask"
+                        },
+                        {
+                            "range": [100, 126],
+                            "name": "Invisible Mask"
+                        }
+                    ]
+                },
+                "Effect Par 1": {
+                    "type": "Effect",
+                    "capabilities": [
+                        {
+                            "range": [0, 9],
+                            "name": "Gobo 1"
+                        },
+                        {
+                            "range": [10, 19],
+                            "name": "Gobo 2"
+                        },
+                        {
+                            "range": [20, 29],
+                            "name": "Gobo 3"
+                        },
+                        {
+                            "range": [30, 39],
+                            "name": "Gobo 4"
+                        },
+                        {
+                            "range": [40, 49],
+                            "name": "Gobo 5"
+                        },
+                        {
+                            "range": [50, 60],
+                            "name": "Gobo 6"
+                        },
+                        {
+                            "range": [61, 70],
+                            "name": "Gobo 7"
+                        },
+                        {
+                            "range": [71, 80],
+                            "name": "Gobo 8"
+                        },
+                        {
+                            "range": [81, 90],
+                            "name": "Gobo 9"
+                        },
+                        {
+                            "range": [91, 100],
+                            "name": "Gobo 10"
+                        }
+                    ]
+                },
+                "Effect Par 2": {
+                    "type": "Effect",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Effect Par 3": {
+                    "type": "Effect",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Effect Par 4": {
+                    "type": "Effect",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Effect Par 5": {
+                    "type": "Effect",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Effect Par 6": {
+                    "type": "Effect",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Frame Top": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Frame Left": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Frame Right": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Frame Bottom": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Size Horizontal": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Size Vertical": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "31-channel Mode",
+                    "shortName": "31ch",
+                    "channels": [
+                        "Intensity",
+                        "Cyan",
+                        "Magenta",
+                        "Yellow",
+                        "Wheel Select",
+                        "Wheel Gobo",
+                        "Effect Move",
+                        "Effect Rotation",
+                        "Rotation X",
+                        "Rotation Y",
+                        "Rotation Z",
+                        "Zoom X",
+                        "Zoom Y",
+                        "Zoom Z",
+                        "Effects",
+                        "Effect Par 1",
+                        "Effect Par 2",
+                        "Effect Par 3",
+                        "Effect Par 4",
+                        "Effect Par 5",
+                        "Effect Par 6",
+                        "Frame Top",
+                        "Frame Left",
+                        "Frame Right",
+                        "Frame Bottom",
+                        "Size Horizontal",
+                        "Size Vertical",
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Deemagix",
+            "name": "Deemagix",
+            "shortName": "Deemagix",
+            "physical": {
+                "dimensions": [100, 100, 100]
+            },
+            "availableChannels": {
+                "Effect": {
+                    "type": "Effect",
+                    "capabilities": [
+                        {
+                            "range": [0, 1],
+                            "name": "none"
+                        },
+                        {
+                            "range": [2, 3],
+                            "name": "gobo1"
+                        },
+                        {
+                            "range": [4, 5],
+                            "name": "gobo2"
+                        },
+                        {
+                            "range": [6, 7],
+                            "name": "gobo3"
+                        },
+                        {
+                            "range": [8, 9],
+                            "name": "gobo4"
+                        },
+                        {
+                            "range": [10, 11],
+                            "name": "gobo5"
+                        },
+                        {
+                            "range": [12, 13],
+                            "name": "gobo6"
+                        },
+                        {
+                            "range": [14, 15],
+                            "name": "gobo7"
+                        },
+                        {
+                            "range": [16, 17],
+                            "name": "gobo8"
+                        },
+                        {
+                            "range": [18, 19],
+                            "name": "gobo9"
+                        },
+                        {
+                            "range": [20, 21],
+                            "name": "gobo10"
+                        },
+                        {
+                            "range": [22, 23],
+                            "name": "gobo11"
+                        },
+                        {
+                            "range": [24, 25],
+                            "name": "gobo12"
+                        },
+                        {
+                            "range": [26, 27],
+                            "name": "gobo13"
+                        },
+                        {
+                            "range": [28, 29],
+                            "name": "gobo14"
+                        },
+                        {
+                            "range": [30, 31],
+                            "name": "gobo15"
+                        },
+                        {
+                            "range": [32, 33],
+                            "name": "gobo16"
+                        },
+                        {
+                            "range": [34, 35],
+                            "name": "gobo17"
+                        },
+                        {
+                            "range": [36, 37],
+                            "name": "gobo18"
+                        },
+                        {
+                            "range": [38, 39],
+                            "name": "gobo19"
+                        },
+                        {
+                            "range": [40, 41],
+                            "name": "gobo20"
+                        },
+                        {
+                            "range": [42, 43],
+                            "name": "gobo21"
+                        },
+                        {
+                            "range": [44, 45],
+                            "name": "gobo22"
+                        },
+                        {
+                            "range": [46, 47],
+                            "name": "gobo23"
+                        },
+                        {
+                            "range": [48, 49],
+                            "name": "gobo24"
+                        },
+                        {
+                            "range": [50, 51],
+                            "name": "gobo25"
+                        },
+                        {
+                            "range": [52, 53],
+                            "name": "gobo26"
+                        },
+                        {
+                            "range": [54, 55],
+                            "name": "gobo27"
+                        },
+                        {
+                            "range": [56, 57],
+                            "name": "gobo28"
+                        },
+                        {
+                            "range": [58, 59],
+                            "name": "gobo29"
+                        },
+                        {
+                            "range": [60, 61],
+                            "name": "gobo30"
+                        },
+                        {
+                            "range": [62, 63],
+                            "name": "gobo31"
+                        },
+                        {
+                            "range": [64, 65],
+                            "name": "gobo32"
+                        },
+                        {
+                            "range": [66, 223],
+                            "name": "reserved"
+                        },
+                        {
+                            "range": [224, 225],
+                            "name": "animation1"
+                        },
+                        {
+                            "range": [226, 227],
+                            "name": "animation2"
+                        },
+                        {
+                            "range": [228, 229],
+                            "name": "animation3"
+                        },
+                        {
+                            "range": [230, 231],
+                            "name": "text1"
+                        },
+                        {
+                            "range": [232, 233],
+                            "name": "text2"
+                        },
+                        {
+                            "range": [234, 235],
+                            "name": "text3"
+                        },
+                        {
+                            "range": [236, 237],
+                            "name": "text4"
+                        },
+                        {
+                            "range": [238, 239],
+                            "name": "text5"
+                        },
+                        {
+                            "range": [240, 241],
+                            "name": "text6"
+                        },
+                        {
+                            "range": [242, 243],
+                            "name": "text7"
+                        },
+                        {
+                            "range": [244, 245],
+                            "name": "text8"
+                        },
+                        {
+                            "range": [246, 247],
+                            "name": "text9"
+                        },
+                        {
+                            "range": [248, 249],
+                            "name": "text10"
+                        },
+                        {
+                            "range": [250, 251],
+                            "name": "testpicture1"
+                        },
+                        {
+                            "range": [252, 253],
+                            "name": "logo"
+                        },
+                        {
+                            "range": [254, 255],
+                            "name": "testpicture2"
+                        }
+                    ]
+                },
+                "Shutter": {
+                    "type": "Shutter",
+                    "defaultValue": 32,
+                    "highlightValue": 32,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 31],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [32, 63],
+                            "name": "open"
+                        },
+                        {
+                            "range": [64, 255],
+                            "name": "strobe"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 185],
+                            "name": "%"
+                        },
+                        {
+                            "range": [186, 255],
+                            "name": "colorfade"
+                        }
+                    ]
+                },
+                "SizeG": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Sizeall": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Ratio": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "Y-Size"
+                        },
+                        {
+                            "range": [128, 255],
+                            "name": "X-Size"
+                        }
+                    ]
+                },
+                "Iris": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 31],
+                            "name": "open"
+                        },
+                        {
+                            "range": [32, 63],
+                            "name": "circle"
+                        },
+                        {
+                            "range": [64, 127],
+                            "name": "square"
+                        },
+                        {
+                            "range": [128, 191],
+                            "name": "left-right"
+                        },
+                        {
+                            "range": [192, 255],
+                            "name": "up-down"
+                        }
+                    ]
+                },
+                "Gobo": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "default"
+                        },
+                        {
+                            "range": [1, 2],
+                            "name": "circle"
+                        },
+                        {
+                            "range": [3, 4],
+                            "name": "square"
+                        },
+                        {
+                            "range": [5, 6],
+                            "name": "triangle"
+                        },
+                        {
+                            "range": [7, 8],
+                            "name": "star1"
+                        },
+                        {
+                            "range": [9, 10],
+                            "name": "star2"
+                        },
+                        {
+                            "range": [11, 12],
+                            "name": "star3"
+                        },
+                        {
+                            "range": [13, 14],
+                            "name": "star4"
+                        },
+                        {
+                            "range": [15, 16],
+                            "name": "star5"
+                        },
+                        {
+                            "range": [17, 18],
+                            "name": "spiral1"
+                        },
+                        {
+                            "range": [19, 20],
+                            "name": "spiral2"
+                        },
+                        {
+                            "range": [21, 22],
+                            "name": "spiral3"
+                        },
+                        {
+                            "range": [23, 24],
+                            "name": "spiral4"
+                        },
+                        {
+                            "range": [25, 26],
+                            "name": "multisquare"
+                        },
+                        {
+                            "range": [27, 28],
+                            "name": "line1"
+                        },
+                        {
+                            "range": [29, 30],
+                            "name": "line2"
+                        },
+                        {
+                            "range": [31, 32],
+                            "name": "2 lines"
+                        },
+                        {
+                            "range": [33, 34],
+                            "name": "3 lines"
+                        },
+                        {
+                            "range": [35, 36],
+                            "name": "multilines"
+                        },
+                        {
+                            "range": [37, 38],
+                            "name": "simple cross"
+                        },
+                        {
+                            "range": [39, 40],
+                            "name": "pointed circle"
+                        },
+                        {
+                            "range": [41, 42],
+                            "name": "multipoint circ"
+                        },
+                        {
+                            "range": [43, 44],
+                            "name": "half circle"
+                        },
+                        {
+                            "range": [45, 46],
+                            "name": "multi circle"
+                        },
+                        {
+                            "range": [47, 48],
+                            "name": "circle blank 1"
+                        },
+                        {
+                            "range": [49, 50],
+                            "name": "circle blank 2"
+                        },
+                        {
+                            "range": [51, 52],
+                            "name": "logo"
+                        },
+                        {
+                            "range": [53, 54],
+                            "name": "saw blade"
+                        },
+                        {
+                            "range": [55, 56],
+                            "name": "cross outline"
+                        },
+                        {
+                            "range": [57, 58],
+                            "name": "cross maltese"
+                        },
+                        {
+                            "range": [59, 60],
+                            "name": "ornament 1"
+                        },
+                        {
+                            "range": [61, 62],
+                            "name": "ornament 2"
+                        },
+                        {
+                            "range": [62, 64],
+                            "name": "ornament 3"
+                        },
+                        {
+                            "range": [65, 66],
+                            "name": "ornament 4"
+                        },
+                        {
+                            "range": [67, 68],
+                            "name": "snowflake"
+                        },
+                        {
+                            "range": [69, 70],
+                            "name": "crystal 1"
+                        },
+                        {
+                            "range": [71, 72],
+                            "name": "crystal 2"
+                        },
+                        {
+                            "range": [73, 74],
+                            "name": "sun",
+                            "color": "#fbac13"
+                        },
+                        {
+                            "range": [75, 76],
+                            "name": "stars"
+                        },
+                        {
+                            "range": [77, 78],
+                            "name": "polygon"
+                        },
+                        {
+                            "range": [79, 80],
+                            "name": "cushion"
+                        },
+                        {
+                            "range": [81, 82],
+                            "name": "arrow up"
+                        },
+                        {
+                            "range": [83, 84],
+                            "name": "arrow left"
+                        },
+                        {
+                            "range": [85, 86],
+                            "name": "arrow curved"
+                        },
+                        {
+                            "range": [87, 88],
+                            "name": "arrow wavy"
+                        },
+                        {
+                            "range": [89, 90],
+                            "name": "3 arrows"
+                        },
+                        {
+                            "range": [91, 92],
+                            "name": "9 arrows"
+                        },
+                        {
+                            "range": [93, 94],
+                            "name": "9 arrows curved"
+                        },
+                        {
+                            "range": [95, 96],
+                            "name": "splash 1"
+                        },
+                        {
+                            "range": [97, 98],
+                            "name": "splash 2"
+                        },
+                        {
+                            "range": [99, 100],
+                            "name": "ornament 6"
+                        },
+                        {
+                            "range": [101, 102],
+                            "name": "ornament 7"
+                        },
+                        {
+                            "range": [103, 104],
+                            "name": "star"
+                        },
+                        {
+                            "range": [105, 106],
+                            "name": "ornament 8"
+                        },
+                        {
+                            "range": [107, 108],
+                            "name": "ornament 9"
+                        },
+                        {
+                            "range": [109, 110],
+                            "name": "ornament 10"
+                        },
+                        {
+                            "range": [111, 112],
+                            "name": "ornament 11"
+                        },
+                        {
+                            "range": [113, 114],
+                            "name": "ornament 12"
+                        },
+                        {
+                            "range": [115, 116],
+                            "name": "ornament 13"
+                        },
+                        {
+                            "range": [117, 118],
+                            "name": "ornament 14"
+                        },
+                        {
+                            "range": [119, 254],
+                            "name": "reserved"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "testpicture"
+                        }
+                    ]
+                },
+                "Rotation": {
+                    "type": "Beam",
+                    "defaultValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "index"
+                        }
+                    ]
+                },
+                "Speed": {
+                    "type": "Speed",
+                    "defaultValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "fast"
+                        },
+                        {
+                            "range": [1, 126],
+                            "name": "%"
+                        },
+                        {
+                            "range": [127, 127],
+                            "name": "slow"
+                        },
+                        {
+                            "range": [128, 254],
+                            "name": "%"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "normal"
+                        }
+                    ]
+                },
+                "Color": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "default"
+                        },
+                        {
+                            "range": [1, 127],
+                            "name": "cont"
+                        },
+                        {
+                            "range": [128, 191],
+                            "name": "autofade"
+                        },
+                        {
+                            "range": [192, 255],
+                            "name": "multicolor"
+                        }
+                    ]
+                },
+                "Repeat": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "repeats"
+                        },
+                        {
+                            "range": [128, 255],
+                            "name": "sparkle"
+                        }
+                    ]
+                },
+                "Invert": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "normal"
+                        },
+                        {
+                            "range": [128, 255],
+                            "name": "invert"
+                        }
+                    ]
+                },
+                "reserved": {
+                    "type": "Beam",
+                    "crossfade": true
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "18-channel Mode",
+                    "shortName": "18ch",
+                    "channels": [
+                        "Effect",
+                        "Shutter",
+                        "Intensity",
+                        "SizeG",
+                        "Sizeall",
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "Ratio",
+                        "Iris",
+                        "Gobo",
+                        "Rotation",
+                        "Speed",
+                        "Color",
+                        "Repeat",
+                        "Invert",
+                        "reserved"
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/fixtures/imports/ecue-MainLibrary/Diversitonics.json
+++ b/fixtures/imports/ecue-MainLibrary/Diversitonics.json
@@ -1,0 +1,55 @@
+{
+    "manufacturers": {
+        "Diversitonics": {
+            "name": "Diversitonics",
+            "website": "http://www.diversitronics.com/"
+        }
+    },
+    "fixtures": [
+        {
+            "manufacturer": "Diversitonics",
+            "name": "DK56QH-DMX",
+            "shortName": "DK56",
+            "comment": "http://www.diversitronics.com/ http://www.feiner-lichttechnik.de/index.php/od-dk56qh-dmx.html Seit 1967 produziert der amerikanische Hersteller Diversitronics hochwertige Xenon-Stroboskope.",
+            "physical": {
+                "dimensions": [200, 200, 240],
+                "weight": 5.5,
+                "power": 3500
+            },
+            "availableChannels": {
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "New Range"
+                        }
+                    ]
+                },
+                "Rate": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "New Range"
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "2-channel Mode",
+                    "shortName": "2ch",
+                    "channels": [
+                        "Intensity",
+                        "Rate"
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/fixtures/imports/ecue-MainLibrary/Elation-Professional.json
+++ b/fixtures/imports/ecue-MainLibrary/Elation-Professional.json
@@ -1,0 +1,3696 @@
+{
+    "manufacturers": {
+        "Elation Professional": {
+            "name": "Elation Professional",
+            "website": "www.elationlighting.com"
+        }
+    },
+    "fixtures": [
+        {
+            "manufacturer": "Elation Professional",
+            "name": "Design Spot 250",
+            "shortName": "DSpot250",
+            "comment": "cd",
+            "physical": {
+                "dimensions": [450, 450, 600],
+                "weight": 25.6,
+                "power": 300
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "highlightValue": null
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 0,
+                    "crossfade": true,
+                    "highlightValue": null
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "highlightValue": null
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 0,
+                    "crossfade": true,
+                    "highlightValue": null
+                },
+                "Color": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 13],
+                            "name": "open"
+                        },
+                        {
+                            "range": [14, 27],
+                            "name": "red",
+                            "color": "#ff0000"
+                        },
+                        {
+                            "range": [28, 41],
+                            "name": "blue",
+                            "color": "#0000ff"
+                        },
+                        {
+                            "range": [42, 55],
+                            "name": "green",
+                            "color": "#00ff00"
+                        },
+                        {
+                            "range": [56, 69],
+                            "name": "light yellow",
+                            "color": "#ffffe0"
+                        },
+                        {
+                            "range": [70, 83],
+                            "name": "magenta",
+                            "color": "#ca1f7b"
+                        },
+                        {
+                            "range": [84, 97],
+                            "name": "orange",
+                            "color": "#ff7f00"
+                        },
+                        {
+                            "range": [98, 111],
+                            "name": "UV"
+                        },
+                        {
+                            "range": [112, 127],
+                            "name": "pink",
+                            "color": "#ffc0cb"
+                        },
+                        {
+                            "range": [128, 187],
+                            "name": ">>"
+                        },
+                        {
+                            "range": [188, 193],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [194, 255],
+                            "name": "<<"
+                        }
+                    ]
+                },
+                "Gobo1": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 9],
+                            "name": "open"
+                        },
+                        {
+                            "range": [10, 19],
+                            "name": "slot1"
+                        },
+                        {
+                            "range": [20, 29],
+                            "name": "slot2"
+                        },
+                        {
+                            "range": [30, 39],
+                            "name": "slot3"
+                        },
+                        {
+                            "range": [40, 49],
+                            "name": "slot4"
+                        },
+                        {
+                            "range": [50, 59],
+                            "name": "slot5"
+                        },
+                        {
+                            "range": [60, 69],
+                            "name": "slot6"
+                        },
+                        {
+                            "range": [70, 79],
+                            "name": "slot7"
+                        },
+                        {
+                            "range": [80, 99],
+                            "name": "slot1 sh."
+                        },
+                        {
+                            "range": [100, 119],
+                            "name": "slot2 sh."
+                        },
+                        {
+                            "range": [120, 139],
+                            "name": "slot3 sh."
+                        },
+                        {
+                            "range": [140, 159],
+                            "name": "slot4 sh."
+                        },
+                        {
+                            "range": [160, 179],
+                            "name": "slot5 sh."
+                        },
+                        {
+                            "range": [180, 199],
+                            "name": "slot6 sh."
+                        },
+                        {
+                            "range": [200, 219],
+                            "name": "slot7 sh."
+                        },
+                        {
+                            "range": [220, 255],
+                            "name": ">>"
+                        }
+                    ]
+                },
+                "Gobo1 rot.": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "index"
+                        },
+                        {
+                            "range": [128, 187],
+                            "name": ">>"
+                        },
+                        {
+                            "range": [188, 193],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [194, 255],
+                            "name": "<<"
+                        }
+                    ]
+                },
+                "Gobo2": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 13],
+                            "name": "open"
+                        },
+                        {
+                            "range": [14, 27],
+                            "name": "slot1"
+                        },
+                        {
+                            "range": [28, 41],
+                            "name": "slot2"
+                        },
+                        {
+                            "range": [42, 55],
+                            "name": "slot3"
+                        },
+                        {
+                            "range": [56, 69],
+                            "name": "slot4"
+                        },
+                        {
+                            "range": [70, 83],
+                            "name": "slot5"
+                        },
+                        {
+                            "range": [84, 97],
+                            "name": "slot6"
+                        },
+                        {
+                            "range": [98, 111],
+                            "name": "slot7"
+                        },
+                        {
+                            "range": [112, 127],
+                            "name": "slot1 sh."
+                        },
+                        {
+                            "range": [128, 143],
+                            "name": "slot2 sh."
+                        },
+                        {
+                            "range": [144, 159],
+                            "name": "slot3 sh."
+                        },
+                        {
+                            "range": [160, 175],
+                            "name": "slot4 sh."
+                        },
+                        {
+                            "range": [176, 191],
+                            "name": "slot5 sh."
+                        },
+                        {
+                            "range": [192, 207],
+                            "name": "slot6 sh."
+                        },
+                        {
+                            "range": [208, 223],
+                            "name": "slot7 sh."
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": ">>"
+                        }
+                    ]
+                },
+                "Prisma": {
+                    "type": "Prism",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 3],
+                            "name": "open"
+                        },
+                        {
+                            "range": [4, 63],
+                            "name": ">>"
+                        },
+                        {
+                            "range": [64, 67],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [68, 127],
+                            "name": "<<"
+                        },
+                        {
+                            "range": [128, 255],
+                            "name": "macro"
+                        }
+                    ]
+                },
+                "Focus": {
+                    "type": "Beam",
+                    "defaultValue": 128,
+                    "crossfade": true
+                },
+                "Shutter": {
+                    "type": "Shutter",
+                    "defaultValue": 50,
+                    "highlightValue": 50,
+                    "capabilities": [
+                        {
+                            "range": [0, 31],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [32, 63],
+                            "name": "open"
+                        },
+                        {
+                            "range": [64, 95],
+                            "name": "strobe"
+                        },
+                        {
+                            "range": [96, 127],
+                            "name": "open"
+                        },
+                        {
+                            "range": [128, 159],
+                            "name": "pulse"
+                        },
+                        {
+                            "range": [160, 191],
+                            "name": "open"
+                        },
+                        {
+                            "range": [192, 223],
+                            "name": "random"
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "open"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Iris": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 191],
+                            "name": "%"
+                        },
+                        {
+                            "range": [192, 223],
+                            "name": "pulse closing"
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "pulse opening"
+                        }
+                    ]
+                },
+                "Frost": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 191],
+                            "name": "%"
+                        },
+                        {
+                            "range": [192, 223],
+                            "name": "pulse closing"
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "pulse opening"
+                        }
+                    ]
+                },
+                "P/T speed": {
+                    "type": "Speed",
+                    "capabilities": [
+                        {
+                            "range": [0, 225],
+                            "name": "speed"
+                        },
+                        {
+                            "range": [226, 245],
+                            "name": "MIB"
+                        },
+                        {
+                            "range": [246, 255],
+                            "name": "no func."
+                        }
+                    ]
+                },
+                "Reset": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 19],
+                            "name": "c. change nor."
+                        },
+                        {
+                            "range": [20, 29],
+                            "name": "c. change any"
+                        },
+                        {
+                            "range": [40, 59],
+                            "name": "lamp on"
+                        },
+                        {
+                            "range": [60, 79],
+                            "name": "lamp off"
+                        },
+                        {
+                            "range": [80, 84],
+                            "name": "reset"
+                        },
+                        {
+                            "range": [85, 87],
+                            "name": "P/T reset"
+                        },
+                        {
+                            "range": [88, 90],
+                            "name": "color reset"
+                        },
+                        {
+                            "range": [91, 93],
+                            "name": "gobo reset"
+                        },
+                        {
+                            "range": [94, 96],
+                            "name": "shutter reset"
+                        },
+                        {
+                            "range": [97, 99],
+                            "name": "other reset"
+                        },
+                        {
+                            "range": [100, 239],
+                            "name": "program"
+                        },
+                        {
+                            "range": [240, 255],
+                            "name": "audio control"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "16-channel Mode",
+                    "shortName": "16ch",
+                    "channels": [
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "Color",
+                        "Gobo1",
+                        "Gobo1 rot.",
+                        "Gobo2",
+                        "Prisma",
+                        "Focus",
+                        "Shutter",
+                        "Intensity",
+                        "Iris",
+                        "Frost",
+                        "P/T speed",
+                        "Reset"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Elation Professional",
+            "name": "Design Wash 250",
+            "shortName": "DWash250",
+            "comment": "cd",
+            "physical": {
+                "dimensions": [450, 450, 600],
+                "weight": 25.6,
+                "power": 300
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "highlightValue": null
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 0,
+                    "crossfade": true,
+                    "highlightValue": null
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "highlightValue": null
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 0,
+                    "crossfade": true,
+                    "highlightValue": null
+                },
+                "Color": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 13],
+                            "name": "open"
+                        },
+                        {
+                            "range": [14, 27],
+                            "name": "color1"
+                        },
+                        {
+                            "range": [28, 41],
+                            "name": "col2"
+                        },
+                        {
+                            "range": [42, 55],
+                            "name": "col3"
+                        },
+                        {
+                            "range": [56, 69],
+                            "name": "col4"
+                        },
+                        {
+                            "range": [70, 83],
+                            "name": "col5"
+                        },
+                        {
+                            "range": [84, 97],
+                            "name": "col6"
+                        },
+                        {
+                            "range": [98, 111],
+                            "name": "col7"
+                        },
+                        {
+                            "range": [112, 127],
+                            "name": "col8"
+                        },
+                        {
+                            "range": [128, 187],
+                            "name": ">>"
+                        },
+                        {
+                            "range": [188, 193],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [194, 255],
+                            "name": "<<"
+                        }
+                    ]
+                },
+                "Cyan": {
+                    "type": "SingleColor",
+                    "color": "Cyan",
+                    "crossfade": true
+                },
+                "Magenta": {
+                    "type": "SingleColor",
+                    "color": "Magenta",
+                    "crossfade": true
+                },
+                "Yellow": {
+                    "type": "SingleColor",
+                    "color": "Yellow",
+                    "crossfade": true
+                },
+                "FX": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 70],
+                            "name": "open"
+                        },
+                        {
+                            "range": [71, 230],
+                            "name": "beam shaper"
+                        },
+                        {
+                            "range": [231, 255],
+                            "name": "frost",
+                            "color": "#edf5dd"
+                        }
+                    ]
+                },
+                "Zoom": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Shutter": {
+                    "type": "Shutter",
+                    "defaultValue": 50,
+                    "capabilities": [
+                        {
+                            "range": [0, 31],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [32, 63],
+                            "name": "open"
+                        },
+                        {
+                            "range": [64, 95],
+                            "name": "strobe"
+                        },
+                        {
+                            "range": [96, 127],
+                            "name": "open"
+                        },
+                        {
+                            "range": [128, 159],
+                            "name": "pulse"
+                        },
+                        {
+                            "range": [160, 191],
+                            "name": "open"
+                        },
+                        {
+                            "range": [192, 223],
+                            "name": "random"
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "open"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Macro": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "CMY speed": {
+                    "type": "Speed",
+                    "crossfade": true
+                },
+                "P/T speed": {
+                    "type": "Speed",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 225],
+                            "name": "speed"
+                        },
+                        {
+                            "range": [226, 245],
+                            "name": "MIB"
+                        },
+                        {
+                            "range": [246, 255],
+                            "name": "no func."
+                        }
+                    ]
+                },
+                "Reset": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 19],
+                            "name": "c. change nor."
+                        },
+                        {
+                            "range": [20, 29],
+                            "name": "c. change any"
+                        },
+                        {
+                            "range": [40, 59],
+                            "name": "lamp on"
+                        },
+                        {
+                            "range": [60, 79],
+                            "name": "lamp off"
+                        },
+                        {
+                            "range": [80, 84],
+                            "name": "reset"
+                        },
+                        {
+                            "range": [85, 87],
+                            "name": "P/T reset"
+                        },
+                        {
+                            "range": [88, 90],
+                            "name": "color reset"
+                        },
+                        {
+                            "range": [91, 93],
+                            "name": "gobo reset"
+                        },
+                        {
+                            "range": [94, 96],
+                            "name": "shutter reset"
+                        },
+                        {
+                            "range": [97, 99],
+                            "name": "other reset"
+                        },
+                        {
+                            "range": [100, 239],
+                            "name": "program"
+                        },
+                        {
+                            "range": [240, 255],
+                            "name": "audio control"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "16-channel Mode",
+                    "shortName": "16ch",
+                    "channels": [
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "Color",
+                        "Cyan",
+                        "Magenta",
+                        "Yellow",
+                        "FX",
+                        "Zoom",
+                        "Shutter",
+                        "Intensity",
+                        "Macro",
+                        "CMY speed",
+                        "P/T speed",
+                        "Reset"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Elation Professional",
+            "name": "Platinum Spot 5R Mode Ba",
+            "shortName": "PSpot 5R M Ba",
+            "physical": {
+                "dimensions": [360, 450, 337],
+                "weight": 14.8,
+                "power": 350
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "crossfade": true
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "crossfade": true
+                },
+                "Colorwheel": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 13],
+                            "name": "open"
+                        },
+                        {
+                            "range": [14, 27],
+                            "name": "color 1"
+                        },
+                        {
+                            "range": [28, 41],
+                            "name": "color 2"
+                        },
+                        {
+                            "range": [42, 55],
+                            "name": "color 3"
+                        },
+                        {
+                            "range": [56, 69],
+                            "name": "color 4"
+                        },
+                        {
+                            "range": [70, 83],
+                            "name": "color 5"
+                        },
+                        {
+                            "range": [84, 97],
+                            "name": "color 6"
+                        },
+                        {
+                            "range": [98, 111],
+                            "name": "color 7"
+                        },
+                        {
+                            "range": [112, 127],
+                            "name": "color 8"
+                        },
+                        {
+                            "range": [128, 189],
+                            "name": "ffw rainbow"
+                        },
+                        {
+                            "range": [190, 193],
+                            "name": "no rotation"
+                        },
+                        {
+                            "range": [194, 255],
+                            "name": "bkw color"
+                        }
+                    ]
+                },
+                "Rot gobos": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 9],
+                            "name": "open"
+                        },
+                        {
+                            "range": [10, 19],
+                            "name": "rot gobo 1"
+                        },
+                        {
+                            "range": [20, 29],
+                            "name": "rot gobo 2"
+                        },
+                        {
+                            "range": [30, 39],
+                            "name": "rot gobo 3"
+                        },
+                        {
+                            "range": [40, 49],
+                            "name": "rot gobo 4"
+                        },
+                        {
+                            "range": [50, 59],
+                            "name": "rot gobo 5"
+                        },
+                        {
+                            "range": [60, 69],
+                            "name": "rot gobo 6"
+                        },
+                        {
+                            "range": [70, 79],
+                            "name": "rot gobo 7"
+                        },
+                        {
+                            "range": [80, 89],
+                            "name": "rot gobo 8"
+                        },
+                        {
+                            "range": [90, 104],
+                            "name": "rot go 1 shake"
+                        },
+                        {
+                            "range": [105, 119],
+                            "name": "rot go 2 shake"
+                        },
+                        {
+                            "range": [120, 134],
+                            "name": "rot go 3 shake"
+                        },
+                        {
+                            "range": [135, 149],
+                            "name": "rot go 4 shake"
+                        },
+                        {
+                            "range": [150, 164],
+                            "name": "rot go 5 shake"
+                        },
+                        {
+                            "range": [165, 179],
+                            "name": "rot go 6 shake"
+                        },
+                        {
+                            "range": [180, 194],
+                            "name": "rot go 7 shake"
+                        },
+                        {
+                            "range": [195, 209],
+                            "name": "rot go 8 shake"
+                        },
+                        {
+                            "range": [210, 255],
+                            "name": "rot go sl to fa"
+                        }
+                    ]
+                },
+                "rot go index": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "gobo index"
+                        },
+                        {
+                            "range": [128, 189],
+                            "name": "ffw rotation"
+                        },
+                        {
+                            "range": [190, 193],
+                            "name": "no rotation"
+                        },
+                        {
+                            "range": [194, 255],
+                            "name": "bkw rotation"
+                        }
+                    ]
+                },
+                "Fixed gobos": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 7],
+                            "name": "open"
+                        },
+                        {
+                            "range": [8, 15],
+                            "name": "gobo 1",
+                            "center": true
+                        },
+                        {
+                            "range": [16, 23],
+                            "name": "gobo 2",
+                            "center": true
+                        },
+                        {
+                            "range": [24, 31],
+                            "name": "gobo 3",
+                            "center": true
+                        },
+                        {
+                            "range": [32, 39],
+                            "name": "gobo 4",
+                            "center": true
+                        },
+                        {
+                            "range": [40, 47],
+                            "name": "gobo 5",
+                            "center": true
+                        },
+                        {
+                            "range": [48, 55],
+                            "name": "gobo 6",
+                            "center": true
+                        },
+                        {
+                            "range": [56, 63],
+                            "name": "gobo 7",
+                            "center": true
+                        },
+                        {
+                            "range": [64, 71],
+                            "name": "gobo 8",
+                            "center": true
+                        },
+                        {
+                            "range": [72, 79],
+                            "name": "gobo 9",
+                            "center": true
+                        },
+                        {
+                            "range": [80, 87],
+                            "name": "gobo 10",
+                            "center": true
+                        },
+                        {
+                            "range": [88, 95],
+                            "name": "gobo 11",
+                            "center": true
+                        },
+                        {
+                            "range": [96, 103],
+                            "name": "gobo 12",
+                            "center": true
+                        },
+                        {
+                            "range": [104, 111],
+                            "name": "gobo 13",
+                            "center": true
+                        },
+                        {
+                            "range": [112, 119],
+                            "name": "gobo 14",
+                            "center": true
+                        },
+                        {
+                            "range": [120, 126],
+                            "name": "gobo 1 shake",
+                            "center": true
+                        },
+                        {
+                            "range": [127, 133],
+                            "name": "gobo 2 shake",
+                            "center": true
+                        },
+                        {
+                            "range": [134, 140],
+                            "name": "gobo 3 shake",
+                            "center": true
+                        },
+                        {
+                            "range": [141, 147],
+                            "name": "gobo 4 shake",
+                            "center": true
+                        },
+                        {
+                            "range": [148, 154],
+                            "name": "gobo 5 shake",
+                            "center": true
+                        },
+                        {
+                            "range": [155, 161],
+                            "name": "gobo 6 shake",
+                            "center": true
+                        },
+                        {
+                            "range": [162, 168],
+                            "name": "gobo 7 shake",
+                            "center": true
+                        },
+                        {
+                            "range": [169, 175],
+                            "name": "gobo 8 shake",
+                            "center": true
+                        },
+                        {
+                            "range": [176, 182],
+                            "name": "gobo 9 shake",
+                            "center": true
+                        },
+                        {
+                            "range": [183, 189],
+                            "name": "gobo 10 shake",
+                            "center": true
+                        },
+                        {
+                            "range": [190, 196],
+                            "name": "gobo 11 shake",
+                            "center": true
+                        },
+                        {
+                            "range": [197, 203],
+                            "name": "gobo 12 shake",
+                            "center": true
+                        },
+                        {
+                            "range": [204, 210],
+                            "name": "gobo 13 shake",
+                            "center": true
+                        },
+                        {
+                            "range": [211, 217],
+                            "name": "gobo 14 shake",
+                            "center": true
+                        },
+                        {
+                            "range": [218, 255],
+                            "name": "gobo rotation"
+                        }
+                    ]
+                },
+                "3 fac gobo macr": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 31],
+                            "name": "open",
+                            "center": true
+                        },
+                        {
+                            "range": [32, 127],
+                            "name": "rot prisma"
+                        },
+                        {
+                            "range": [128, 135],
+                            "name": "macro 1",
+                            "center": true
+                        },
+                        {
+                            "range": [136, 143],
+                            "name": "macro 2",
+                            "center": true
+                        },
+                        {
+                            "range": [144, 151],
+                            "name": "macro 3",
+                            "center": true
+                        },
+                        {
+                            "range": [152, 159],
+                            "name": "macro 4",
+                            "center": true
+                        },
+                        {
+                            "range": [160, 167],
+                            "name": "macro 5",
+                            "center": true
+                        },
+                        {
+                            "range": [168, 175],
+                            "name": "macro 6",
+                            "center": true
+                        },
+                        {
+                            "range": [176, 183],
+                            "name": "macro 7",
+                            "center": true
+                        },
+                        {
+                            "range": [184, 191],
+                            "name": "macro 8",
+                            "center": true
+                        },
+                        {
+                            "range": [192, 199],
+                            "name": "macro 9",
+                            "center": true
+                        },
+                        {
+                            "range": [200, 207],
+                            "name": "macro 10",
+                            "center": true
+                        },
+                        {
+                            "range": [208, 215],
+                            "name": "macro 11",
+                            "center": true
+                        },
+                        {
+                            "range": [216, 223],
+                            "name": "macro 12",
+                            "center": true
+                        },
+                        {
+                            "range": [224, 231],
+                            "name": "macro 13",
+                            "center": true
+                        },
+                        {
+                            "range": [232, 239],
+                            "name": "macro 14",
+                            "center": true
+                        },
+                        {
+                            "range": [240, 247],
+                            "name": "macro 15",
+                            "center": true
+                        },
+                        {
+                            "range": [248, 255],
+                            "name": "macro 16",
+                            "center": true
+                        }
+                    ]
+                },
+                "rot prism index": {
+                    "type": "Prism",
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "prism index"
+                        },
+                        {
+                            "range": [128, 189],
+                            "name": "ffw rotation"
+                        },
+                        {
+                            "range": [190, 193],
+                            "name": "no rotation"
+                        },
+                        {
+                            "range": [194, 255],
+                            "name": "bkw rotation"
+                        }
+                    ]
+                },
+                "Focus": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Shutter": {
+                    "type": "Shutter",
+                    "defaultValue": 255,
+                    "capabilities": [
+                        {
+                            "range": [0, 31],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [32, 63],
+                            "name": "open"
+                        },
+                        {
+                            "range": [64, 95],
+                            "name": "strobe"
+                        },
+                        {
+                            "range": [96, 127],
+                            "name": "open"
+                        },
+                        {
+                            "range": [128, 159],
+                            "name": "pulse"
+                        },
+                        {
+                            "range": [160, 191],
+                            "name": "open"
+                        },
+                        {
+                            "range": [192, 223],
+                            "name": "random"
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "open"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Iris": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 191],
+                            "name": "maximum"
+                        },
+                        {
+                            "range": [192, 223],
+                            "name": "pulse closing"
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "pulse opening"
+                        }
+                    ]
+                },
+                "Frost": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 191],
+                            "name": "frost 0-100%"
+                        },
+                        {
+                            "range": [192, 223],
+                            "name": "pulse fast - sl"
+                        },
+                        {
+                            "range": [224, 254],
+                            "name": "pulse sl - fast"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "max frost"
+                        }
+                    ]
+                },
+                "P/T speed": {
+                    "type": "Speed",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 225],
+                            "name": "max to min"
+                        },
+                        {
+                            "range": [226, 235],
+                            "name": "bl out movement"
+                        },
+                        {
+                            "range": [236, 245],
+                            "name": "bl out wheel"
+                        },
+                        {
+                            "range": [246, 255],
+                            "name": "no funktion"
+                        }
+                    ]
+                },
+                "Reset": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 19],
+                            "name": "c. change nor."
+                        },
+                        {
+                            "range": [20, 29],
+                            "name": "c. change any"
+                        },
+                        {
+                            "range": [30, 39],
+                            "name": "c g change any"
+                        },
+                        {
+                            "range": [40, 59],
+                            "name": "lamp on"
+                        },
+                        {
+                            "range": [60, 79],
+                            "name": "lamp off"
+                        },
+                        {
+                            "range": [80, 84],
+                            "name": "reset"
+                        },
+                        {
+                            "range": [85, 87],
+                            "name": "P/T reset"
+                        },
+                        {
+                            "range": [88, 90],
+                            "name": "color reset"
+                        },
+                        {
+                            "range": [91, 93],
+                            "name": "gobo reset"
+                        },
+                        {
+                            "range": [94, 96],
+                            "name": "shutter reset"
+                        },
+                        {
+                            "range": [97, 99],
+                            "name": "other reset"
+                        },
+                        {
+                            "range": [100, 119],
+                            "name": "program 1"
+                        },
+                        {
+                            "range": [120, 139],
+                            "name": "program 2"
+                        },
+                        {
+                            "range": [140, 159],
+                            "name": "program 3"
+                        },
+                        {
+                            "range": [160, 179],
+                            "name": "program 4"
+                        },
+                        {
+                            "range": [180, 199],
+                            "name": "program 5"
+                        },
+                        {
+                            "range": [200, 219],
+                            "name": "program 6"
+                        },
+                        {
+                            "range": [220, 239],
+                            "name": "program 7"
+                        },
+                        {
+                            "range": [240, 255],
+                            "name": "audio control"
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "15-channel Mode",
+                    "shortName": "15ch",
+                    "channels": [
+                        "Pan",
+                        "Tilt",
+                        "Colorwheel",
+                        "Rot gobos",
+                        "rot go index",
+                        "Fixed gobos",
+                        "3 fac gobo macr",
+                        "rot prism index",
+                        "Focus",
+                        "Shutter",
+                        "Intensity",
+                        "Iris",
+                        "Frost",
+                        "P/T speed",
+                        "Reset"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Elation Professional",
+            "name": "Platinum Spot 5R Mode Ex",
+            "shortName": "PSpot 5R M Ex",
+            "physical": {
+                "dimensions": [360, 450, 337],
+                "weight": 14.8,
+                "power": 350
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "highlightValue": null
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 0,
+                    "crossfade": true,
+                    "highlightValue": null
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "highlightValue": null
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 0,
+                    "crossfade": true,
+                    "highlightValue": null
+                },
+                "Colorwheel": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 13],
+                            "name": "open"
+                        },
+                        {
+                            "range": [14, 27],
+                            "name": "color 1"
+                        },
+                        {
+                            "range": [28, 41],
+                            "name": "color 2"
+                        },
+                        {
+                            "range": [42, 55],
+                            "name": "color 3"
+                        },
+                        {
+                            "range": [56, 69],
+                            "name": "color 4"
+                        },
+                        {
+                            "range": [70, 83],
+                            "name": "color 5"
+                        },
+                        {
+                            "range": [84, 97],
+                            "name": "color 6"
+                        },
+                        {
+                            "range": [98, 111],
+                            "name": "color 7"
+                        },
+                        {
+                            "range": [112, 127],
+                            "name": "color 8"
+                        },
+                        {
+                            "range": [128, 189],
+                            "name": "ffw rainbow"
+                        },
+                        {
+                            "range": [190, 193],
+                            "name": "no rotation"
+                        },
+                        {
+                            "range": [194, 255],
+                            "name": "bkw color"
+                        }
+                    ],
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "Colorwheel fine": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 13],
+                            "name": "open"
+                        },
+                        {
+                            "range": [14, 27],
+                            "name": "color 1"
+                        },
+                        {
+                            "range": [28, 41],
+                            "name": "color 2"
+                        },
+                        {
+                            "range": [42, 55],
+                            "name": "color 3"
+                        },
+                        {
+                            "range": [56, 69],
+                            "name": "color 4"
+                        },
+                        {
+                            "range": [70, 83],
+                            "name": "color 5"
+                        },
+                        {
+                            "range": [84, 97],
+                            "name": "color 6"
+                        },
+                        {
+                            "range": [98, 111],
+                            "name": "color 7"
+                        },
+                        {
+                            "range": [112, 127],
+                            "name": "color 8"
+                        },
+                        {
+                            "range": [128, 189],
+                            "name": "ffw rainbow"
+                        },
+                        {
+                            "range": [190, 193],
+                            "name": "no rotation"
+                        },
+                        {
+                            "range": [194, 255],
+                            "name": "bkw color"
+                        }
+                    ],
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "Rot gobos": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 9],
+                            "name": "open"
+                        },
+                        {
+                            "range": [10, 19],
+                            "name": "rot gobo 1"
+                        },
+                        {
+                            "range": [20, 29],
+                            "name": "rot gobo 2"
+                        },
+                        {
+                            "range": [30, 39],
+                            "name": "rot gobo 3"
+                        },
+                        {
+                            "range": [40, 49],
+                            "name": "rot gobo 4"
+                        },
+                        {
+                            "range": [50, 59],
+                            "name": "rot gobo 5"
+                        },
+                        {
+                            "range": [60, 69],
+                            "name": "rot gobo 6"
+                        },
+                        {
+                            "range": [70, 79],
+                            "name": "rot gobo 7"
+                        },
+                        {
+                            "range": [80, 89],
+                            "name": "rot gobo 8"
+                        },
+                        {
+                            "range": [90, 104],
+                            "name": "rot go 1 shake"
+                        },
+                        {
+                            "range": [105, 119],
+                            "name": "rot go 2 shake"
+                        },
+                        {
+                            "range": [120, 134],
+                            "name": "rot go 3 shake"
+                        },
+                        {
+                            "range": [135, 149],
+                            "name": "rot go 4 shake"
+                        },
+                        {
+                            "range": [150, 164],
+                            "name": "rot go 5 shake"
+                        },
+                        {
+                            "range": [165, 179],
+                            "name": "rot go 6 shake"
+                        },
+                        {
+                            "range": [180, 194],
+                            "name": "rot go 7 shake"
+                        },
+                        {
+                            "range": [195, 209],
+                            "name": "rot go 8 shake"
+                        },
+                        {
+                            "range": [210, 255],
+                            "name": "rot go sl to fa"
+                        }
+                    ]
+                },
+                "rot go index": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "gobo index"
+                        },
+                        {
+                            "range": [128, 189],
+                            "name": "ffw rotation"
+                        },
+                        {
+                            "range": [190, 193],
+                            "name": "no rotation"
+                        },
+                        {
+                            "range": [194, 255],
+                            "name": "bkw rotation"
+                        }
+                    ],
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "rot go index fine": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "gobo index"
+                        },
+                        {
+                            "range": [128, 189],
+                            "name": "ffw rotation"
+                        },
+                        {
+                            "range": [190, 193],
+                            "name": "no rotation"
+                        },
+                        {
+                            "range": [194, 255],
+                            "name": "bkw rotation"
+                        }
+                    ],
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "Fixed gobos": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 7],
+                            "name": "open"
+                        },
+                        {
+                            "range": [8, 15],
+                            "name": "gobo 1",
+                            "center": true
+                        },
+                        {
+                            "range": [16, 23],
+                            "name": "gobo 2",
+                            "center": true
+                        },
+                        {
+                            "range": [24, 31],
+                            "name": "gobo 3",
+                            "center": true
+                        },
+                        {
+                            "range": [32, 39],
+                            "name": "gobo 4",
+                            "center": true
+                        },
+                        {
+                            "range": [40, 47],
+                            "name": "gobo 5",
+                            "center": true
+                        },
+                        {
+                            "range": [48, 55],
+                            "name": "gobo 6",
+                            "center": true
+                        },
+                        {
+                            "range": [56, 63],
+                            "name": "gobo 7",
+                            "center": true
+                        },
+                        {
+                            "range": [64, 71],
+                            "name": "gobo 8",
+                            "center": true
+                        },
+                        {
+                            "range": [72, 79],
+                            "name": "gobo 9",
+                            "center": true
+                        },
+                        {
+                            "range": [80, 87],
+                            "name": "gobo 10",
+                            "center": true
+                        },
+                        {
+                            "range": [88, 95],
+                            "name": "gobo 11",
+                            "center": true
+                        },
+                        {
+                            "range": [96, 103],
+                            "name": "gobo 12",
+                            "center": true
+                        },
+                        {
+                            "range": [104, 111],
+                            "name": "gobo 13",
+                            "center": true
+                        },
+                        {
+                            "range": [112, 119],
+                            "name": "gobo 14",
+                            "center": true
+                        },
+                        {
+                            "range": [120, 126],
+                            "name": "gobo 1 shake",
+                            "center": true
+                        },
+                        {
+                            "range": [127, 133],
+                            "name": "gobo 2 shake",
+                            "center": true
+                        },
+                        {
+                            "range": [134, 140],
+                            "name": "gobo 3 shake",
+                            "center": true
+                        },
+                        {
+                            "range": [141, 147],
+                            "name": "gobo 4 shake",
+                            "center": true
+                        },
+                        {
+                            "range": [148, 154],
+                            "name": "gobo 5 shake",
+                            "center": true
+                        },
+                        {
+                            "range": [155, 161],
+                            "name": "gobo 6 shake",
+                            "center": true
+                        },
+                        {
+                            "range": [162, 168],
+                            "name": "gobo 7 shake",
+                            "center": true
+                        },
+                        {
+                            "range": [169, 175],
+                            "name": "gobo 8 shake",
+                            "center": true
+                        },
+                        {
+                            "range": [176, 182],
+                            "name": "gobo 9 shake",
+                            "center": true
+                        },
+                        {
+                            "range": [183, 189],
+                            "name": "gobo 10 shake",
+                            "center": true
+                        },
+                        {
+                            "range": [190, 196],
+                            "name": "gobo 11 shake",
+                            "center": true
+                        },
+                        {
+                            "range": [197, 203],
+                            "name": "gobo 12 shake",
+                            "center": true
+                        },
+                        {
+                            "range": [204, 210],
+                            "name": "gobo 13 shake",
+                            "center": true
+                        },
+                        {
+                            "range": [211, 217],
+                            "name": "gobo 14 shake",
+                            "center": true
+                        },
+                        {
+                            "range": [218, 255],
+                            "name": "gobo rotation"
+                        }
+                    ],
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "Fixed gobos fine": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 7],
+                            "name": "open"
+                        },
+                        {
+                            "range": [8, 15],
+                            "name": "gobo 1",
+                            "center": true
+                        },
+                        {
+                            "range": [16, 23],
+                            "name": "gobo 2",
+                            "center": true
+                        },
+                        {
+                            "range": [24, 31],
+                            "name": "gobo 3",
+                            "center": true
+                        },
+                        {
+                            "range": [32, 39],
+                            "name": "gobo 4",
+                            "center": true
+                        },
+                        {
+                            "range": [40, 47],
+                            "name": "gobo 5",
+                            "center": true
+                        },
+                        {
+                            "range": [48, 55],
+                            "name": "gobo 6",
+                            "center": true
+                        },
+                        {
+                            "range": [56, 63],
+                            "name": "gobo 7",
+                            "center": true
+                        },
+                        {
+                            "range": [64, 71],
+                            "name": "gobo 8",
+                            "center": true
+                        },
+                        {
+                            "range": [72, 79],
+                            "name": "gobo 9",
+                            "center": true
+                        },
+                        {
+                            "range": [80, 87],
+                            "name": "gobo 10",
+                            "center": true
+                        },
+                        {
+                            "range": [88, 95],
+                            "name": "gobo 11",
+                            "center": true
+                        },
+                        {
+                            "range": [96, 103],
+                            "name": "gobo 12",
+                            "center": true
+                        },
+                        {
+                            "range": [104, 111],
+                            "name": "gobo 13",
+                            "center": true
+                        },
+                        {
+                            "range": [112, 119],
+                            "name": "gobo 14",
+                            "center": true
+                        },
+                        {
+                            "range": [120, 126],
+                            "name": "gobo 1 shake",
+                            "center": true
+                        },
+                        {
+                            "range": [127, 133],
+                            "name": "gobo 2 shake",
+                            "center": true
+                        },
+                        {
+                            "range": [134, 140],
+                            "name": "gobo 3 shake",
+                            "center": true
+                        },
+                        {
+                            "range": [141, 147],
+                            "name": "gobo 4 shake",
+                            "center": true
+                        },
+                        {
+                            "range": [148, 154],
+                            "name": "gobo 5 shake",
+                            "center": true
+                        },
+                        {
+                            "range": [155, 161],
+                            "name": "gobo 6 shake",
+                            "center": true
+                        },
+                        {
+                            "range": [162, 168],
+                            "name": "gobo 7 shake",
+                            "center": true
+                        },
+                        {
+                            "range": [169, 175],
+                            "name": "gobo 8 shake",
+                            "center": true
+                        },
+                        {
+                            "range": [176, 182],
+                            "name": "gobo 9 shake",
+                            "center": true
+                        },
+                        {
+                            "range": [183, 189],
+                            "name": "gobo 10 shake",
+                            "center": true
+                        },
+                        {
+                            "range": [190, 196],
+                            "name": "gobo 11 shake",
+                            "center": true
+                        },
+                        {
+                            "range": [197, 203],
+                            "name": "gobo 12 shake",
+                            "center": true
+                        },
+                        {
+                            "range": [204, 210],
+                            "name": "gobo 13 shake",
+                            "center": true
+                        },
+                        {
+                            "range": [211, 217],
+                            "name": "gobo 14 shake",
+                            "center": true
+                        },
+                        {
+                            "range": [218, 255],
+                            "name": "gobo rotation"
+                        }
+                    ],
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "3 fac gobo macr": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 31],
+                            "name": "open",
+                            "center": true
+                        },
+                        {
+                            "range": [32, 127],
+                            "name": "rot prisma"
+                        },
+                        {
+                            "range": [128, 135],
+                            "name": "macro 1",
+                            "center": true
+                        },
+                        {
+                            "range": [136, 143],
+                            "name": "macro 2",
+                            "center": true
+                        },
+                        {
+                            "range": [144, 151],
+                            "name": "macro 3",
+                            "center": true
+                        },
+                        {
+                            "range": [152, 159],
+                            "name": "macro 4",
+                            "center": true
+                        },
+                        {
+                            "range": [160, 167],
+                            "name": "macro 5",
+                            "center": true
+                        },
+                        {
+                            "range": [168, 175],
+                            "name": "macro 6",
+                            "center": true
+                        },
+                        {
+                            "range": [176, 183],
+                            "name": "macro 7",
+                            "center": true
+                        },
+                        {
+                            "range": [184, 191],
+                            "name": "macro 8",
+                            "center": true
+                        },
+                        {
+                            "range": [192, 199],
+                            "name": "macro 9",
+                            "center": true
+                        },
+                        {
+                            "range": [200, 207],
+                            "name": "macro 10",
+                            "center": true
+                        },
+                        {
+                            "range": [208, 215],
+                            "name": "macro 11",
+                            "center": true
+                        },
+                        {
+                            "range": [216, 223],
+                            "name": "macro 12",
+                            "center": true
+                        },
+                        {
+                            "range": [224, 231],
+                            "name": "macro 13",
+                            "center": true
+                        },
+                        {
+                            "range": [232, 239],
+                            "name": "macro 14",
+                            "center": true
+                        },
+                        {
+                            "range": [240, 247],
+                            "name": "macro 15",
+                            "center": true
+                        },
+                        {
+                            "range": [248, 255],
+                            "name": "macro 16",
+                            "center": true
+                        }
+                    ]
+                },
+                "rot prism index": {
+                    "type": "Prism",
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "prism index"
+                        },
+                        {
+                            "range": [128, 189],
+                            "name": "ffw rotation"
+                        },
+                        {
+                            "range": [190, 193],
+                            "name": "no rotation"
+                        },
+                        {
+                            "range": [194, 255],
+                            "name": "bkw rotation"
+                        }
+                    ],
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "rot prism index fine": {
+                    "type": "Prism",
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "prism index"
+                        },
+                        {
+                            "range": [128, 189],
+                            "name": "ffw rotation"
+                        },
+                        {
+                            "range": [190, 193],
+                            "name": "no rotation"
+                        },
+                        {
+                            "range": [194, 255],
+                            "name": "bkw rotation"
+                        }
+                    ],
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "Focus": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "Focus fine": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "Shutter": {
+                    "type": "Shutter",
+                    "defaultValue": 255,
+                    "capabilities": [
+                        {
+                            "range": [0, 31],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [32, 63],
+                            "name": "open"
+                        },
+                        {
+                            "range": [64, 95],
+                            "name": "strobe"
+                        },
+                        {
+                            "range": [96, 127],
+                            "name": "open"
+                        },
+                        {
+                            "range": [128, 159],
+                            "name": "pulse"
+                        },
+                        {
+                            "range": [160, 191],
+                            "name": "open"
+                        },
+                        {
+                            "range": [192, 223],
+                            "name": "random"
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "open"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 0,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "defaultValue": null
+                },
+                "Intensity fine": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "defaultValue": null
+                },
+                "Iris": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 191],
+                            "name": "maximum"
+                        },
+                        {
+                            "range": [192, 223],
+                            "name": "pulse closing"
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "pulse opening"
+                        }
+                    ],
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "Iris fine": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 191],
+                            "name": "maximum"
+                        },
+                        {
+                            "range": [192, 223],
+                            "name": "pulse closing"
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "pulse opening"
+                        }
+                    ],
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "Frost": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 191],
+                            "name": "frost 0-100%"
+                        },
+                        {
+                            "range": [192, 223],
+                            "name": "pulse fast - sl"
+                        },
+                        {
+                            "range": [224, 254],
+                            "name": "pulse sl - fast"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "max frost"
+                        }
+                    ]
+                },
+                "P/T speed": {
+                    "type": "Speed",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 225],
+                            "name": "max to min"
+                        },
+                        {
+                            "range": [226, 235],
+                            "name": "bl out movement"
+                        },
+                        {
+                            "range": [236, 245],
+                            "name": "bl out wheel"
+                        },
+                        {
+                            "range": [246, 255],
+                            "name": "no funktion"
+                        }
+                    ]
+                },
+                "Reset": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 19],
+                            "name": "c. change nor."
+                        },
+                        {
+                            "range": [20, 29],
+                            "name": "c. change any"
+                        },
+                        {
+                            "range": [30, 39],
+                            "name": "c g change any"
+                        },
+                        {
+                            "range": [40, 59],
+                            "name": "lamp on"
+                        },
+                        {
+                            "range": [60, 79],
+                            "name": "lamp off"
+                        },
+                        {
+                            "range": [80, 84],
+                            "name": "reset"
+                        },
+                        {
+                            "range": [85, 87],
+                            "name": "P/T reset"
+                        },
+                        {
+                            "range": [88, 90],
+                            "name": "color reset"
+                        },
+                        {
+                            "range": [91, 93],
+                            "name": "gobo reset"
+                        },
+                        {
+                            "range": [94, 96],
+                            "name": "shutter reset"
+                        },
+                        {
+                            "range": [97, 99],
+                            "name": "other reset"
+                        },
+                        {
+                            "range": [100, 119],
+                            "name": "program 1"
+                        },
+                        {
+                            "range": [120, 139],
+                            "name": "program 2"
+                        },
+                        {
+                            "range": [140, 159],
+                            "name": "program 3"
+                        },
+                        {
+                            "range": [160, 179],
+                            "name": "program 4"
+                        },
+                        {
+                            "range": [180, 199],
+                            "name": "program 5"
+                        },
+                        {
+                            "range": [200, 219],
+                            "name": "program 6"
+                        },
+                        {
+                            "range": [220, 239],
+                            "name": "program 7"
+                        },
+                        {
+                            "range": [240, 255],
+                            "name": "audio control"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ],
+                [
+                    "Colorwheel",
+                    "Colorwheel fine"
+                ],
+                [
+                    "rot go index",
+                    "rot go index fine"
+                ],
+                [
+                    "Fixed gobos",
+                    "Fixed gobos fine"
+                ],
+                [
+                    "rot prism index",
+                    "rot prism index fine"
+                ],
+                [
+                    "Focus",
+                    "Focus fine"
+                ],
+                [
+                    "Intensity",
+                    "Intensity fine"
+                ],
+                [
+                    "Iris",
+                    "Iris fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "24-channel Mode",
+                    "shortName": "24ch",
+                    "channels": [
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "Colorwheel",
+                        "Colorwheel fine",
+                        "Rot gobos",
+                        "rot go index",
+                        "rot go index fine",
+                        "Fixed gobos",
+                        "Fixed gobos fine",
+                        "3 fac gobo macr",
+                        "rot prism index",
+                        "rot prism index fine",
+                        "Focus",
+                        "Focus fine",
+                        "Shutter",
+                        "Intensity",
+                        "Intensity fine",
+                        "Iris",
+                        "Iris fine",
+                        "Frost",
+                        "P/T speed",
+                        "Reset"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Elation Professional",
+            "name": "Platinum Spot 5R Mode St",
+            "shortName": "PSpot 5R M St",
+            "physical": {
+                "dimensions": [360, 450, 337],
+                "weight": 14.8,
+                "power": 350
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "highlightValue": null
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 0,
+                    "crossfade": true,
+                    "highlightValue": null
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "highlightValue": null
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 0,
+                    "crossfade": true,
+                    "highlightValue": null
+                },
+                "Colorwheel": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 13],
+                            "name": "open"
+                        },
+                        {
+                            "range": [14, 27],
+                            "name": "color 1"
+                        },
+                        {
+                            "range": [28, 41],
+                            "name": "color 2"
+                        },
+                        {
+                            "range": [42, 55],
+                            "name": "color 3"
+                        },
+                        {
+                            "range": [56, 69],
+                            "name": "color 4"
+                        },
+                        {
+                            "range": [70, 83],
+                            "name": "color 5"
+                        },
+                        {
+                            "range": [84, 97],
+                            "name": "color 6"
+                        },
+                        {
+                            "range": [98, 111],
+                            "name": "color 7"
+                        },
+                        {
+                            "range": [112, 127],
+                            "name": "color 8"
+                        },
+                        {
+                            "range": [128, 189],
+                            "name": "ffw rainbow"
+                        },
+                        {
+                            "range": [190, 193],
+                            "name": "no rotation"
+                        },
+                        {
+                            "range": [194, 255],
+                            "name": "bkw color"
+                        }
+                    ]
+                },
+                "Rot gobos": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 9],
+                            "name": "open"
+                        },
+                        {
+                            "range": [10, 19],
+                            "name": "rot gobo 1"
+                        },
+                        {
+                            "range": [20, 29],
+                            "name": "rot gobo 2"
+                        },
+                        {
+                            "range": [30, 39],
+                            "name": "rot gobo 3"
+                        },
+                        {
+                            "range": [40, 49],
+                            "name": "rot gobo 4"
+                        },
+                        {
+                            "range": [50, 59],
+                            "name": "rot gobo 5"
+                        },
+                        {
+                            "range": [60, 69],
+                            "name": "rot gobo 6"
+                        },
+                        {
+                            "range": [70, 79],
+                            "name": "rot gobo 7"
+                        },
+                        {
+                            "range": [80, 89],
+                            "name": "rot gobo 8"
+                        },
+                        {
+                            "range": [90, 104],
+                            "name": "rot go 1 shake"
+                        },
+                        {
+                            "range": [105, 119],
+                            "name": "rot go 2 shake"
+                        },
+                        {
+                            "range": [120, 134],
+                            "name": "rot go 3 shake"
+                        },
+                        {
+                            "range": [135, 149],
+                            "name": "rot go 4 shake"
+                        },
+                        {
+                            "range": [150, 164],
+                            "name": "rot go 5 shake"
+                        },
+                        {
+                            "range": [165, 179],
+                            "name": "rot go 6 shake"
+                        },
+                        {
+                            "range": [180, 194],
+                            "name": "rot go 7 shake"
+                        },
+                        {
+                            "range": [195, 209],
+                            "name": "rot go 8 shake"
+                        },
+                        {
+                            "range": [210, 255],
+                            "name": "rot go sl to fa"
+                        }
+                    ]
+                },
+                "rot go index": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "gobo index"
+                        },
+                        {
+                            "range": [128, 189],
+                            "name": "ffw rotation"
+                        },
+                        {
+                            "range": [190, 193],
+                            "name": "no rotation"
+                        },
+                        {
+                            "range": [194, 255],
+                            "name": "bkw rotation"
+                        }
+                    ]
+                },
+                "Fixed gobos": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 7],
+                            "name": "open"
+                        },
+                        {
+                            "range": [8, 15],
+                            "name": "gobo 1",
+                            "center": true
+                        },
+                        {
+                            "range": [16, 23],
+                            "name": "gobo 2",
+                            "center": true
+                        },
+                        {
+                            "range": [24, 31],
+                            "name": "gobo 3",
+                            "center": true
+                        },
+                        {
+                            "range": [32, 39],
+                            "name": "gobo 4",
+                            "center": true
+                        },
+                        {
+                            "range": [40, 47],
+                            "name": "gobo 5",
+                            "center": true
+                        },
+                        {
+                            "range": [48, 55],
+                            "name": "gobo 6",
+                            "center": true
+                        },
+                        {
+                            "range": [56, 63],
+                            "name": "gobo 7",
+                            "center": true
+                        },
+                        {
+                            "range": [64, 71],
+                            "name": "gobo 8",
+                            "center": true
+                        },
+                        {
+                            "range": [72, 79],
+                            "name": "gobo 9",
+                            "center": true
+                        },
+                        {
+                            "range": [80, 87],
+                            "name": "gobo 10",
+                            "center": true
+                        },
+                        {
+                            "range": [88, 95],
+                            "name": "gobo 11",
+                            "center": true
+                        },
+                        {
+                            "range": [96, 103],
+                            "name": "gobo 12",
+                            "center": true
+                        },
+                        {
+                            "range": [104, 111],
+                            "name": "gobo 13",
+                            "center": true
+                        },
+                        {
+                            "range": [112, 119],
+                            "name": "gobo 14",
+                            "center": true
+                        },
+                        {
+                            "range": [120, 126],
+                            "name": "gobo 1 shake",
+                            "center": true
+                        },
+                        {
+                            "range": [127, 133],
+                            "name": "gobo 2 shake",
+                            "center": true
+                        },
+                        {
+                            "range": [134, 140],
+                            "name": "gobo 3 shake",
+                            "center": true
+                        },
+                        {
+                            "range": [141, 147],
+                            "name": "gobo 4 shake",
+                            "center": true
+                        },
+                        {
+                            "range": [148, 154],
+                            "name": "gobo 5 shake",
+                            "center": true
+                        },
+                        {
+                            "range": [155, 161],
+                            "name": "gobo 6 shake",
+                            "center": true
+                        },
+                        {
+                            "range": [162, 168],
+                            "name": "gobo 7 shake",
+                            "center": true
+                        },
+                        {
+                            "range": [169, 175],
+                            "name": "gobo 8 shake",
+                            "center": true
+                        },
+                        {
+                            "range": [176, 182],
+                            "name": "gobo 9 shake",
+                            "center": true
+                        },
+                        {
+                            "range": [183, 189],
+                            "name": "gobo 10 shake",
+                            "center": true
+                        },
+                        {
+                            "range": [190, 196],
+                            "name": "gobo 11 shake",
+                            "center": true
+                        },
+                        {
+                            "range": [197, 203],
+                            "name": "gobo 12 shake",
+                            "center": true
+                        },
+                        {
+                            "range": [204, 210],
+                            "name": "gobo 13 shake",
+                            "center": true
+                        },
+                        {
+                            "range": [211, 217],
+                            "name": "gobo 14 shake",
+                            "center": true
+                        },
+                        {
+                            "range": [218, 255],
+                            "name": "gobo rotation"
+                        }
+                    ]
+                },
+                "3 fac gobo macr": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 31],
+                            "name": "open",
+                            "center": true
+                        },
+                        {
+                            "range": [32, 127],
+                            "name": "rot prisma"
+                        },
+                        {
+                            "range": [128, 135],
+                            "name": "macro 1",
+                            "center": true
+                        },
+                        {
+                            "range": [136, 143],
+                            "name": "macro 2",
+                            "center": true
+                        },
+                        {
+                            "range": [144, 151],
+                            "name": "macro 3",
+                            "center": true
+                        },
+                        {
+                            "range": [152, 159],
+                            "name": "macro 4",
+                            "center": true
+                        },
+                        {
+                            "range": [160, 167],
+                            "name": "macro 5",
+                            "center": true
+                        },
+                        {
+                            "range": [168, 175],
+                            "name": "macro 6",
+                            "center": true
+                        },
+                        {
+                            "range": [176, 183],
+                            "name": "macro 7",
+                            "center": true
+                        },
+                        {
+                            "range": [184, 191],
+                            "name": "macro 8",
+                            "center": true
+                        },
+                        {
+                            "range": [192, 199],
+                            "name": "macro 9",
+                            "center": true
+                        },
+                        {
+                            "range": [200, 207],
+                            "name": "macro 10",
+                            "center": true
+                        },
+                        {
+                            "range": [208, 215],
+                            "name": "macro 11",
+                            "center": true
+                        },
+                        {
+                            "range": [216, 223],
+                            "name": "macro 12",
+                            "center": true
+                        },
+                        {
+                            "range": [224, 231],
+                            "name": "macro 13",
+                            "center": true
+                        },
+                        {
+                            "range": [232, 239],
+                            "name": "macro 14",
+                            "center": true
+                        },
+                        {
+                            "range": [240, 247],
+                            "name": "macro 15",
+                            "center": true
+                        },
+                        {
+                            "range": [248, 255],
+                            "name": "macro 16",
+                            "center": true
+                        }
+                    ]
+                },
+                "rot prism index": {
+                    "type": "Prism",
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "prism index"
+                        },
+                        {
+                            "range": [128, 189],
+                            "name": "ffw rotation"
+                        },
+                        {
+                            "range": [190, 193],
+                            "name": "no rotation"
+                        },
+                        {
+                            "range": [194, 255],
+                            "name": "bkw rotation"
+                        }
+                    ]
+                },
+                "Focus": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Shutter": {
+                    "type": "Shutter",
+                    "defaultValue": 255,
+                    "capabilities": [
+                        {
+                            "range": [0, 31],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [32, 63],
+                            "name": "open"
+                        },
+                        {
+                            "range": [64, 95],
+                            "name": "strobe"
+                        },
+                        {
+                            "range": [96, 127],
+                            "name": "open"
+                        },
+                        {
+                            "range": [128, 159],
+                            "name": "pulse"
+                        },
+                        {
+                            "range": [160, 191],
+                            "name": "open"
+                        },
+                        {
+                            "range": [192, 223],
+                            "name": "random"
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "open"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Iris": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 191],
+                            "name": "maximum"
+                        },
+                        {
+                            "range": [192, 223],
+                            "name": "pulse closing"
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "pulse opening"
+                        }
+                    ]
+                },
+                "Frost": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 191],
+                            "name": "frost 0-100%"
+                        },
+                        {
+                            "range": [192, 223],
+                            "name": "pulse fast - sl"
+                        },
+                        {
+                            "range": [224, 254],
+                            "name": "pulse sl - fast"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "max frost"
+                        }
+                    ]
+                },
+                "P/T speed": {
+                    "type": "Speed",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 225],
+                            "name": "max to min"
+                        },
+                        {
+                            "range": [226, 235],
+                            "name": "bl out movement"
+                        },
+                        {
+                            "range": [236, 245],
+                            "name": "bl out wheel"
+                        },
+                        {
+                            "range": [246, 255],
+                            "name": "no funktion"
+                        }
+                    ]
+                },
+                "Reset": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 19],
+                            "name": "c. change nor."
+                        },
+                        {
+                            "range": [20, 29],
+                            "name": "c. change any"
+                        },
+                        {
+                            "range": [30, 39],
+                            "name": "c g change any"
+                        },
+                        {
+                            "range": [40, 59],
+                            "name": "lamp on"
+                        },
+                        {
+                            "range": [60, 79],
+                            "name": "lamp off"
+                        },
+                        {
+                            "range": [80, 84],
+                            "name": "reset"
+                        },
+                        {
+                            "range": [85, 87],
+                            "name": "P/T reset"
+                        },
+                        {
+                            "range": [88, 90],
+                            "name": "color reset"
+                        },
+                        {
+                            "range": [91, 93],
+                            "name": "gobo reset"
+                        },
+                        {
+                            "range": [94, 96],
+                            "name": "shutter reset"
+                        },
+                        {
+                            "range": [97, 99],
+                            "name": "other reset"
+                        },
+                        {
+                            "range": [100, 119],
+                            "name": "program 1"
+                        },
+                        {
+                            "range": [120, 139],
+                            "name": "program 2"
+                        },
+                        {
+                            "range": [140, 159],
+                            "name": "program 3"
+                        },
+                        {
+                            "range": [160, 179],
+                            "name": "program 4"
+                        },
+                        {
+                            "range": [180, 199],
+                            "name": "program 5"
+                        },
+                        {
+                            "range": [200, 219],
+                            "name": "program 6"
+                        },
+                        {
+                            "range": [220, 239],
+                            "name": "program 7"
+                        },
+                        {
+                            "range": [240, 255],
+                            "name": "audio control"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "17-channel Mode",
+                    "shortName": "17ch",
+                    "channels": [
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "Colorwheel",
+                        "Rot gobos",
+                        "rot go index",
+                        "Fixed gobos",
+                        "3 fac gobo macr",
+                        "rot prism index",
+                        "Focus",
+                        "Shutter",
+                        "Intensity",
+                        "Iris",
+                        "Frost",
+                        "P/T speed",
+                        "Reset"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Elation Professional",
+            "name": "Power Spot 700 CMY",
+            "shortName": "PSpot700CMY",
+            "comment": "cd",
+            "physical": {
+                "dimensions": [500, 500, 700],
+                "weight": 28.5,
+                "power": 900
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "highlightValue": null
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 0,
+                    "crossfade": true,
+                    "highlightValue": null
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "highlightValue": null
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 0,
+                    "crossfade": true,
+                    "highlightValue": null
+                },
+                "Color1": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 3],
+                            "name": "open"
+                        },
+                        {
+                            "range": [4, 7],
+                            "name": "lila 509"
+                        },
+                        {
+                            "range": [8, 11],
+                            "name": "green 206"
+                        },
+                        {
+                            "range": [12, 15],
+                            "name": "pink 312"
+                        },
+                        {
+                            "range": [16, 19],
+                            "name": "orange 306u"
+                        },
+                        {
+                            "range": [20, 23],
+                            "name": "lila 502"
+                        },
+                        {
+                            "range": [24, 27],
+                            "name": "yellow 601"
+                        },
+                        {
+                            "range": [28, 31],
+                            "name": "CTB"
+                        },
+                        {
+                            "range": [32, 35],
+                            "name": "red 308"
+                        },
+                        {
+                            "range": [36, 67],
+                            "name": "open"
+                        },
+                        {
+                            "range": [68, 71],
+                            "name": "lila 509"
+                        },
+                        {
+                            "range": [72, 75],
+                            "name": "green 206"
+                        },
+                        {
+                            "range": [76, 79],
+                            "name": "pink 312"
+                        },
+                        {
+                            "range": [80, 83],
+                            "name": "orange 306u"
+                        },
+                        {
+                            "range": [84, 87],
+                            "name": "lila 502"
+                        },
+                        {
+                            "range": [88, 91],
+                            "name": "yellow 601"
+                        },
+                        {
+                            "range": [92, 95],
+                            "name": "CTB"
+                        },
+                        {
+                            "range": [96, 99],
+                            "name": "red 308"
+                        },
+                        {
+                            "range": [100, 127],
+                            "name": "open"
+                        },
+                        {
+                            "range": [128, 129],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [130, 191],
+                            "name": ">>"
+                        },
+                        {
+                            "range": [192, 253],
+                            "name": "<<"
+                        },
+                        {
+                            "range": [254, 255],
+                            "name": "audio chase"
+                        }
+                    ]
+                },
+                "Cyan": {
+                    "type": "SingleColor",
+                    "color": "Cyan",
+                    "crossfade": true
+                },
+                "Magenta": {
+                    "type": "SingleColor",
+                    "color": "Magenta",
+                    "crossfade": true
+                },
+                "Yellow": {
+                    "type": "SingleColor",
+                    "color": "Yellow",
+                    "crossfade": true
+                },
+                "Gobo1": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 7],
+                            "name": "open"
+                        },
+                        {
+                            "range": [8, 15],
+                            "name": "slot1"
+                        },
+                        {
+                            "range": [16, 23],
+                            "name": "slot2"
+                        },
+                        {
+                            "range": [24, 31],
+                            "name": "slot3"
+                        },
+                        {
+                            "range": [32, 39],
+                            "name": "slot4"
+                        },
+                        {
+                            "range": [40, 47],
+                            "name": "slot5"
+                        },
+                        {
+                            "range": [48, 55],
+                            "name": "slot6"
+                        },
+                        {
+                            "range": [56, 63],
+                            "name": "slot7"
+                        },
+                        {
+                            "range": [64, 71],
+                            "name": "open"
+                        },
+                        {
+                            "range": [72, 79],
+                            "name": "slot1"
+                        },
+                        {
+                            "range": [80, 87],
+                            "name": "slot2"
+                        },
+                        {
+                            "range": [88, 95],
+                            "name": "slot3"
+                        },
+                        {
+                            "range": [96, 103],
+                            "name": "slot4"
+                        },
+                        {
+                            "range": [104, 111],
+                            "name": "slot5"
+                        },
+                        {
+                            "range": [112, 119],
+                            "name": "slot6"
+                        },
+                        {
+                            "range": [120, 127],
+                            "name": "slot7"
+                        },
+                        {
+                            "range": [128, 129],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [130, 191],
+                            "name": ">>"
+                        },
+                        {
+                            "range": [192, 253],
+                            "name": "<<"
+                        },
+                        {
+                            "range": [254, 255],
+                            "name": "audio chase"
+                        }
+                    ]
+                },
+                "Gobo1 rot.": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "index"
+                        },
+                        {
+                            "range": [128, 129],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [130, 191],
+                            "name": ">>"
+                        },
+                        {
+                            "range": [192, 253],
+                            "name": "<<"
+                        },
+                        {
+                            "range": [254, 255],
+                            "name": "audio chase"
+                        }
+                    ]
+                },
+                "Gobo2": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 3],
+                            "name": "open"
+                        },
+                        {
+                            "range": [4, 7],
+                            "name": "slot1"
+                        },
+                        {
+                            "range": [8, 11],
+                            "name": "slot2"
+                        },
+                        {
+                            "range": [12, 15],
+                            "name": "slot3"
+                        },
+                        {
+                            "range": [16, 19],
+                            "name": "slot4"
+                        },
+                        {
+                            "range": [20, 23],
+                            "name": "slot5"
+                        },
+                        {
+                            "range": [24, 27],
+                            "name": "slot6"
+                        },
+                        {
+                            "range": [28, 31],
+                            "name": "slot7"
+                        },
+                        {
+                            "range": [32, 35],
+                            "name": "slot8"
+                        },
+                        {
+                            "range": [36, 63],
+                            "name": "slot9"
+                        },
+                        {
+                            "range": [64, 67],
+                            "name": "open"
+                        },
+                        {
+                            "range": [68, 71],
+                            "name": "slot1"
+                        },
+                        {
+                            "range": [72, 75],
+                            "name": "slot2"
+                        },
+                        {
+                            "range": [76, 79],
+                            "name": "slot3"
+                        },
+                        {
+                            "range": [80, 83],
+                            "name": "slot4"
+                        },
+                        {
+                            "range": [84, 87],
+                            "name": "slot5"
+                        },
+                        {
+                            "range": [88, 91],
+                            "name": "slot6"
+                        },
+                        {
+                            "range": [92, 95],
+                            "name": "slot7"
+                        },
+                        {
+                            "range": [96, 99],
+                            "name": "slot8"
+                        },
+                        {
+                            "range": [100, 127],
+                            "name": "slot9"
+                        },
+                        {
+                            "range": [128, 129],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [130, 191],
+                            "name": ">>"
+                        },
+                        {
+                            "range": [192, 253],
+                            "name": "<<"
+                        },
+                        {
+                            "range": [254, 255],
+                            "name": "audio chase"
+                        }
+                    ]
+                },
+                "Shutter": {
+                    "type": "Shutter",
+                    "highlightValue": 255,
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [16, 31],
+                            "name": "random"
+                        },
+                        {
+                            "range": [32, 47],
+                            "name": "pulse"
+                        },
+                        {
+                            "range": [48, 63],
+                            "name": "audio"
+                        },
+                        {
+                            "range": [64, 239],
+                            "name": "strobe"
+                        },
+                        {
+                            "range": [240, 255],
+                            "name": "open"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Focus": {
+                    "type": "Beam",
+                    "defaultValue": 128,
+                    "crossfade": true
+                },
+                "Zoom": {
+                    "type": "Beam",
+                    "defaultValue": 128,
+                    "crossfade": true
+                },
+                "Frost": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Prisma": {
+                    "type": "Prism",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 5],
+                            "name": "open"
+                        },
+                        {
+                            "range": [6, 129],
+                            "name": "index"
+                        },
+                        {
+                            "range": [130, 191],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [192, 253],
+                            "name": ">>"
+                        },
+                        {
+                            "range": [254, 254],
+                            "name": "<<"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "audio"
+                        }
+                    ]
+                },
+                "Iris": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "%"
+                        },
+                        {
+                            "range": [128, 159],
+                            "name": "random"
+                        },
+                        {
+                            "range": [160, 191],
+                            "name": "audio"
+                        },
+                        {
+                            "range": [192, 223],
+                            "name": "strobe"
+                        },
+                        {
+                            "range": [224, 253],
+                            "name": "pulse"
+                        },
+                        {
+                            "range": [254, 255],
+                            "name": "open"
+                        }
+                    ]
+                },
+                "CTO": {
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "crossfade": true
+                },
+                "Wheel swing": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Wheel rot.": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": ">>"
+                        },
+                        {
+                            "range": [128, 255],
+                            "name": "<<"
+                        }
+                    ]
+                },
+                "Special": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Movement": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "P/T speed": {
+                    "type": "Speed",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "track"
+                        },
+                        {
+                            "range": [16, 255],
+                            "name": "speed"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "24-channel Mode",
+                    "shortName": "24ch",
+                    "channels": [
+                        "Pan",
+                        "Pan fine",
+                        "Color1",
+                        "Tilt fine",
+                        null,
+                        "Cyan",
+                        "Magenta",
+                        "Yellow",
+                        "Gobo1",
+                        "Gobo1 rot.",
+                        "Gobo2",
+                        "Shutter",
+                        "Intensity",
+                        "Focus",
+                        "Zoom",
+                        "Frost",
+                        "Prisma",
+                        "Iris",
+                        "CTO",
+                        "Wheel swing",
+                        "Wheel rot.",
+                        "Special",
+                        "Movement",
+                        "P/T speed"
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/fixtures/imports/ecue-MainLibrary/Element-Labs.json
+++ b/fixtures/imports/ecue-MainLibrary/Element-Labs.json
@@ -1,0 +1,100 @@
+{
+    "manufacturers": {
+        "Element Labs": {
+            "name": "Element Labs",
+            "website": "www.elementlabs.com"
+        }
+    },
+    "fixtures": [
+        {
+            "manufacturer": "Element Labs",
+            "name": "VersaDrive C1",
+            "shortName": "VD-C1",
+            "physical": {
+                "dimensions": [100, 100, 100],
+                "weight": 4
+            },
+            "availableChannels": {
+                "Pattern Select": {
+                    "type": "Beam"
+                },
+                "Playback Mode": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 50],
+                            "name": "Loop"
+                        },
+                        {
+                            "range": [51, 100],
+                            "name": "Hold"
+                        },
+                        {
+                            "range": [101, 150],
+                            "name": "Once"
+                        },
+                        {
+                            "range": [151, 200],
+                            "name": "Bounce"
+                        },
+                        {
+                            "range": [201, 255],
+                            "name": "All"
+                        }
+                    ]
+                },
+                "D.C. Mode": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 63],
+                            "name": "additive"
+                        },
+                        {
+                            "range": [64, 193],
+                            "name": "undefined"
+                        },
+                        {
+                            "range": [194, 255],
+                            "name": "subtractive"
+                        }
+                    ]
+                },
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "invert": true,
+                    "precendence": "HTP"
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "invert": true,
+                    "precendence": "HTP"
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "invert": true,
+                    "precendence": "HTP"
+                }
+            },
+            "modes": [
+                {
+                    "name": "6-channel Mode",
+                    "shortName": "6ch",
+                    "channels": [
+                        "Pattern Select",
+                        "Playback Mode",
+                        "D.C. Mode",
+                        "Red",
+                        "Green",
+                        "Blue"
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/fixtures/imports/ecue-MainLibrary/Eurolite.json
+++ b/fixtures/imports/ecue-MainLibrary/Eurolite.json
@@ -1,0 +1,1252 @@
+{
+    "manufacturers": {
+        "Eurolite": {
+            "name": "Eurolite",
+            "website": "http:eurolite.de"
+        }
+    },
+    "fixtures": [
+        {
+            "manufacturer": "Eurolite",
+            "name": "LED Bar 324 10 RGB 11ChMode",
+            "shortName": "LedBar11Ch",
+            "comment": "http://download.showtechnic.de/data/documents/00039723.pdf",
+            "physical": {
+                "dimensions": [800, 135, 100],
+                "weight": 4.5,
+                "power": 85
+            },
+            "availableChannels": {
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 250],
+                            "name": "Dimmer 0-100%"
+                        },
+                        {
+                            "range": [251, 255],
+                            "name": "Preset Mode"
+                        }
+                    ]
+                },
+                "Flash / Preset": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 10],
+                            "name": "Black Out"
+                        },
+                        {
+                            "range": [11, 21],
+                            "name": "Red",
+                            "color": "#ff0000"
+                        },
+                        {
+                            "range": [22, 32],
+                            "name": "Yellow",
+                            "color": "#ffff00"
+                        },
+                        {
+                            "range": [33, 43],
+                            "name": "Green",
+                            "color": "#00ff00"
+                        },
+                        {
+                            "range": [44, 54],
+                            "name": "Cyan",
+                            "color": "#00ffff"
+                        },
+                        {
+                            "range": [55, 65],
+                            "name": "Blue",
+                            "color": "#0000ff"
+                        },
+                        {
+                            "range": [66, 76],
+                            "name": "Purple",
+                            "color": "#800080"
+                        },
+                        {
+                            "range": [77, 87],
+                            "name": "White",
+                            "color": "#ffffff"
+                        },
+                        {
+                            "range": [88, 98],
+                            "name": "Slow Dream"
+                        },
+                        {
+                            "range": [99, 109],
+                            "name": "Fast Dream"
+                        },
+                        {
+                            "range": [110, 120],
+                            "name": "Color Fade"
+                        },
+                        {
+                            "range": [121, 131],
+                            "name": "Color Change"
+                        },
+                        {
+                            "range": [132, 142],
+                            "name": "Flow1"
+                        },
+                        {
+                            "range": [143, 153],
+                            "name": "Flow2"
+                        },
+                        {
+                            "range": [154, 164],
+                            "name": "Flow3"
+                        },
+                        {
+                            "range": [165, 175],
+                            "name": "Flow4"
+                        },
+                        {
+                            "range": [176, 186],
+                            "name": "Double Flow1"
+                        },
+                        {
+                            "range": [187, 197],
+                            "name": "Double Flow2"
+                        },
+                        {
+                            "range": [198, 208],
+                            "name": "Multi Color"
+                        },
+                        {
+                            "range": [209, 219],
+                            "name": "2 color Flow1"
+                        },
+                        {
+                            "range": [220, 230],
+                            "name": "2 color Flow2"
+                        },
+                        {
+                            "range": [231, 255],
+                            "name": "Sound Active"
+                        }
+                    ]
+                },
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Red-1c0h5": {
+                    "name": "Red",
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green-2s1nq": {
+                    "name": "Green",
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue-tjpyi": {
+                    "name": "Blue",
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Red-kdisd": {
+                    "name": "Red",
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green-2yda0": {
+                    "name": "Green",
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue-jddwd": {
+                    "name": "Blue",
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                }
+            },
+            "modes": [
+                {
+                    "name": "11-channel Mode",
+                    "shortName": "11ch",
+                    "channels": [
+                        "Intensity",
+                        "Flash / Preset",
+                        "Red",
+                        "Green",
+                        "Blue",
+                        "Red-1c0h5",
+                        "Green-2s1nq",
+                        "Blue-tjpyi",
+                        "Red-kdisd",
+                        "Green-2yda0",
+                        "Blue-jddwd"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Eurolite",
+            "name": "LED Bar 324 10 RGB 20ChMode",
+            "shortName": "LedBar20Ch",
+            "comment": "http://download.showtechnic.de/data/documents/00039723.pdf",
+            "physical": {
+                "dimensions": [800, 135, 100],
+                "weight": 4.5,
+                "power": 85
+            },
+            "availableChannels": {
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 250],
+                            "name": "Dimmer 0-100%"
+                        },
+                        {
+                            "range": [251, 255],
+                            "name": "Preset Mode"
+                        }
+                    ]
+                },
+                "Flash / Preset": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 10],
+                            "name": "Black Out"
+                        },
+                        {
+                            "range": [11, 21],
+                            "name": "Red",
+                            "color": "#ff0000"
+                        },
+                        {
+                            "range": [22, 32],
+                            "name": "Yellow",
+                            "color": "#ffff00"
+                        },
+                        {
+                            "range": [33, 43],
+                            "name": "Green",
+                            "color": "#00ff00"
+                        },
+                        {
+                            "range": [44, 54],
+                            "name": "Cyan",
+                            "color": "#00ffff"
+                        },
+                        {
+                            "range": [55, 65],
+                            "name": "Blue",
+                            "color": "#0000ff"
+                        },
+                        {
+                            "range": [66, 76],
+                            "name": "Purple",
+                            "color": "#800080"
+                        },
+                        {
+                            "range": [77, 87],
+                            "name": "White",
+                            "color": "#ffffff"
+                        },
+                        {
+                            "range": [88, 98],
+                            "name": "Slow Dream"
+                        },
+                        {
+                            "range": [99, 109],
+                            "name": "Fast Dream"
+                        },
+                        {
+                            "range": [110, 120],
+                            "name": "Color Fade"
+                        },
+                        {
+                            "range": [121, 131],
+                            "name": "Color Change"
+                        },
+                        {
+                            "range": [132, 142],
+                            "name": "Flow1"
+                        },
+                        {
+                            "range": [143, 153],
+                            "name": "Flow2"
+                        },
+                        {
+                            "range": [154, 164],
+                            "name": "Flow3"
+                        },
+                        {
+                            "range": [165, 175],
+                            "name": "Flow4"
+                        },
+                        {
+                            "range": [176, 186],
+                            "name": "Double Flow1"
+                        },
+                        {
+                            "range": [187, 197],
+                            "name": "Double Flow2"
+                        },
+                        {
+                            "range": [198, 208],
+                            "name": "Multi Color"
+                        },
+                        {
+                            "range": [209, 219],
+                            "name": "2 color Flow1"
+                        },
+                        {
+                            "range": [220, 230],
+                            "name": "2 color Flow2"
+                        },
+                        {
+                            "range": [231, 255],
+                            "name": "Sound Active"
+                        }
+                    ]
+                },
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Red-qsebf": {
+                    "name": "Red",
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green-tk11e": {
+                    "name": "Green",
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue-7pz2p": {
+                    "name": "Blue",
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Red-3b1y2": {
+                    "name": "Red",
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green-8u3ni": {
+                    "name": "Green",
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue-ll96j": {
+                    "name": "Blue",
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Red-8vvqk": {
+                    "name": "Red",
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green-rv4n2": {
+                    "name": "Green",
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue-apt5a": {
+                    "name": "Blue",
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Red-mdvi8": {
+                    "name": "Red",
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green-dmsne": {
+                    "name": "Green",
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue-0yrgy": {
+                    "name": "Blue",
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Red-gq8kb": {
+                    "name": "Red",
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green-anwc6": {
+                    "name": "Green",
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue-cbv6b": {
+                    "name": "Blue",
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                }
+            },
+            "modes": [
+                {
+                    "name": "20-channel Mode",
+                    "shortName": "20ch",
+                    "channels": [
+                        "Intensity",
+                        "Flash / Preset",
+                        "Red",
+                        "Green",
+                        "Blue",
+                        "Red-qsebf",
+                        "Green-tk11e",
+                        "Blue-7pz2p",
+                        "Red-3b1y2",
+                        "Green-8u3ni",
+                        "Blue-ll96j",
+                        "Red-8vvqk",
+                        "Green-rv4n2",
+                        "Blue-apt5a",
+                        "Red-mdvi8",
+                        "Green-dmsne",
+                        "Blue-0yrgy",
+                        "Red-gq8kb",
+                        "Green-anwc6",
+                        "Blue-cbv6b"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Eurolite",
+            "name": "LED Bar 648 5 RGB Group1 3Ch",
+            "shortName": "LedBar648/5 Group1 3Ch",
+            "comment": "http://www.eurolite.de/eur_artdetail.php?artnr=51913856",
+            "physical": {
+                "dimensions": [820, 120, 75],
+                "weight": 5,
+                "power": 50
+            },
+            "availableChannels": {
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                }
+            },
+            "modes": [
+                {
+                    "name": "3-channel Mode",
+                    "shortName": "3ch",
+                    "channels": [
+                        "Red",
+                        "Green",
+                        "Blue"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Eurolite",
+            "name": "LED Bar 648 5 RGB Group1 6CH",
+            "shortName": "LedBar648/5 Group 1 6Ch",
+            "comment": "http://www.eurolite.de/eur_artdetail.php?artnr=51913856",
+            "physical": {
+                "dimensions": [820, 120, 75],
+                "weight": 5,
+                "power": 50
+            },
+            "availableChannels": {
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 4],
+                            "name": "No Funktion"
+                        },
+                        {
+                            "range": [5, 5],
+                            "name": "Full On"
+                        },
+                        {
+                            "range": [6, 247],
+                            "name": "Fant. Effect"
+                        },
+                        {
+                            "range": [248, 255],
+                            "name": "Full On"
+                        }
+                    ]
+                },
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Strobe": {
+                    "type": "Strobe",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 4],
+                            "name": "No Function"
+                        },
+                        {
+                            "range": [5, 253],
+                            "name": "Slow to Fast"
+                        },
+                        {
+                            "range": [254, 255],
+                            "name": "Full On"
+                        }
+                    ]
+                },
+                "Preset": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 4],
+                            "name": "No Function"
+                        },
+                        {
+                            "range": [5, 30],
+                            "name": "Mode 1"
+                        },
+                        {
+                            "range": [31, 60],
+                            "name": "Mode 2"
+                        },
+                        {
+                            "range": [61, 90],
+                            "name": "Mode 3"
+                        },
+                        {
+                            "range": [91, 120],
+                            "name": "Mode 4"
+                        },
+                        {
+                            "range": [121, 150],
+                            "name": "Mode 5"
+                        },
+                        {
+                            "range": [151, 180],
+                            "name": "Mode 6"
+                        },
+                        {
+                            "range": [181, 210],
+                            "name": "Mode 7"
+                        },
+                        {
+                            "range": [211, 240],
+                            "name": "Mode 8"
+                        },
+                        {
+                            "range": [241, 255],
+                            "name": "Sound Active"
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "6-channel Mode",
+                    "shortName": "6ch",
+                    "channels": [
+                        "Intensity",
+                        "Red",
+                        "Green",
+                        "Blue",
+                        "Strobe",
+                        "Preset"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Eurolite",
+            "name": "LED FE-800RGBAW",
+            "shortName": "LED FE-800RGBAW",
+            "comment": "http://www.eurolite.de/eur_artdetail.php?artnr=51913856",
+            "physical": {
+                "dimensions": [320, 310, 175],
+                "weight": 3.5,
+                "power": 25
+            },
+            "availableChannels": {
+                "Color": {
+                    "type": "MultiColor",
+                    "highlightValue": 90,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [1, 5],
+                            "name": "off",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [6, 10],
+                            "name": "red",
+                            "color": "#ff0000",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [11, 15],
+                            "name": "green",
+                            "color": "#00ff00",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [16, 21],
+                            "name": "blue",
+                            "color": "#0000ff",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [22, 27],
+                            "name": "white",
+                            "color": "#ffffff",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [28, 33],
+                            "name": "amber",
+                            "color": "#ffbf00",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [34, 39],
+                            "name": "green + blue",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [40, 45],
+                            "name": "red + blue",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [46, 51],
+                            "name": "red + green",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [52, 57],
+                            "name": "red + white ",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [58, 63],
+                            "name": "red + amber",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [64, 69],
+                            "name": "green + white",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [70, 75],
+                            "name": "green + amber",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [76, 81],
+                            "name": "blue + white",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [82, 87],
+                            "name": "blue + amber",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [88, 93],
+                            "name": "RGBAW",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [94, 123],
+                            "name": "auto 1 Color",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [124, 185],
+                            "name": "auto 2 color",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [186, 218],
+                            "name": "fast auto",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [219, 250],
+                            "name": "slow auto",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [251, 255],
+                            "name": "sound 2 light",
+                            "showInMenu": false
+                        }
+                    ]
+                },
+                "Color Speed": {
+                    "type": "Speed",
+                    "crossfade": true
+                },
+                "Strobe": {
+                    "type": "Strobe",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 9],
+                            "name": "No Function"
+                        },
+                        {
+                            "range": [10, 254],
+                            "name": "Slow to Fast"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "sound 2 light"
+                        }
+                    ]
+                },
+                "Rotation": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 4],
+                            "name": "No Rotation"
+                        },
+                        {
+                            "range": [5, 127],
+                            "name": "cw"
+                        },
+                        {
+                            "range": [128, 133],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [134, 255],
+                            "name": "ccw"
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "4-channel Mode",
+                    "shortName": "4ch",
+                    "channels": [
+                        "Color",
+                        "Color Speed",
+                        "Strobe",
+                        "Rotation"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Eurolite",
+            "name": "LED PAR 56",
+            "shortName": "LEDPAR56",
+            "comment": "cd",
+            "physical": {
+                "dimensions": [220, 220, 220],
+                "weight": 1.5,
+                "power": 20
+            },
+            "availableChannels": {
+                "Mode": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 63],
+                            "name": "RGB"
+                        },
+                        {
+                            "range": [64, 127],
+                            "name": "7 color fade"
+                        },
+                        {
+                            "range": [128, 191],
+                            "name": "7 color ch."
+                        },
+                        {
+                            "range": [192, 255],
+                            "name": "3 color ch."
+                        }
+                    ]
+                },
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "4-channel Mode",
+                    "shortName": "4ch",
+                    "channels": [
+                        "Mode",
+                        "Red",
+                        "Green",
+                        "Blue"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Eurolite",
+            "name": "LED PAR-64 RGB",
+            "shortName": "LEDPAR64",
+            "comment": "max ambient temperature 45 http://www.eurolite.de/eur_artdetail.php?artnr=51913634",
+            "physical": {
+                "dimensions": [265, 265, 340],
+                "weight": 2.4,
+                "power": 32
+            },
+            "availableChannels": {
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Flash/Strobe": {
+                    "type": "Strobe",
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 9],
+                            "name": "Static"
+                        },
+                        {
+                            "range": [10, 255],
+                            "name": "slow-fast Strob"
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "5-channel Mode",
+                    "shortName": "5ch",
+                    "channels": [
+                        "Red",
+                        "Green",
+                        "Blue",
+                        "Intensity",
+                        "Flash/Strobe"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Eurolite",
+            "name": "TS-255",
+            "shortName": "TS-255",
+            "physical": {
+                "dimensions": [270, 285, 555],
+                "weight": 9,
+                "power": 460
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 125,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Color": {
+                    "type": "MultiColor",
+                    "capabilities": [
+                        {
+                            "range": [0, 31],
+                            "name": "Open/white"
+                        },
+                        {
+                            "range": [32, 63],
+                            "name": "Red",
+                            "color": "#ff0000"
+                        },
+                        {
+                            "range": [64, 95],
+                            "name": "Yellow",
+                            "color": "#ffff00"
+                        },
+                        {
+                            "range": [96, 127],
+                            "name": "Violet",
+                            "color": "#7f00ff"
+                        },
+                        {
+                            "range": [128, 159],
+                            "name": "Green",
+                            "color": "#00ff00"
+                        },
+                        {
+                            "range": [160, 191],
+                            "name": "Orange",
+                            "color": "#ff7f00"
+                        },
+                        {
+                            "range": [192, 223],
+                            "name": "Blue",
+                            "color": "#0000ff"
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "Pink",
+                            "color": "#ffc0cb"
+                        }
+                    ]
+                },
+                "Gobo": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 31],
+                            "name": "offen"
+                        },
+                        {
+                            "range": [32, 63],
+                            "name": "Gobo 1"
+                        },
+                        {
+                            "range": [64, 95],
+                            "name": "Gobo 2"
+                        },
+                        {
+                            "range": [96, 127],
+                            "name": "Gobo 3"
+                        },
+                        {
+                            "range": [128, 159],
+                            "name": "Gobo 4"
+                        },
+                        {
+                            "range": [160, 191],
+                            "name": "Gobo 5"
+                        },
+                        {
+                            "range": [192, 223],
+                            "name": "Gobo 6"
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "Gobo 7"
+                        }
+                    ]
+                },
+                "Shutter": {
+                    "type": "Shutter",
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 14],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [15, 29],
+                            "name": "open"
+                        },
+                        {
+                            "range": [30, 250],
+                            "name": "Strobe s->f"
+                        },
+                        {
+                            "range": [251, 255],
+                            "name": "open"
+                        }
+                    ]
+                },
+                "Gobo Rot": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 4],
+                            "name": "no rotation"
+                        },
+                        {
+                            "range": [5, 120],
+                            "name": "foward rot."
+                        },
+                        {
+                            "range": [121, 139],
+                            "name": "no rotation"
+                        },
+                        {
+                            "range": [140, 255],
+                            "name": "backwards rot."
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "6-channel Mode",
+                    "shortName": "6ch",
+                    "channels": [
+                        "Pan",
+                        "Tilt",
+                        "Color",
+                        "Gobo",
+                        "Shutter",
+                        "Gobo Rot"
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/fixtures/imports/ecue-MainLibrary/Expolite.json
+++ b/fixtures/imports/ecue-MainLibrary/Expolite.json
@@ -1,0 +1,2240 @@
+{
+    "manufacturers": {
+        "Expolite": {
+            "name": "Expolite"
+        }
+    },
+    "fixtures": [
+        {
+            "manufacturer": "Expolite",
+            "name": "AkkuLED 36 Mode Ar1 D",
+            "shortName": "AkkuLED36 M Ar1 D",
+            "comment": "LED",
+            "physical": {
+                "dimensions": [190, 342, 190],
+                "weight": 13.5,
+                "power": 45
+            },
+            "availableChannels": {
+                "Dimmer": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                }
+            },
+            "modes": [
+                {
+                    "name": "4-channel Mode",
+                    "shortName": "4ch",
+                    "channels": [
+                        "Dimmer",
+                        "Red",
+                        "Green",
+                        "Blue"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Expolite",
+            "name": "AkkuLED 36 Mode Ar1 S",
+            "shortName": "AkkuLED36 M Ar1 S",
+            "comment": "LED",
+            "physical": {
+                "dimensions": [190, 342, 190],
+                "weight": 13.5,
+                "power": 45
+            },
+            "availableChannels": {
+                "Dimmer": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Shutter/Strobe": {
+                    "type": "Shutter",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 10],
+                            "name": "no Funktion",
+                            "center": true
+                        },
+                        {
+                            "range": [11, 255],
+                            "name": "1-20Hz"
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "5-channel Mode",
+                    "shortName": "5ch",
+                    "channels": [
+                        "Dimmer",
+                        "Red",
+                        "Green",
+                        "Blue",
+                        "Shutter/Strobe"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Expolite",
+            "name": "AkkuLED 36 Mode Arc 1",
+            "shortName": "AkkuLED36 M Arc 1",
+            "comment": "LED",
+            "physical": {
+                "dimensions": [190, 342, 190],
+                "weight": 13.5,
+                "power": 45
+            },
+            "availableChannels": {
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                }
+            },
+            "modes": [
+                {
+                    "name": "3-channel Mode",
+                    "shortName": "3ch",
+                    "channels": [
+                        "Red",
+                        "Green",
+                        "Blue"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Expolite",
+            "name": "AkkuLED 36 Mode Block",
+            "shortName": "AkkuLED36 M Block",
+            "comment": "LED",
+            "physical": {
+                "dimensions": [190, 342, 190],
+                "weight": 13.5,
+                "power": 45
+            },
+            "availableChannels": {
+                "Red 1": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green 2": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue 3": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Red 1-1hteg": {
+                    "name": "Red 1",
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green 2-opfx4": {
+                    "name": "Green 2",
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue 3-wcbuo": {
+                    "name": "Blue 3",
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                }
+            },
+            "modes": [
+                {
+                    "name": "6-channel Mode",
+                    "shortName": "6ch",
+                    "channels": [
+                        "Red 1",
+                        "Green 2",
+                        "Blue 3",
+                        "Red 1-1hteg",
+                        "Green 2-opfx4",
+                        "Blue 3-wcbuo"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Expolite",
+            "name": "AkkuLED 36 Mode HSV",
+            "shortName": "AkkuLED36 M HSV",
+            "comment": "LED",
+            "physical": {
+                "dimensions": [190, 342, 190],
+                "weight": 13.5,
+                "power": 45
+            },
+            "availableChannels": {
+                "HUE": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Saturation": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Value": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                }
+            },
+            "modes": [
+                {
+                    "name": "3-channel Mode",
+                    "shortName": "3ch",
+                    "channels": [
+                        "HUE",
+                        "Saturation",
+                        "Value"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Expolite",
+            "name": "AkkuLED 36 Mode Tour",
+            "shortName": "AkkuLED36 M Tour",
+            "comment": "LED",
+            "physical": {
+                "dimensions": [190, 342, 190],
+                "weight": 13.5,
+                "power": 45
+            },
+            "availableChannels": {
+                "Dimmer": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Red 1": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green 1": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue 1": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Red 2": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green 2": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue 2": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Color Macro": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 5],
+                            "name": "No Macro"
+                        },
+                        {
+                            "range": [11, 30],
+                            "name": "R100 G up B 0",
+                            "center": true
+                        },
+                        {
+                            "range": [31, 50],
+                            "name": "R dow G 100 B 0",
+                            "center": true
+                        },
+                        {
+                            "range": [51, 70],
+                            "name": "R 0 G 100 B up",
+                            "center": true
+                        },
+                        {
+                            "range": [71, 90],
+                            "name": "R 0 G dow B 100",
+                            "center": true
+                        },
+                        {
+                            "range": [91, 110],
+                            "name": "R up g 0 b 100 ",
+                            "center": true
+                        },
+                        {
+                            "range": [111, 130],
+                            "name": "R 100 g 0 b dow",
+                            "center": true
+                        },
+                        {
+                            "range": [131, 150],
+                            "name": "R 100 G up B up",
+                            "center": true
+                        },
+                        {
+                            "range": [151, 170],
+                            "name": "R do G do B 100",
+                            "center": true
+                        },
+                        {
+                            "range": [171, 200],
+                            "name": "RGBW 100",
+                            "center": true
+                        },
+                        {
+                            "range": [201, 205],
+                            "name": "White 3200 K",
+                            "center": true
+                        },
+                        {
+                            "range": [206, 210],
+                            "name": "White 3400 K",
+                            "center": true
+                        },
+                        {
+                            "range": [211, 215],
+                            "name": "White 4200 K",
+                            "center": true
+                        },
+                        {
+                            "range": [216, 220],
+                            "name": "White 4900 K",
+                            "center": true
+                        },
+                        {
+                            "range": [221, 225],
+                            "name": "White 5600 K",
+                            "center": true
+                        },
+                        {
+                            "range": [226, 230],
+                            "name": "White 5900 K",
+                            "center": true
+                        },
+                        {
+                            "range": [231, 235],
+                            "name": "White 6500 K",
+                            "center": true
+                        },
+                        {
+                            "range": [236, 240],
+                            "name": "White 7200 K",
+                            "center": true
+                        },
+                        {
+                            "range": [241, 245],
+                            "name": "White 8000 K",
+                            "center": true
+                        },
+                        {
+                            "range": [246, 250],
+                            "name": "White 8500 K",
+                            "center": true
+                        },
+                        {
+                            "range": [251, 255],
+                            "name": "White 10000 K",
+                            "center": true
+                        }
+                    ]
+                },
+                "Shutter/Strobe": {
+                    "type": "Shutter",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 10],
+                            "name": "no Funktion",
+                            "center": true
+                        },
+                        {
+                            "range": [11, 255],
+                            "name": "1-20Hz"
+                        }
+                    ]
+                },
+                "Auto": {
+                    "type": "MultiColor",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 40],
+                            "name": "no Funktion",
+                            "center": true
+                        },
+                        {
+                            "range": [41, 50],
+                            "name": "Auto 1",
+                            "center": true
+                        },
+                        {
+                            "range": [51, 60],
+                            "name": "Auto 2",
+                            "center": true
+                        },
+                        {
+                            "range": [61, 70],
+                            "name": "Auto 3",
+                            "center": true
+                        },
+                        {
+                            "range": [71, 80],
+                            "name": "Auto 4",
+                            "center": true
+                        },
+                        {
+                            "range": [81, 90],
+                            "name": "Auto 5",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [91, 100],
+                            "name": "Auto 6",
+                            "center": true
+                        },
+                        {
+                            "range": [101, 110],
+                            "name": "Auto 7",
+                            "center": true
+                        },
+                        {
+                            "range": [111, 120],
+                            "name": "Auto 8",
+                            "center": true
+                        },
+                        {
+                            "range": [121, 130],
+                            "name": "Auto 9",
+                            "center": true
+                        },
+                        {
+                            "range": [131, 140],
+                            "name": "Auto 10",
+                            "center": true
+                        },
+                        {
+                            "range": [141, 150],
+                            "name": "Prg 1",
+                            "center": true
+                        },
+                        {
+                            "range": [151, 160],
+                            "name": "Prg 2",
+                            "center": true
+                        },
+                        {
+                            "range": [161, 170],
+                            "name": "Prg 3",
+                            "center": true
+                        },
+                        {
+                            "range": [171, 180],
+                            "name": "Prg 4",
+                            "center": true
+                        },
+                        {
+                            "range": [181, 190],
+                            "name": "Prg 5",
+                            "center": true
+                        },
+                        {
+                            "range": [191, 200],
+                            "name": "Prg 6",
+                            "center": true
+                        },
+                        {
+                            "range": [201, 210],
+                            "name": "Prg 7",
+                            "center": true
+                        },
+                        {
+                            "range": [211, 220],
+                            "name": "Prg 8",
+                            "center": true
+                        },
+                        {
+                            "range": [221, 230],
+                            "name": "Prg 9",
+                            "center": true
+                        },
+                        {
+                            "range": [231, 255],
+                            "name": "Prg 10",
+                            "center": true
+                        }
+                    ]
+                },
+                "Auto Speed": {
+                    "type": "Speed",
+                    "crossfade": true
+                },
+                "Dimmer Speed": {
+                    "type": "Speed",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 9],
+                            "name": "Present Dimmer"
+                        },
+                        {
+                            "range": [10, 29],
+                            "name": "Linear Dimmer"
+                        },
+                        {
+                            "range": [30, 69],
+                            "name": "non lim Dim 1"
+                        },
+                        {
+                            "range": [70, 129],
+                            "name": "non lim Dim 2"
+                        },
+                        {
+                            "range": [130, 189],
+                            "name": "non lim Dim 3"
+                        },
+                        {
+                            "range": [190, 255],
+                            "name": "non lim Dim 4"
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "12-channel Mode",
+                    "shortName": "12ch",
+                    "channels": [
+                        "Dimmer",
+                        "Red 1",
+                        "Green 1",
+                        "Blue 1",
+                        "Red 2",
+                        "Green 2",
+                        "Blue 2",
+                        "Color Macro",
+                        "Shutter/Strobe",
+                        "Auto",
+                        "Auto Speed",
+                        "Dimmer Speed"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Expolite",
+            "name": "TourLED 21 Mode Arc 1",
+            "shortName": "TourLED21 M Arc1",
+            "comment": "LED",
+            "physical": {
+                "dimensions": [240, 210, 160],
+                "weight": 2.5,
+                "power": 35
+            },
+            "availableChannels": {
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                }
+            },
+            "modes": [
+                {
+                    "name": "3-channel Mode",
+                    "shortName": "3ch",
+                    "channels": [
+                        "Red",
+                        "Green",
+                        "Blue"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Expolite",
+            "name": "TourLED 21 Mode Arc 1d",
+            "shortName": "TourLED21 M Arc1d",
+            "comment": "LED",
+            "physical": {
+                "dimensions": [240, 210, 160],
+                "weight": 2.5,
+                "power": 35
+            },
+            "availableChannels": {
+                "Dimmer": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                }
+            },
+            "modes": [
+                {
+                    "name": "4-channel Mode",
+                    "shortName": "4ch",
+                    "channels": [
+                        "Dimmer",
+                        "Red",
+                        "Green",
+                        "Blue"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Expolite",
+            "name": "TourLED 21 Mode Tour",
+            "shortName": "TourLED21 M Tour",
+            "comment": "LED",
+            "physical": {
+                "dimensions": [240, 210, 160],
+                "weight": 2.5,
+                "power": 35
+            },
+            "availableChannels": {
+                "Dimmer": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Color Macro": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 10],
+                            "name": "No Macro"
+                        },
+                        {
+                            "range": [11, 35],
+                            "name": "R100 G up B 0",
+                            "center": true
+                        },
+                        {
+                            "range": [36, 60],
+                            "name": "R dow G 100 B 0",
+                            "center": true
+                        },
+                        {
+                            "range": [61, 85],
+                            "name": "R 0 G 100 B up",
+                            "center": true
+                        },
+                        {
+                            "range": [86, 110],
+                            "name": "R 0 G dow B 100",
+                            "center": true
+                        },
+                        {
+                            "range": [111, 135],
+                            "name": "R up g 0 b 100 ",
+                            "center": true
+                        },
+                        {
+                            "range": [136, 160],
+                            "name": "R 100 g 0 b dow",
+                            "center": true
+                        },
+                        {
+                            "range": [161, 185],
+                            "name": "R 100 G up B up",
+                            "center": true
+                        },
+                        {
+                            "range": [186, 210],
+                            "name": "R do G do B 100",
+                            "center": true
+                        },
+                        {
+                            "range": [211, 215],
+                            "name": "White 3200 K",
+                            "center": true
+                        },
+                        {
+                            "range": [216, 220],
+                            "name": "White 3400 K",
+                            "center": true
+                        },
+                        {
+                            "range": [221, 225],
+                            "name": "White 4200 K",
+                            "center": true
+                        },
+                        {
+                            "range": [226, 230],
+                            "name": "White 4900 K",
+                            "center": true
+                        },
+                        {
+                            "range": [231, 235],
+                            "name": "White 5600 K",
+                            "center": true
+                        },
+                        {
+                            "range": [236, 240],
+                            "name": "White 5900 K",
+                            "center": true
+                        },
+                        {
+                            "range": [241, 245],
+                            "name": "White 6500 K",
+                            "center": true
+                        },
+                        {
+                            "range": [246, 250],
+                            "name": "White 7200 K",
+                            "center": true
+                        },
+                        {
+                            "range": [251, 255],
+                            "name": "White 8500 K",
+                            "center": true
+                        }
+                    ]
+                },
+                "Shutter/Strobe": {
+                    "type": "Shutter",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 10],
+                            "name": "no Funktion",
+                            "center": true
+                        },
+                        {
+                            "range": [11, 255],
+                            "name": "1-20Hz"
+                        }
+                    ]
+                },
+                "Auto": {
+                    "type": "MultiColor",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 20],
+                            "name": "no Funktion",
+                            "center": true
+                        },
+                        {
+                            "range": [21, 30],
+                            "name": "Auto 1",
+                            "center": true
+                        },
+                        {
+                            "range": [31, 40],
+                            "name": "Auto 2",
+                            "center": true
+                        },
+                        {
+                            "range": [41, 50],
+                            "name": "Auto 3",
+                            "center": true
+                        },
+                        {
+                            "range": [51, 60],
+                            "name": "Auto 4",
+                            "center": true
+                        },
+                        {
+                            "range": [61, 70],
+                            "name": "Auto 5",
+                            "center": true
+                        },
+                        {
+                            "range": [71, 80],
+                            "name": "Auto 6",
+                            "center": true
+                        },
+                        {
+                            "range": [81, 90],
+                            "name": "Auto 7",
+                            "center": true
+                        },
+                        {
+                            "range": [91, 100],
+                            "name": "Auto 8",
+                            "center": true
+                        },
+                        {
+                            "range": [101, 110],
+                            "name": "Auto 9",
+                            "center": true
+                        },
+                        {
+                            "range": [111, 120],
+                            "name": "Auto 10",
+                            "center": true
+                        },
+                        {
+                            "range": [121, 130],
+                            "name": "Custom 1",
+                            "center": true
+                        },
+                        {
+                            "range": [131, 140],
+                            "name": "Custom 2",
+                            "center": true
+                        },
+                        {
+                            "range": [141, 150],
+                            "name": "Custom 3",
+                            "center": true
+                        },
+                        {
+                            "range": [151, 160],
+                            "name": "Custom 4",
+                            "center": true
+                        },
+                        {
+                            "range": [161, 170],
+                            "name": "Custom 5",
+                            "center": true
+                        },
+                        {
+                            "range": [171, 180],
+                            "name": "Custom 6",
+                            "center": true
+                        },
+                        {
+                            "range": [181, 190],
+                            "name": "Custom 7",
+                            "center": true
+                        },
+                        {
+                            "range": [191, 200],
+                            "name": "Custom 8",
+                            "center": true
+                        },
+                        {
+                            "range": [201, 210],
+                            "name": "Custom 9",
+                            "center": true
+                        },
+                        {
+                            "range": [211, 220],
+                            "name": "Custom 10",
+                            "center": true
+                        },
+                        {
+                            "range": [221, 255],
+                            "name": "no Funktion",
+                            "center": true
+                        }
+                    ]
+                },
+                "Auto Speed": {
+                    "type": "Speed",
+                    "crossfade": true
+                },
+                "ID Address": {
+                    "type": "Beam"
+                }
+            },
+            "modes": [
+                {
+                    "name": "9-channel Mode",
+                    "shortName": "9ch",
+                    "channels": [
+                        "Dimmer",
+                        "Red",
+                        "Green",
+                        "Blue",
+                        "Color Macro",
+                        "Shutter/Strobe",
+                        "Auto",
+                        "Auto Speed",
+                        "ID Address"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Expolite",
+            "name": "TourLED 37 Pro Zoom Mode Ar1 d ",
+            "shortName": "TourLED37Zoom M Ar1d",
+            "comment": "LED",
+            "physical": {
+                "dimensions": [311, 250, 203],
+                "weight": 6.5,
+                "power": 150
+            },
+            "availableChannels": {
+                "Dimmer": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                }
+            },
+            "modes": [
+                {
+                    "name": "4-channel Mode",
+                    "shortName": "4ch",
+                    "channels": [
+                        "Dimmer",
+                        "Red",
+                        "Green",
+                        "Blue"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Expolite",
+            "name": "TourLED 37 Pro Zoom Mode Ar2 d",
+            "shortName": "TourLED37Zoom M Ar2d",
+            "comment": "LED",
+            "physical": {
+                "dimensions": [311, 250, 203],
+                "weight": 6.5,
+                "power": 150
+            },
+            "availableChannels": {
+                "Dimmer": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "White": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                }
+            },
+            "modes": [
+                {
+                    "name": "5-channel Mode",
+                    "shortName": "5ch",
+                    "channels": [
+                        "Dimmer",
+                        "Red",
+                        "Green",
+                        "Blue",
+                        "White"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Expolite",
+            "name": "TourLED 37 Pro Zoom Mode Ar2 s",
+            "shortName": "TourLED37Zoom M Ar2s",
+            "comment": "LED",
+            "physical": {
+                "dimensions": [311, 250, 203],
+                "weight": 6.5,
+                "power": 150
+            },
+            "availableChannels": {
+                "Dimmer": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "White": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Shutter/Strobe": {
+                    "type": "Shutter",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "1-20Hz"
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "6-channel Mode",
+                    "shortName": "6ch",
+                    "channels": [
+                        "Dimmer",
+                        "Red",
+                        "Green",
+                        "Blue",
+                        "White",
+                        null,
+                        "Shutter/Strobe"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Expolite",
+            "name": "TourLED 37 Pro Zoom Mode Arc 1",
+            "shortName": "TourLED37Zoom M Arc 1",
+            "comment": "LED",
+            "physical": {
+                "dimensions": [311, 250, 203],
+                "weight": 6.5,
+                "power": 150
+            },
+            "availableChannels": {
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                }
+            },
+            "modes": [
+                {
+                    "name": "3-channel Mode",
+                    "shortName": "3ch",
+                    "channels": [
+                        "Red",
+                        "Green",
+                        "Blue"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Expolite",
+            "name": "TourLED 37 Pro Zoom Mode Arc 2",
+            "shortName": "TourLED37Zoom M Arc2",
+            "comment": "LED",
+            "physical": {
+                "dimensions": [311, 250, 203],
+                "weight": 6.5,
+                "power": 150
+            },
+            "availableChannels": {
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "White": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                }
+            },
+            "modes": [
+                {
+                    "name": "4-channel Mode",
+                    "shortName": "4ch",
+                    "channels": [
+                        "Red",
+                        "Green",
+                        "Blue",
+                        "White"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Expolite",
+            "name": "TourLED 37 Pro Zoom Mode HSV",
+            "shortName": "TourLED37Zoom HSV",
+            "comment": "LED",
+            "physical": {
+                "dimensions": [311, 250, 203],
+                "weight": 6.5,
+                "power": 150
+            },
+            "availableChannels": {
+                "HUE": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Saturation": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Value": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                }
+            },
+            "modes": [
+                {
+                    "name": "3-channel Mode",
+                    "shortName": "3ch",
+                    "channels": [
+                        "HUE",
+                        "Saturation",
+                        "Value"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Expolite",
+            "name": "TourLED 37 Pro Zoom Mode Tour",
+            "shortName": "TourLED37Zoom M Tour",
+            "comment": "LED",
+            "physical": {
+                "dimensions": [311, 250, 203],
+                "weight": 6.5,
+                "power": 150
+            },
+            "availableChannels": {
+                "Dimmer": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "White": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Color Macro": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 5],
+                            "name": "No Macro"
+                        },
+                        {
+                            "range": [11, 30],
+                            "name": "R100 G up B 0",
+                            "center": true
+                        },
+                        {
+                            "range": [31, 50],
+                            "name": "R dow G 100 B 0",
+                            "center": true
+                        },
+                        {
+                            "range": [51, 70],
+                            "name": "R 0 G 100 B up",
+                            "center": true
+                        },
+                        {
+                            "range": [71, 90],
+                            "name": "R 0 G dow B 100",
+                            "center": true
+                        },
+                        {
+                            "range": [91, 110],
+                            "name": "R up g 0 b 100 ",
+                            "center": true
+                        },
+                        {
+                            "range": [111, 130],
+                            "name": "R 100 g 0 b dow",
+                            "center": true
+                        },
+                        {
+                            "range": [131, 150],
+                            "name": "R 100 G up B up",
+                            "center": true
+                        },
+                        {
+                            "range": [151, 170],
+                            "name": "R do G do B 100",
+                            "center": true
+                        },
+                        {
+                            "range": [171, 200],
+                            "name": "RGBW 100",
+                            "center": true
+                        },
+                        {
+                            "range": [201, 205],
+                            "name": "White 3200 K",
+                            "center": true
+                        },
+                        {
+                            "range": [206, 210],
+                            "name": "White 3400 K",
+                            "center": true
+                        },
+                        {
+                            "range": [211, 215],
+                            "name": "White 4200 K",
+                            "center": true
+                        },
+                        {
+                            "range": [216, 220],
+                            "name": "White 4900 K",
+                            "center": true
+                        },
+                        {
+                            "range": [221, 225],
+                            "name": "White 5600 K",
+                            "center": true
+                        },
+                        {
+                            "range": [226, 230],
+                            "name": "White 5900 K",
+                            "center": true
+                        },
+                        {
+                            "range": [231, 235],
+                            "name": "White 6500 K",
+                            "center": true
+                        },
+                        {
+                            "range": [236, 240],
+                            "name": "White 7200 K",
+                            "center": true
+                        },
+                        {
+                            "range": [241, 245],
+                            "name": "White 8000 K",
+                            "center": true
+                        },
+                        {
+                            "range": [246, 250],
+                            "name": "White 8500 K",
+                            "center": true
+                        },
+                        {
+                            "range": [251, 255],
+                            "name": "White 10000 K",
+                            "center": true
+                        }
+                    ]
+                },
+                "Shutter/Strobe": {
+                    "type": "Shutter",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 10],
+                            "name": "no Funktion",
+                            "center": true
+                        },
+                        {
+                            "range": [11, 255],
+                            "name": "1-20Hz"
+                        }
+                    ]
+                },
+                "Auto": {
+                    "type": "MultiColor",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 20],
+                            "name": "no Funktion",
+                            "center": true
+                        },
+                        {
+                            "range": [21, 30],
+                            "name": "Auto 1",
+                            "center": true
+                        },
+                        {
+                            "range": [31, 40],
+                            "name": "Auto 2",
+                            "center": true
+                        },
+                        {
+                            "range": [41, 50],
+                            "name": "Auto 3",
+                            "center": true
+                        },
+                        {
+                            "range": [51, 60],
+                            "name": "Auto 4",
+                            "center": true
+                        },
+                        {
+                            "range": [61, 70],
+                            "name": "Auto 5",
+                            "center": true
+                        },
+                        {
+                            "range": [71, 80],
+                            "name": "Auto 6",
+                            "center": true
+                        },
+                        {
+                            "range": [81, 90],
+                            "name": "Auto 7",
+                            "center": true
+                        },
+                        {
+                            "range": [91, 100],
+                            "name": "Auto 8",
+                            "center": true
+                        },
+                        {
+                            "range": [101, 110],
+                            "name": "Auto 9",
+                            "center": true
+                        },
+                        {
+                            "range": [111, 120],
+                            "name": "Auto 10",
+                            "center": true
+                        },
+                        {
+                            "range": [121, 130],
+                            "name": "Custom 1",
+                            "center": true
+                        },
+                        {
+                            "range": [131, 140],
+                            "name": "Custom 2",
+                            "center": true
+                        },
+                        {
+                            "range": [141, 150],
+                            "name": "Custom 3",
+                            "center": true
+                        },
+                        {
+                            "range": [151, 160],
+                            "name": "Custom 4",
+                            "center": true
+                        },
+                        {
+                            "range": [161, 170],
+                            "name": "Custom 5",
+                            "center": true
+                        },
+                        {
+                            "range": [171, 180],
+                            "name": "Custom 6",
+                            "center": true
+                        },
+                        {
+                            "range": [181, 190],
+                            "name": "Custom 7",
+                            "center": true
+                        },
+                        {
+                            "range": [191, 200],
+                            "name": "Custom 8",
+                            "center": true
+                        },
+                        {
+                            "range": [201, 210],
+                            "name": "Custom 9",
+                            "center": true
+                        },
+                        {
+                            "range": [211, 220],
+                            "name": "Custom 10",
+                            "center": true
+                        },
+                        {
+                            "range": [221, 255],
+                            "name": "no Funktion",
+                            "center": true
+                        }
+                    ]
+                },
+                "Auto Speed": {
+                    "type": "Speed",
+                    "crossfade": true
+                },
+                "Dimmer Speed": {
+                    "type": "Speed",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 9],
+                            "name": "Present Dimmer"
+                        },
+                        {
+                            "range": [10, 29],
+                            "name": "Linear Dimmer"
+                        },
+                        {
+                            "range": [30, 69],
+                            "name": "non lim Dim 1"
+                        },
+                        {
+                            "range": [70, 129],
+                            "name": "non lim Dim 2"
+                        },
+                        {
+                            "range": [130, 189],
+                            "name": "non lim Dim 3"
+                        },
+                        {
+                            "range": [190, 255],
+                            "name": "non lim Dim 4"
+                        }
+                    ]
+                },
+                "Zoom": {
+                    "type": "Beam",
+                    "defaultValue": 128,
+                    "highlightValue": 128
+                },
+                "Zoom reset": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 200],
+                            "name": "no Funktion",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [201, 220],
+                            "name": "Zoom reset",
+                            "center": true
+                        },
+                        {
+                            "range": [221, 255],
+                            "name": "no Funktion",
+                            "showInMenu": false
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "12-channel Mode",
+                    "shortName": "12ch",
+                    "channels": [
+                        "Dimmer",
+                        "Red",
+                        "Green",
+                        "Blue",
+                        "White",
+                        "Color Macro",
+                        "Shutter/Strobe",
+                        "Auto",
+                        "Auto Speed",
+                        "Dimmer Speed",
+                        "Zoom",
+                        "Zoom reset"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Expolite",
+            "name": "TourLED 42 Mode Arc 1",
+            "shortName": "TourLED42 M Arc1",
+            "comment": "LED",
+            "physical": {
+                "dimensions": [245, 205, 245],
+                "weight": 4.8,
+                "power": 70
+            },
+            "availableChannels": {
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                }
+            },
+            "modes": [
+                {
+                    "name": "3-channel Mode",
+                    "shortName": "3ch",
+                    "channels": [
+                        "Red",
+                        "Green",
+                        "Blue"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Expolite",
+            "name": "TourLED 42 Mode Arc 1d",
+            "shortName": "TourLED42 M Arc1d",
+            "comment": "LED",
+            "physical": {
+                "dimensions": [245, 205, 245],
+                "weight": 4.8,
+                "power": 70
+            },
+            "availableChannels": {
+                "Dimmer": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                }
+            },
+            "modes": [
+                {
+                    "name": "4-channel Mode",
+                    "shortName": "4ch",
+                    "channels": [
+                        "Dimmer",
+                        "Red",
+                        "Green",
+                        "Blue"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Expolite",
+            "name": "TourLED 42 Mode HSV",
+            "shortName": "TourLED42 M HSV",
+            "comment": "LED",
+            "physical": {
+                "dimensions": [245, 205, 245],
+                "weight": 4.8,
+                "power": 70
+            },
+            "availableChannels": {
+                "HUE": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Saturation": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Value": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                }
+            },
+            "modes": [
+                {
+                    "name": "3-channel Mode",
+                    "shortName": "3ch",
+                    "channels": [
+                        "HUE",
+                        "Saturation",
+                        "Value"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Expolite",
+            "name": "TourLED 42 Mode Tour",
+            "shortName": "TourLED42 M Tour",
+            "comment": "LED",
+            "physical": {
+                "dimensions": [245, 205, 245],
+                "weight": 4.8,
+                "power": 70
+            },
+            "availableChannels": {
+                "Dimmer": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Color Macro": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 5],
+                            "name": "No Macro"
+                        },
+                        {
+                            "range": [11, 30],
+                            "name": "R100 G up B 0",
+                            "center": true
+                        },
+                        {
+                            "range": [31, 50],
+                            "name": "R dow G 100 B 0",
+                            "center": true
+                        },
+                        {
+                            "range": [51, 70],
+                            "name": "R 0 G 100 B up",
+                            "center": true
+                        },
+                        {
+                            "range": [71, 90],
+                            "name": "R 0 G dow B 100",
+                            "center": true
+                        },
+                        {
+                            "range": [91, 110],
+                            "name": "R up g 0 b 100 ",
+                            "center": true
+                        },
+                        {
+                            "range": [111, 130],
+                            "name": "R 100 g 0 b dow",
+                            "center": true
+                        },
+                        {
+                            "range": [131, 150],
+                            "name": "R 100 G up B up",
+                            "center": true
+                        },
+                        {
+                            "range": [151, 170],
+                            "name": "R do G do B 100",
+                            "center": true
+                        },
+                        {
+                            "range": [171, 200],
+                            "name": "RGBW 100",
+                            "center": true
+                        },
+                        {
+                            "range": [201, 205],
+                            "name": "White 3200 K",
+                            "center": true
+                        },
+                        {
+                            "range": [206, 210],
+                            "name": "White 3400 K",
+                            "center": true
+                        },
+                        {
+                            "range": [211, 215],
+                            "name": "White 4200 K",
+                            "center": true
+                        },
+                        {
+                            "range": [216, 220],
+                            "name": "White 4900 K",
+                            "center": true
+                        },
+                        {
+                            "range": [221, 225],
+                            "name": "White 5600 K",
+                            "center": true
+                        },
+                        {
+                            "range": [226, 230],
+                            "name": "White 5900 K",
+                            "center": true
+                        },
+                        {
+                            "range": [231, 235],
+                            "name": "White 6500 K",
+                            "center": true
+                        },
+                        {
+                            "range": [236, 240],
+                            "name": "White 7200 K",
+                            "center": true
+                        },
+                        {
+                            "range": [241, 245],
+                            "name": "White 8000 K",
+                            "center": true
+                        },
+                        {
+                            "range": [246, 250],
+                            "name": "White 8500 K",
+                            "center": true
+                        },
+                        {
+                            "range": [251, 255],
+                            "name": "White 10000 K",
+                            "center": true
+                        }
+                    ]
+                },
+                "Shutter/Strobe": {
+                    "type": "Shutter",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 10],
+                            "name": "no Funktion",
+                            "center": true
+                        },
+                        {
+                            "range": [11, 255],
+                            "name": "1-20Hz"
+                        }
+                    ]
+                },
+                "Auto": {
+                    "type": "MultiColor",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 20],
+                            "name": "no Funktion",
+                            "center": true
+                        },
+                        {
+                            "range": [21, 30],
+                            "name": "Auto 1",
+                            "center": true
+                        },
+                        {
+                            "range": [31, 40],
+                            "name": "Auto 2",
+                            "center": true
+                        },
+                        {
+                            "range": [41, 50],
+                            "name": "Auto 3",
+                            "center": true
+                        },
+                        {
+                            "range": [51, 60],
+                            "name": "Auto 4",
+                            "center": true
+                        },
+                        {
+                            "range": [61, 70],
+                            "name": "Auto 5",
+                            "center": true
+                        },
+                        {
+                            "range": [71, 80],
+                            "name": "Auto 6",
+                            "center": true
+                        },
+                        {
+                            "range": [81, 90],
+                            "name": "Auto 7",
+                            "center": true
+                        },
+                        {
+                            "range": [91, 100],
+                            "name": "Auto 8",
+                            "center": true
+                        },
+                        {
+                            "range": [101, 110],
+                            "name": "Auto 9",
+                            "center": true
+                        },
+                        {
+                            "range": [111, 120],
+                            "name": "Auto 10",
+                            "center": true
+                        },
+                        {
+                            "range": [121, 130],
+                            "name": "Custom 1",
+                            "center": true
+                        },
+                        {
+                            "range": [131, 140],
+                            "name": "Custom 2",
+                            "center": true
+                        },
+                        {
+                            "range": [141, 150],
+                            "name": "Custom 3",
+                            "center": true
+                        },
+                        {
+                            "range": [151, 160],
+                            "name": "Custom 4",
+                            "center": true
+                        },
+                        {
+                            "range": [161, 170],
+                            "name": "Custom 5",
+                            "center": true
+                        },
+                        {
+                            "range": [171, 180],
+                            "name": "Custom 6",
+                            "center": true
+                        },
+                        {
+                            "range": [181, 190],
+                            "name": "Custom 7",
+                            "center": true
+                        },
+                        {
+                            "range": [191, 200],
+                            "name": "Custom 8",
+                            "center": true
+                        },
+                        {
+                            "range": [201, 210],
+                            "name": "Custom 9",
+                            "center": true
+                        },
+                        {
+                            "range": [211, 220],
+                            "name": "Custom 10",
+                            "center": true
+                        },
+                        {
+                            "range": [221, 255],
+                            "name": "no Funktion",
+                            "center": true
+                        }
+                    ]
+                },
+                "Auto Speed": {
+                    "type": "Speed",
+                    "crossfade": true
+                },
+                "Dimmer Speed": {
+                    "type": "Speed",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 9],
+                            "name": "Present Dimmer"
+                        },
+                        {
+                            "range": [10, 29],
+                            "name": "Linear Dimmer"
+                        },
+                        {
+                            "range": [30, 69],
+                            "name": "non lim Dim 1"
+                        },
+                        {
+                            "range": [70, 129],
+                            "name": "non lim Dim 2"
+                        },
+                        {
+                            "range": [130, 189],
+                            "name": "non lim Dim 3"
+                        },
+                        {
+                            "range": [190, 255],
+                            "name": "non lim Dim 4"
+                        }
+                    ]
+                },
+                "ID Address": {
+                    "type": "Beam"
+                },
+                "ID Address 2": {
+                    "type": "Beam"
+                }
+            },
+            "modes": [
+                {
+                    "name": "11-channel Mode",
+                    "shortName": "11ch",
+                    "channels": [
+                        "Dimmer",
+                        "Red",
+                        "Green",
+                        "Blue",
+                        "Color Macro",
+                        "Shutter/Strobe",
+                        "Auto",
+                        "Auto Speed",
+                        "Dimmer Speed",
+                        "ID Address",
+                        "ID Address 2"
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/fixtures/imports/ecue-MainLibrary/Future-Light.json
+++ b/fixtures/imports/ecue-MainLibrary/Future-Light.json
@@ -1,0 +1,8124 @@
+{
+    "manufacturers": {
+        "Future Light": {
+            "name": "Future Light",
+            "website": "www.future-light.com"
+        }
+    },
+    "fixtures": [
+        {
+            "manufacturer": "Future Light",
+            "name": "CC-200",
+            "shortName": "CC-200",
+            "comment": "Color Changer",
+            "physical": {
+                "dimensions": [200, 200, 350],
+                "weight": 12,
+                "power": 400
+            },
+            "availableChannels": {
+                "Colour": {
+                    "type": "MultiColor",
+                    "capabilities": [
+                        {
+                            "range": [0, 10],
+                            "name": "open"
+                        },
+                        {
+                            "range": [11, 20],
+                            "name": "green",
+                            "color": "#00ff00"
+                        },
+                        {
+                            "range": [21, 31],
+                            "name": "red",
+                            "color": "#ff0000"
+                        },
+                        {
+                            "range": [32, 41],
+                            "name": "cyan",
+                            "color": "#00ffff"
+                        },
+                        {
+                            "range": [42, 52],
+                            "name": "green2"
+                        },
+                        {
+                            "range": [53, 63],
+                            "name": "magenta",
+                            "color": "#ca1f7b"
+                        },
+                        {
+                            "range": [64, 73],
+                            "name": "lt blue"
+                        },
+                        {
+                            "range": [74, 84],
+                            "name": "yellow",
+                            "color": "#ffff00"
+                        },
+                        {
+                            "range": [85, 95],
+                            "name": "green3"
+                        },
+                        {
+                            "range": [96, 105],
+                            "name": "pink",
+                            "color": "#ffc0cb"
+                        },
+                        {
+                            "range": [106, 116],
+                            "name": "dk blue"
+                        },
+                        {
+                            "range": [117, 126],
+                            "name": "orange",
+                            "color": "#ff7f00"
+                        },
+                        {
+                            "range": [127, 127],
+                            "name": "open2",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [128, 255],
+                            "name": ">>"
+                        }
+                    ]
+                },
+                "Colour 2": {
+                    "type": "MultiColor",
+                    "capabilities": [
+                        {
+                            "range": [0, 20],
+                            "name": "open"
+                        },
+                        {
+                            "range": [21, 42],
+                            "name": "ctc1"
+                        },
+                        {
+                            "range": [43, 63],
+                            "name": "ctc2"
+                        },
+                        {
+                            "range": [64, 84],
+                            "name": "magenta",
+                            "color": "#ca1f7b"
+                        },
+                        {
+                            "range": [85, 106],
+                            "name": "cyan",
+                            "color": "#00ffff"
+                        },
+                        {
+                            "range": [107, 127],
+                            "name": "yellow",
+                            "color": "#ffff00"
+                        },
+                        {
+                            "range": [128, 148],
+                            "name": "uv"
+                        },
+                        {
+                            "range": [149, 170],
+                            "name": "gobo 1"
+                        },
+                        {
+                            "range": [171, 191],
+                            "name": "gobo 2"
+                        },
+                        {
+                            "range": [192, 212],
+                            "name": "circle 1"
+                        },
+                        {
+                            "range": [213, 234],
+                            "name": "circle 2"
+                        },
+                        {
+                            "range": [235, 255],
+                            "name": "circle 3"
+                        }
+                    ]
+                },
+                "Control": {
+                    "type": "Beam",
+                    "highlightValue": 145,
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "fan"
+                        },
+                        {
+                            "range": [134, 144],
+                            "name": "lamp on",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [145, 149],
+                            "name": "open"
+                        },
+                        {
+                            "range": [150, 219],
+                            "name": "str"
+                        },
+                        {
+                            "range": [225, 234],
+                            "name": "open",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [235, 254],
+                            "name": "lamp off",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "open",
+                            "showInMenu": false
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        },
+                        {
+                            "range": [254, 255],
+                            "name": "lamp_on"
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "4-channel Mode",
+                    "shortName": "4ch",
+                    "channels": [
+                        "Colour",
+                        "Colour 2",
+                        "Control",
+                        "Intensity"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Future Light",
+            "name": "DJ Scan 250",
+            "shortName": "DJSC250",
+            "comment": "Scanner",
+            "physical": {
+                "dimensions": [300, 150, 525],
+                "weight": 15,
+                "power": 500
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Color": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 18],
+                            "name": "white",
+                            "color": "#ffffff"
+                        },
+                        {
+                            "range": [18, 35],
+                            "name": "dark blue",
+                            "color": "#00008b"
+                        },
+                        {
+                            "range": [36, 53],
+                            "name": "pink",
+                            "color": "#ffc0cb"
+                        },
+                        {
+                            "range": [54, 71],
+                            "name": "light green",
+                            "color": "#90ee90"
+                        },
+                        {
+                            "range": [72, 89],
+                            "name": "orange",
+                            "color": "#ff7f00"
+                        },
+                        {
+                            "range": [90, 107],
+                            "name": "light blue",
+                            "color": "#add8e6"
+                        },
+                        {
+                            "range": [108, 126],
+                            "name": "yellow",
+                            "color": "#ffff00"
+                        },
+                        {
+                            "range": [127, 127],
+                            "name": "red",
+                            "color": "#ff0000"
+                        },
+                        {
+                            "range": [128, 191],
+                            "name": "rainbow cw"
+                        },
+                        {
+                            "range": [192, 255],
+                            "name": "rainbow ccw"
+                        }
+                    ]
+                },
+                "Gobo": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "open"
+                        },
+                        {
+                            "range": [16, 31],
+                            "name": "Gobo 1"
+                        },
+                        {
+                            "range": [32, 47],
+                            "name": "Gobo 2"
+                        },
+                        {
+                            "range": [48, 63],
+                            "name": "Gobo 3"
+                        },
+                        {
+                            "range": [64, 79],
+                            "name": "Gobo 4"
+                        },
+                        {
+                            "range": [80, 95],
+                            "name": "Gobo 5"
+                        },
+                        {
+                            "range": [96, 111],
+                            "name": "Gobo 6"
+                        },
+                        {
+                            "range": [112, 127],
+                            "name": "Gobo 7"
+                        },
+                        {
+                            "range": [128, 191],
+                            "name": "rainbow cw"
+                        },
+                        {
+                            "range": [192, 255],
+                            "name": "rainbow ccw"
+                        }
+                    ]
+                },
+                "Gobo Rot": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [16, 135],
+                            "name": "turn cw"
+                        },
+                        {
+                            "range": [136, 255],
+                            "name": "turn ccw"
+                        }
+                    ]
+                },
+                "Shutter": {
+                    "type": "Shutter",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 5],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [6, 128],
+                            "name": "Intensity"
+                        },
+                        {
+                            "range": [129, 131],
+                            "name": "reset"
+                        },
+                        {
+                            "range": [132, 139],
+                            "name": "open"
+                        },
+                        {
+                            "range": [140, 199],
+                            "name": "strobe"
+                        },
+                        {
+                            "range": [200, 249],
+                            "name": "random"
+                        },
+                        {
+                            "range": [250, 255],
+                            "name": "open"
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "6-channel Mode",
+                    "shortName": "6ch",
+                    "channels": [
+                        "Pan",
+                        "Tilt",
+                        "Color",
+                        "Gobo",
+                        "Gobo Rot",
+                        "Shutter"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Future Light",
+            "name": "Evo-5",
+            "shortName": "EVO5",
+            "comment": "cd",
+            "physical": {
+                "dimensions": [300, 290, 360],
+                "weight": 9.5,
+                "power": 200
+            },
+            "availableChannels": {
+                "Color": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "%"
+                        },
+                        {
+                            "range": [128, 187],
+                            "name": ">>"
+                        },
+                        {
+                            "range": [188, 193],
+                            "name": "stop",
+                            "center": true
+                        },
+                        {
+                            "range": [194, 255],
+                            "name": "<<"
+                        }
+                    ]
+                },
+                "Gobo": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 3],
+                            "name": "closed",
+                            "center": true
+                        },
+                        {
+                            "range": [4, 7],
+                            "name": "reset",
+                            "center": true
+                        },
+                        {
+                            "range": [8, 19],
+                            "name": "closed",
+                            "center": true
+                        },
+                        {
+                            "range": [20, 39],
+                            "name": "slot1",
+                            "center": true
+                        },
+                        {
+                            "range": [40, 59],
+                            "name": "slot2",
+                            "center": true
+                        },
+                        {
+                            "range": [60, 79],
+                            "name": "slot3",
+                            "center": true
+                        },
+                        {
+                            "range": [80, 99],
+                            "name": "slot4",
+                            "center": true
+                        },
+                        {
+                            "range": [100, 120],
+                            "name": "slot5",
+                            "center": true
+                        },
+                        {
+                            "range": [121, 147],
+                            "name": "slot1 sh."
+                        },
+                        {
+                            "range": [148, 174],
+                            "name": "slot2 sh."
+                        },
+                        {
+                            "range": [175, 201],
+                            "name": "slot3 sh."
+                        },
+                        {
+                            "range": [202, 228],
+                            "name": "slot4 sh."
+                        },
+                        {
+                            "range": [229, 255],
+                            "name": "slot5 sh."
+                        }
+                    ]
+                },
+                "Gobo rot.": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 7],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [8, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Prisma": {
+                    "type": "Prism",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 7],
+                            "name": "open",
+                            "center": true
+                        },
+                        {
+                            "range": [8, 127],
+                            "name": ">>"
+                        },
+                        {
+                            "range": [128, 135],
+                            "name": "stop",
+                            "center": true
+                        },
+                        {
+                            "range": [136, 255],
+                            "name": "<<"
+                        }
+                    ]
+                },
+                "Program": {
+                    "type": "Effect",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 23],
+                            "name": "normal",
+                            "center": true
+                        },
+                        {
+                            "range": [24, 47],
+                            "name": "program1",
+                            "center": true
+                        },
+                        {
+                            "range": [48, 71],
+                            "name": "program2",
+                            "center": true
+                        },
+                        {
+                            "range": [72, 95],
+                            "name": "program3",
+                            "center": true
+                        },
+                        {
+                            "range": [96, 119],
+                            "name": "program4",
+                            "center": true
+                        },
+                        {
+                            "range": [120, 143],
+                            "name": "program5",
+                            "center": true
+                        },
+                        {
+                            "range": [144, 167],
+                            "name": "program6",
+                            "center": true
+                        },
+                        {
+                            "range": [168, 191],
+                            "name": "program7",
+                            "center": true
+                        },
+                        {
+                            "range": [192, 215],
+                            "name": "program8",
+                            "center": true
+                        },
+                        {
+                            "range": [216, 239],
+                            "name": "program9",
+                            "center": true
+                        },
+                        {
+                            "range": [240, 255],
+                            "name": "program10",
+                            "center": true
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "5-channel Mode",
+                    "shortName": "5ch",
+                    "channels": [
+                        "Color",
+                        "Gobo",
+                        "Gobo rot.",
+                        "Prisma",
+                        "Program"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Future Light",
+            "name": "Evo-7",
+            "shortName": "EVO7",
+            "comment": "cd",
+            "physical": {
+                "dimensions": [300, 290, 360],
+                "weight": 10,
+                "power": 375
+            },
+            "availableChannels": {
+                "Color": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "%"
+                        },
+                        {
+                            "range": [128, 187],
+                            "name": ">>"
+                        },
+                        {
+                            "range": [188, 193],
+                            "name": "stop",
+                            "center": true
+                        },
+                        {
+                            "range": [194, 255],
+                            "name": "<<"
+                        }
+                    ]
+                },
+                "Prisma": {
+                    "type": "Prism",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 7],
+                            "name": "open",
+                            "center": true
+                        },
+                        {
+                            "range": [8, 127],
+                            "name": ">>"
+                        },
+                        {
+                            "range": [128, 135],
+                            "name": "stop",
+                            "center": true
+                        },
+                        {
+                            "range": [136, 255],
+                            "name": "<<"
+                        }
+                    ]
+                },
+                "Shutter": {
+                    "type": "Shutter",
+                    "highlightValue": 100,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 3],
+                            "name": "closed",
+                            "center": true
+                        },
+                        {
+                            "range": [4, 7],
+                            "name": "reset",
+                            "center": true
+                        },
+                        {
+                            "range": [8, 31],
+                            "name": "closed",
+                            "center": true
+                        },
+                        {
+                            "range": [32, 63],
+                            "name": "%"
+                        },
+                        {
+                            "range": [64, 95],
+                            "name": "strobe"
+                        },
+                        {
+                            "range": [96, 127],
+                            "name": "open",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 159],
+                            "name": "puls",
+                            "center": true
+                        },
+                        {
+                            "range": [160, 191],
+                            "name": "open",
+                            "center": true
+                        },
+                        {
+                            "range": [192, 223],
+                            "name": "random strob"
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "open",
+                            "center": true
+                        }
+                    ]
+                },
+                "Program": {
+                    "type": "Effect",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 23],
+                            "name": "normal",
+                            "center": true
+                        },
+                        {
+                            "range": [24, 47],
+                            "name": "program1",
+                            "center": true
+                        },
+                        {
+                            "range": [48, 71],
+                            "name": "program2",
+                            "center": true
+                        },
+                        {
+                            "range": [72, 95],
+                            "name": "program3",
+                            "center": true
+                        },
+                        {
+                            "range": [96, 119],
+                            "name": "program4",
+                            "center": true
+                        },
+                        {
+                            "range": [120, 143],
+                            "name": "program5",
+                            "center": true
+                        },
+                        {
+                            "range": [144, 167],
+                            "name": "program6",
+                            "center": true
+                        },
+                        {
+                            "range": [168, 191],
+                            "name": "program7",
+                            "center": true
+                        },
+                        {
+                            "range": [192, 215],
+                            "name": "program8",
+                            "center": true
+                        },
+                        {
+                            "range": [216, 239],
+                            "name": "program9",
+                            "center": true
+                        },
+                        {
+                            "range": [240, 255],
+                            "name": "program10",
+                            "center": true
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "4-channel Mode",
+                    "shortName": "4ch",
+                    "channels": [
+                        "Color",
+                        "Prisma",
+                        "Shutter",
+                        "Program"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Future Light",
+            "name": "Eye 18",
+            "shortName": "Eye18",
+            "comment": "cd",
+            "physical": {
+                "dimensions": [300, 300, 400],
+                "weight": 8.5,
+                "power": 80
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Speed": {
+                    "type": "Speed",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 225],
+                            "name": "fade"
+                        },
+                        {
+                            "range": [226, 235],
+                            "name": "MIB"
+                        },
+                        {
+                            "range": [236, 255],
+                            "name": "idle"
+                        }
+                    ]
+                },
+                "Effect": {
+                    "type": "Effect",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 7],
+                            "name": "idle"
+                        },
+                        {
+                            "range": [8, 255],
+                            "name": "rainbow"
+                        }
+                    ]
+                },
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Strobe": {
+                    "type": "Strobe",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 63],
+                            "name": "open"
+                        },
+                        {
+                            "range": [64, 95],
+                            "name": "strobe"
+                        },
+                        {
+                            "range": [96, 127],
+                            "name": "open"
+                        },
+                        {
+                            "range": [128, 159],
+                            "name": "pulse"
+                        },
+                        {
+                            "range": [160, 191],
+                            "name": "open"
+                        },
+                        {
+                            "range": [192, 223],
+                            "name": "random"
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "open"
+                        }
+                    ]
+                },
+                "Reset": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 95],
+                            "name": "idle"
+                        },
+                        {
+                            "range": [96, 111],
+                            "name": "macro1"
+                        },
+                        {
+                            "range": [112, 127],
+                            "name": "macro2"
+                        },
+                        {
+                            "range": [128, 143],
+                            "name": "macro3"
+                        },
+                        {
+                            "range": [144, 159],
+                            "name": "macro4"
+                        },
+                        {
+                            "range": [160, 175],
+                            "name": "macro5"
+                        },
+                        {
+                            "range": [176, 191],
+                            "name": "macro6"
+                        },
+                        {
+                            "range": [192, 207],
+                            "name": "macro7"
+                        },
+                        {
+                            "range": [208, 223],
+                            "name": "macro8"
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "idle"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "12-channel Mode",
+                    "shortName": "12ch",
+                    "channels": [
+                        "Pan",
+                        "Tilt",
+                        "Speed",
+                        "Effect",
+                        "Red",
+                        "Green",
+                        "Blue",
+                        "Strobe",
+                        "Reset",
+                        "Pan fine",
+                        "Tilt fine",
+                        "Intensity"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Future Light",
+            "name": "Eye 36",
+            "shortName": "Eye36",
+            "comment": "cd",
+            "physical": {
+                "dimensions": [350, 350, 400],
+                "weight": 10.3,
+                "power": 160
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Speed": {
+                    "type": "Speed",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 225],
+                            "name": "fade"
+                        },
+                        {
+                            "range": [226, 235],
+                            "name": "MIB"
+                        },
+                        {
+                            "range": [236, 255],
+                            "name": "idle"
+                        }
+                    ]
+                },
+                "Effect": {
+                    "type": "Effect",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 7],
+                            "name": "idle"
+                        },
+                        {
+                            "range": [8, 255],
+                            "name": "rainbow"
+                        }
+                    ]
+                },
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Strobe": {
+                    "type": "Strobe",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 63],
+                            "name": "open"
+                        },
+                        {
+                            "range": [64, 95],
+                            "name": "strobe"
+                        },
+                        {
+                            "range": [96, 127],
+                            "name": "open"
+                        },
+                        {
+                            "range": [128, 159],
+                            "name": "pulse"
+                        },
+                        {
+                            "range": [160, 191],
+                            "name": "open"
+                        },
+                        {
+                            "range": [192, 223],
+                            "name": "random"
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "open"
+                        }
+                    ]
+                },
+                "Reset": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 95],
+                            "name": "idle"
+                        },
+                        {
+                            "range": [96, 111],
+                            "name": "macro1"
+                        },
+                        {
+                            "range": [112, 127],
+                            "name": "macro2"
+                        },
+                        {
+                            "range": [128, 143],
+                            "name": "macro3"
+                        },
+                        {
+                            "range": [144, 159],
+                            "name": "macro4"
+                        },
+                        {
+                            "range": [160, 175],
+                            "name": "macro5"
+                        },
+                        {
+                            "range": [176, 191],
+                            "name": "macro6"
+                        },
+                        {
+                            "range": [192, 207],
+                            "name": "macro7"
+                        },
+                        {
+                            "range": [208, 223],
+                            "name": "macro8"
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "idle"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "12-channel Mode",
+                    "shortName": "12ch",
+                    "channels": [
+                        "Pan",
+                        "Tilt",
+                        "Speed",
+                        "Effect",
+                        "Red",
+                        "Green",
+                        "Blue",
+                        "Strobe",
+                        "Reset",
+                        "Pan fine",
+                        "Tilt fine",
+                        "Intensity"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Future Light",
+            "name": "H-150",
+            "shortName": "H-150",
+            "physical": {
+                "dimensions": [250, 250, 600],
+                "weight": 10,
+                "power": 150
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Control": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 254],
+                            "name": "100%",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "80%",
+                            "showInMenu": false
+                        }
+                    ]
+                },
+                "Gobo": {
+                    "type": "Gobo",
+                    "highlightValue": 11,
+                    "capabilities": [
+                        {
+                            "range": [0, 10],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [11, 18],
+                            "name": "gobo1"
+                        },
+                        {
+                            "range": [19, 26],
+                            "name": "gobo2"
+                        },
+                        {
+                            "range": [27, 34],
+                            "name": "closed",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [35, 42],
+                            "name": "gobo3"
+                        },
+                        {
+                            "range": [43, 50],
+                            "name": "gobo4"
+                        },
+                        {
+                            "range": [51, 58],
+                            "name": "closed",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [59, 66],
+                            "name": "gobo5"
+                        },
+                        {
+                            "range": [67, 74],
+                            "name": "gobo6"
+                        },
+                        {
+                            "range": [75, 82],
+                            "name": "closed",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [83, 90],
+                            "name": "gobo7"
+                        },
+                        {
+                            "range": [91, 98],
+                            "name": "gobo8"
+                        },
+                        {
+                            "range": [99, 106],
+                            "name": "closed",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [107, 114],
+                            "name": "gobo9"
+                        },
+                        {
+                            "range": [115, 122],
+                            "name": "gobo10"
+                        },
+                        {
+                            "range": [123, 130],
+                            "name": "closed",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [131, 138],
+                            "name": "gobo11"
+                        },
+                        {
+                            "range": [139, 146],
+                            "name": "gobo12"
+                        },
+                        {
+                            "range": [147, 154],
+                            "name": "str gob1",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [155, 162],
+                            "name": "str gob2",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [163, 170],
+                            "name": "str gob3",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [171, 178],
+                            "name": "str gob4",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [179, 186],
+                            "name": "str gob5",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [187, 194],
+                            "name": "str gob6",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [195, 202],
+                            "name": "str gob7",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [203, 210],
+                            "name": "str gob8",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [211, 218],
+                            "name": "str gob9",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [219, 226],
+                            "name": "strgob10",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [227, 234],
+                            "name": "strgob11",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [235, 255],
+                            "name": ">>"
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "4-channel Mode",
+                    "shortName": "4ch",
+                    "channels": [
+                        "Pan",
+                        "Tilt",
+                        "Control",
+                        "Gobo"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Future Light",
+            "name": "MH-460 Mode 1",
+            "shortName": "MH-460m1",
+            "physical": {
+                "dimensions": [400, 400, 450],
+                "weight": 11,
+                "power": 300
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Speed": {
+                    "type": "Speed",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 249],
+                            "name": "speed"
+                        },
+                        {
+                            "range": [250, 252],
+                            "name": "black_change",
+                            "center": true
+                        },
+                        {
+                            "range": [253, 255],
+                            "name": "black_move",
+                            "center": true
+                        }
+                    ]
+                },
+                "Color": {
+                    "type": "MultiColor",
+                    "capabilities": [
+                        {
+                            "range": [0, 9],
+                            "name": "open",
+                            "center": true
+                        },
+                        {
+                            "range": [10, 20],
+                            "name": "turquoise",
+                            "color": "#40e0d0",
+                            "center": true
+                        },
+                        {
+                            "range": [21, 31],
+                            "name": "red",
+                            "color": "#ff0000",
+                            "center": true
+                        },
+                        {
+                            "range": [32, 42],
+                            "name": "cyan",
+                            "color": "#00ffff",
+                            "center": true
+                        },
+                        {
+                            "range": [42, 52],
+                            "name": "lightgreen",
+                            "color": "#90ee90",
+                            "center": true
+                        },
+                        {
+                            "range": [53, 63],
+                            "name": "magenta",
+                            "color": "#ca1f7b",
+                            "center": true
+                        },
+                        {
+                            "range": [64, 73],
+                            "name": "lightblue",
+                            "color": "#add8e6",
+                            "center": true
+                        },
+                        {
+                            "range": [74, 84],
+                            "name": "yellow",
+                            "color": "#ffff00",
+                            "center": true
+                        },
+                        {
+                            "range": [85, 95],
+                            "name": "green",
+                            "color": "#00ff00",
+                            "center": true
+                        },
+                        {
+                            "range": [96, 105],
+                            "name": "pink",
+                            "color": "#ffc0cb",
+                            "center": true
+                        },
+                        {
+                            "range": [105, 116],
+                            "name": "blue",
+                            "color": "#0000ff",
+                            "center": true
+                        },
+                        {
+                            "range": [117, 127],
+                            "name": "orange",
+                            "color": "#ff7f00",
+                            "center": true
+                        },
+                        {
+                            "range": [168, 175],
+                            "name": "macro2"
+                        },
+                        {
+                            "range": [191, 192],
+                            "name": "no_rot"
+                        },
+                        {
+                            "range": [193, 255],
+                            "name": "rainbow_bw"
+                        }
+                    ]
+                },
+                "Gobo": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "open"
+                        },
+                        {
+                            "range": [16, 31],
+                            "name": "gobo1",
+                            "center": true
+                        },
+                        {
+                            "range": [32, 47],
+                            "name": "gobo2",
+                            "center": true
+                        },
+                        {
+                            "range": [46, 63],
+                            "name": "gobo3",
+                            "center": true
+                        },
+                        {
+                            "range": [64, 79],
+                            "name": "gobo4",
+                            "center": true
+                        },
+                        {
+                            "range": [80, 95],
+                            "name": "gobo5",
+                            "center": true
+                        },
+                        {
+                            "range": [96, 111],
+                            "name": "gobo6",
+                            "center": true
+                        },
+                        {
+                            "range": [112, 131],
+                            "name": "gobo1_sh",
+                            "center": true
+                        },
+                        {
+                            "range": [132, 151],
+                            "name": "gobo2_sh",
+                            "center": true
+                        },
+                        {
+                            "range": [152, 171],
+                            "name": "gobo3_sh",
+                            "center": true
+                        },
+                        {
+                            "range": [172, 191],
+                            "name": "gobo4_sh",
+                            "center": true
+                        },
+                        {
+                            "range": [192, 211],
+                            "name": "gobo5_sh",
+                            "center": true
+                        },
+                        {
+                            "range": [212, 231],
+                            "name": "gobo6_sh",
+                            "center": true
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "gobo_rot"
+                        }
+                    ]
+                },
+                "Index": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "index"
+                        },
+                        {
+                            "range": [128, 191],
+                            "name": "goborot_fw"
+                        },
+                        {
+                            "range": [192, 192],
+                            "name": "no_rot"
+                        },
+                        {
+                            "range": [193, 255],
+                            "name": "goborot_bw"
+                        }
+                    ]
+                },
+                "Shutter": {
+                    "type": "Shutter",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "capabilities": [
+                        {
+                            "range": [0, 63],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [64, 95],
+                            "name": "open"
+                        },
+                        {
+                            "range": [96, 127],
+                            "name": "strobe"
+                        },
+                        {
+                            "range": [128, 139],
+                            "name": "reset",
+                            "center": true
+                        },
+                        {
+                            "range": [140, 159],
+                            "name": "closed",
+                            "center": true
+                        },
+                        {
+                            "range": [160, 191],
+                            "name": "pulse"
+                        },
+                        {
+                            "range": [192, 223],
+                            "name": "strobe_rnd"
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "open"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "9-channel Mode",
+                    "shortName": "9ch",
+                    "channels": [
+                        "Pan",
+                        "Tilt",
+                        "Pan fine",
+                        "Tilt fine",
+                        "Speed",
+                        "Color",
+                        "Gobo",
+                        "Index",
+                        "Shutter"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Future Light",
+            "name": "MH-460 Mode 2",
+            "shortName": "MH-460m2",
+            "physical": {
+                "dimensions": [400, 400, 450],
+                "weight": 11,
+                "power": 300
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Speed": {
+                    "type": "Speed",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 249],
+                            "name": "speed"
+                        },
+                        {
+                            "range": [250, 252],
+                            "name": "black_change",
+                            "center": true
+                        },
+                        {
+                            "range": [253, 255],
+                            "name": "black_move",
+                            "center": true
+                        }
+                    ]
+                },
+                "Color": {
+                    "type": "MultiColor",
+                    "capabilities": [
+                        {
+                            "range": [0, 9],
+                            "name": "open",
+                            "center": true
+                        },
+                        {
+                            "range": [10, 20],
+                            "name": "turquoise",
+                            "color": "#40e0d0",
+                            "center": true
+                        },
+                        {
+                            "range": [21, 31],
+                            "name": "red",
+                            "color": "#ff0000",
+                            "center": true
+                        },
+                        {
+                            "range": [32, 42],
+                            "name": "cyan",
+                            "color": "#00ffff",
+                            "center": true
+                        },
+                        {
+                            "range": [42, 52],
+                            "name": "lightgreen",
+                            "color": "#90ee90",
+                            "center": true
+                        },
+                        {
+                            "range": [53, 63],
+                            "name": "magenta",
+                            "color": "#ca1f7b",
+                            "center": true
+                        },
+                        {
+                            "range": [64, 73],
+                            "name": "lightblue",
+                            "color": "#add8e6",
+                            "center": true
+                        },
+                        {
+                            "range": [74, 84],
+                            "name": "yellow",
+                            "color": "#ffff00",
+                            "center": true
+                        },
+                        {
+                            "range": [85, 95],
+                            "name": "green",
+                            "color": "#00ff00",
+                            "center": true
+                        },
+                        {
+                            "range": [96, 105],
+                            "name": "pink",
+                            "color": "#ffc0cb",
+                            "center": true
+                        },
+                        {
+                            "range": [105, 116],
+                            "name": "blue",
+                            "color": "#0000ff",
+                            "center": true
+                        },
+                        {
+                            "range": [117, 127],
+                            "name": "orange",
+                            "color": "#ff7f00",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 190],
+                            "name": "rainbow_fw"
+                        },
+                        {
+                            "range": [191, 192],
+                            "name": "no_rot"
+                        },
+                        {
+                            "range": [193, 255],
+                            "name": "rainbow_bw"
+                        }
+                    ]
+                },
+                "Gobo": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "open"
+                        },
+                        {
+                            "range": [16, 31],
+                            "name": "gobo1",
+                            "center": true
+                        },
+                        {
+                            "range": [32, 47],
+                            "name": "gobo2",
+                            "center": true
+                        },
+                        {
+                            "range": [46, 63],
+                            "name": "gobo3",
+                            "center": true
+                        },
+                        {
+                            "range": [64, 79],
+                            "name": "gobo4",
+                            "center": true
+                        },
+                        {
+                            "range": [80, 95],
+                            "name": "gobo5",
+                            "center": true
+                        },
+                        {
+                            "range": [96, 111],
+                            "name": "gobo6",
+                            "center": true
+                        },
+                        {
+                            "range": [112, 131],
+                            "name": "gobo1_sh",
+                            "center": true
+                        },
+                        {
+                            "range": [132, 151],
+                            "name": "gobo2_sh",
+                            "center": true
+                        },
+                        {
+                            "range": [152, 171],
+                            "name": "gobo3_sh",
+                            "center": true
+                        },
+                        {
+                            "range": [172, 191],
+                            "name": "gobo4_sh",
+                            "center": true
+                        },
+                        {
+                            "range": [192, 211],
+                            "name": "gobo5_sh",
+                            "center": true
+                        },
+                        {
+                            "range": [212, 231],
+                            "name": "gobo6_sh",
+                            "center": true
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "gobo_rot"
+                        }
+                    ]
+                },
+                "Index": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "index"
+                        },
+                        {
+                            "range": [128, 191],
+                            "name": "goborot_fw"
+                        },
+                        {
+                            "range": [192, 192],
+                            "name": "no_rot"
+                        },
+                        {
+                            "range": [193, 255],
+                            "name": "goborot_bw"
+                        }
+                    ]
+                },
+                "Shutter": {
+                    "type": "Shutter",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "capabilities": [
+                        {
+                            "range": [0, 63],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [64, 95],
+                            "name": "open"
+                        },
+                        {
+                            "range": [96, 127],
+                            "name": "strobe"
+                        },
+                        {
+                            "range": [128, 139],
+                            "name": "reset",
+                            "center": true
+                        },
+                        {
+                            "range": [140, 159],
+                            "name": "closed",
+                            "center": true
+                        },
+                        {
+                            "range": [160, 191],
+                            "name": "pulse"
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "open"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "9-channel Mode",
+                    "shortName": "9ch",
+                    "channels": [
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "Speed",
+                        "Color",
+                        "Gobo",
+                        "Index",
+                        "Shutter"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Future Light",
+            "name": "MH-640",
+            "shortName": "MH-640",
+            "physical": {
+                "dimensions": [450, 450, 550],
+                "weight": 16,
+                "power": 500
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Speed": {
+                    "type": "Speed",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 249],
+                            "name": "speed"
+                        },
+                        {
+                            "range": [250, 252],
+                            "name": "black_change",
+                            "center": true
+                        },
+                        {
+                            "range": [253, 255],
+                            "name": "black_move",
+                            "center": true
+                        }
+                    ]
+                },
+                "Lamp": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "fan_speed"
+                        },
+                        {
+                            "range": [128, 139],
+                            "name": "lamp_on",
+                            "center": true
+                        },
+                        {
+                            "range": [140, 239],
+                            "name": "nofunction"
+                        },
+                        {
+                            "range": [230, 239],
+                            "name": "lamp_off",
+                            "center": true
+                        },
+                        {
+                            "range": [240, 255],
+                            "name": "nofunction",
+                            "center": true
+                        }
+                    ]
+                },
+                "Color": {
+                    "type": "MultiColor",
+                    "capabilities": [
+                        {
+                            "range": [0, 17],
+                            "name": "open"
+                        },
+                        {
+                            "range": [18, 35],
+                            "name": "red",
+                            "color": "#ff0000",
+                            "center": true
+                        },
+                        {
+                            "range": [36, 53],
+                            "name": "blue",
+                            "color": "#0000ff",
+                            "center": true
+                        },
+                        {
+                            "range": [54, 72],
+                            "name": "green",
+                            "color": "#00ff00",
+                            "center": true
+                        },
+                        {
+                            "range": [73, 90],
+                            "name": "3200k",
+                            "center": true
+                        },
+                        {
+                            "range": [91, 108],
+                            "name": "5600k",
+                            "center": true
+                        },
+                        {
+                            "range": [109, 127],
+                            "name": "UV",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 190],
+                            "name": "rainbow_fw"
+                        },
+                        {
+                            "range": [191, 192],
+                            "name": "no_rot"
+                        },
+                        {
+                            "range": [193, 255],
+                            "name": "rainbow_bw"
+                        }
+                    ]
+                },
+                "Cyan": {
+                    "type": "SingleColor",
+                    "color": "Cyan",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Magenta": {
+                    "type": "SingleColor",
+                    "color": "Magenta",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Yellow": {
+                    "type": "SingleColor",
+                    "color": "Yellow",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Speed-3mity": {
+                    "name": "Speed",
+                    "type": "Speed",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Macro": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 7],
+                            "name": "open"
+                        },
+                        {
+                            "range": [8, 15],
+                            "name": "macro1",
+                            "center": true
+                        },
+                        {
+                            "range": [16, 23],
+                            "name": "macro2",
+                            "center": true
+                        },
+                        {
+                            "range": [24, 31],
+                            "name": "macro3",
+                            "center": true
+                        },
+                        {
+                            "range": [32, 39],
+                            "name": "macro4",
+                            "center": true
+                        },
+                        {
+                            "range": [40, 47],
+                            "name": "macro5",
+                            "center": true
+                        },
+                        {
+                            "range": [48, 55],
+                            "name": "macro6",
+                            "center": true
+                        },
+                        {
+                            "range": [56, 63],
+                            "name": "macro7",
+                            "center": true
+                        },
+                        {
+                            "range": [64, 71],
+                            "name": "macro8",
+                            "center": true
+                        },
+                        {
+                            "range": [72, 79],
+                            "name": "macro9",
+                            "center": true
+                        },
+                        {
+                            "range": [80, 87],
+                            "name": "macro10",
+                            "center": true
+                        },
+                        {
+                            "range": [88, 95],
+                            "name": "macro11",
+                            "center": true
+                        },
+                        {
+                            "range": [96, 103],
+                            "name": "macro12",
+                            "center": true
+                        },
+                        {
+                            "range": [104, 111],
+                            "name": "macro13",
+                            "center": true
+                        },
+                        {
+                            "range": [112, 119],
+                            "name": "macro14",
+                            "center": true
+                        },
+                        {
+                            "range": [120, 127],
+                            "name": "macro15",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 135],
+                            "name": "macro16",
+                            "center": true
+                        },
+                        {
+                            "range": [136, 143],
+                            "name": "macro17",
+                            "center": true
+                        },
+                        {
+                            "range": [144, 151],
+                            "name": "macro18",
+                            "center": true
+                        },
+                        {
+                            "range": [152, 159],
+                            "name": "macro19",
+                            "center": true
+                        },
+                        {
+                            "range": [160, 167],
+                            "name": "macro20",
+                            "center": true
+                        },
+                        {
+                            "range": [168, 175],
+                            "name": "macro21",
+                            "center": true
+                        },
+                        {
+                            "range": [176, 183],
+                            "name": "macro22",
+                            "center": true
+                        },
+                        {
+                            "range": [184, 191],
+                            "name": "macro23",
+                            "center": true
+                        },
+                        {
+                            "range": [192, 199],
+                            "name": "macro24",
+                            "center": true
+                        },
+                        {
+                            "range": [200, 207],
+                            "name": "macro25",
+                            "center": true
+                        },
+                        {
+                            "range": [208, 215],
+                            "name": "macro26",
+                            "center": true
+                        },
+                        {
+                            "range": [216, 223],
+                            "name": "macro27",
+                            "center": true
+                        },
+                        {
+                            "range": [224, 231],
+                            "name": "macro28",
+                            "center": true
+                        },
+                        {
+                            "range": [232, 239],
+                            "name": "macro29",
+                            "center": true
+                        },
+                        {
+                            "range": [240, 247],
+                            "name": "macro30",
+                            "center": true
+                        },
+                        {
+                            "range": [248, 255],
+                            "name": "macro31",
+                            "center": true
+                        }
+                    ]
+                },
+                "Effect": {
+                    "type": "Effect",
+                    "capabilities": [
+                        {
+                            "range": [0, 70],
+                            "name": "circle"
+                        },
+                        {
+                            "range": [71, 230],
+                            "name": "shaper"
+                        },
+                        {
+                            "range": [231, 255],
+                            "name": "frost",
+                            "color": "#edf5dd"
+                        }
+                    ]
+                },
+                "Shutter": {
+                    "type": "Shutter",
+                    "defaultValue": 45,
+                    "highlightValue": 45,
+                    "capabilities": [
+                        {
+                            "range": [0, 31],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [32, 63],
+                            "name": "open",
+                            "center": true
+                        },
+                        {
+                            "range": [64, 95],
+                            "name": "strobe"
+                        },
+                        {
+                            "range": [96, 127],
+                            "name": "open"
+                        },
+                        {
+                            "range": [128, 159],
+                            "name": "pulse"
+                        },
+                        {
+                            "range": [160, 191],
+                            "name": "open",
+                            "center": true
+                        },
+                        {
+                            "range": [192, 223],
+                            "name": "strobe_rnd"
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "open",
+                            "center": true
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "16-channel Mode",
+                    "shortName": "16ch",
+                    "channels": [
+                        "Pan",
+                        "Tilt",
+                        "Pan fine",
+                        "Tilt fine",
+                        "Speed",
+                        "Lamp",
+                        "Color",
+                        "Cyan",
+                        "Magenta",
+                        "Yellow",
+                        "Speed-3mity",
+                        "Macro",
+                        "Effect",
+                        null,
+                        "Shutter",
+                        "Intensity"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Future Light",
+            "name": "MH-660",
+            "shortName": "MH-660",
+            "physical": {
+                "dimensions": [450, 450, 550],
+                "weight": 16,
+                "power": 500
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Speed": {
+                    "type": "Speed",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 249],
+                            "name": "speed"
+                        },
+                        {
+                            "range": [250, 252],
+                            "name": "black_change",
+                            "center": true
+                        },
+                        {
+                            "range": [253, 255],
+                            "name": "black_move",
+                            "center": true
+                        }
+                    ]
+                },
+                "Lamp": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "fan_speed"
+                        },
+                        {
+                            "range": [128, 139],
+                            "name": "lamp_on",
+                            "center": true
+                        },
+                        {
+                            "range": [140, 239],
+                            "name": "nofunction"
+                        },
+                        {
+                            "range": [230, 239],
+                            "name": "lamp_off",
+                            "center": true
+                        },
+                        {
+                            "range": [240, 255],
+                            "name": "nofunction",
+                            "center": true
+                        }
+                    ]
+                },
+                "Color": {
+                    "type": "MultiColor",
+                    "capabilities": [
+                        {
+                            "range": [0, 9],
+                            "name": "open",
+                            "center": true
+                        },
+                        {
+                            "range": [10, 20],
+                            "name": "turquoise",
+                            "color": "#40e0d0",
+                            "center": true
+                        },
+                        {
+                            "range": [21, 31],
+                            "name": "red",
+                            "color": "#ff0000",
+                            "center": true
+                        },
+                        {
+                            "range": [32, 42],
+                            "name": "cyan",
+                            "color": "#00ffff",
+                            "center": true
+                        },
+                        {
+                            "range": [42, 52],
+                            "name": "lightgreen",
+                            "color": "#90ee90",
+                            "center": true
+                        },
+                        {
+                            "range": [53, 63],
+                            "name": "magenta",
+                            "color": "#ca1f7b",
+                            "center": true
+                        },
+                        {
+                            "range": [64, 73],
+                            "name": "lightblue",
+                            "color": "#add8e6",
+                            "center": true
+                        },
+                        {
+                            "range": [74, 84],
+                            "name": "yellow",
+                            "color": "#ffff00",
+                            "center": true
+                        },
+                        {
+                            "range": [85, 95],
+                            "name": "green",
+                            "color": "#00ff00",
+                            "center": true
+                        },
+                        {
+                            "range": [96, 105],
+                            "name": "pink",
+                            "color": "#ffc0cb",
+                            "center": true
+                        },
+                        {
+                            "range": [105, 116],
+                            "name": "blue",
+                            "color": "#0000ff",
+                            "center": true
+                        },
+                        {
+                            "range": [117, 127],
+                            "name": "orange",
+                            "color": "#ff7f00",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 190],
+                            "name": "rainbow_fw"
+                        },
+                        {
+                            "range": [191, 192],
+                            "name": "no_rot"
+                        },
+                        {
+                            "range": [193, 255],
+                            "name": "rainbow_bw"
+                        }
+                    ]
+                },
+                "Prism": {
+                    "type": "Prism",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 95],
+                            "name": "open"
+                        },
+                        {
+                            "range": [96, 159],
+                            "name": "3_prism"
+                        },
+                        {
+                            "range": [160, 167],
+                            "name": "macro1",
+                            "center": true
+                        },
+                        {
+                            "range": [168, 175],
+                            "name": "macro2",
+                            "center": true
+                        },
+                        {
+                            "range": [176, 183],
+                            "name": "macro3",
+                            "center": true
+                        },
+                        {
+                            "range": [184, 191],
+                            "name": "macro4",
+                            "center": true
+                        },
+                        {
+                            "range": [192, 199],
+                            "name": "macro5",
+                            "center": true
+                        },
+                        {
+                            "range": [200, 207],
+                            "name": "macro6",
+                            "center": true
+                        },
+                        {
+                            "range": [208, 215],
+                            "name": "macro7",
+                            "center": true
+                        },
+                        {
+                            "range": [216, 223],
+                            "name": "macro8",
+                            "center": true
+                        },
+                        {
+                            "range": [224, 231],
+                            "name": "macro9",
+                            "center": true
+                        },
+                        {
+                            "range": [232, 239],
+                            "name": "macro10",
+                            "center": true
+                        },
+                        {
+                            "range": [240, 247],
+                            "name": "macro11",
+                            "center": true
+                        },
+                        {
+                            "range": [248, 255],
+                            "name": "macro12",
+                            "center": true
+                        }
+                    ]
+                },
+                "Rot_Prism": {
+                    "type": "Prism",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "no_rot"
+                        },
+                        {
+                            "range": [1, 126],
+                            "name": "rot_fw"
+                        },
+                        {
+                            "range": [127, 128],
+                            "name": "no_rot"
+                        },
+                        {
+                            "range": [129, 255],
+                            "name": "rot_bw"
+                        }
+                    ]
+                },
+                "Gobo_Rot": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 31],
+                            "name": "open"
+                        },
+                        {
+                            "range": [32, 63],
+                            "name": "gobo1",
+                            "center": true
+                        },
+                        {
+                            "range": [64, 95],
+                            "name": "gobo2",
+                            "center": true
+                        },
+                        {
+                            "range": [96, 127],
+                            "name": "gobo3",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 159],
+                            "name": "gobo4",
+                            "center": true
+                        },
+                        {
+                            "range": [160, 223],
+                            "name": "gobo5",
+                            "center": true
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "gobo_rot"
+                        }
+                    ]
+                },
+                "Index": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "index"
+                        },
+                        {
+                            "range": [128, 190],
+                            "name": "goborot_fw"
+                        },
+                        {
+                            "range": [191, 192],
+                            "name": "no_rot"
+                        },
+                        {
+                            "range": [193, 255],
+                            "name": "goborot_bw"
+                        }
+                    ]
+                },
+                "Focus": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Shutter": {
+                    "type": "Shutter",
+                    "defaultValue": 45,
+                    "highlightValue": 45,
+                    "capabilities": [
+                        {
+                            "range": [0, 31],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [32, 63],
+                            "name": "open",
+                            "center": true
+                        },
+                        {
+                            "range": [64, 95],
+                            "name": "strobe"
+                        },
+                        {
+                            "range": [96, 127],
+                            "name": "open",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 159],
+                            "name": "pulse"
+                        },
+                        {
+                            "range": [160, 191],
+                            "name": "open",
+                            "center": true
+                        },
+                        {
+                            "range": [192, 223],
+                            "name": "strobe_rnd"
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "open",
+                            "center": true
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "16-channel Mode",
+                    "shortName": "16ch",
+                    "channels": [
+                        "Pan",
+                        "Tilt",
+                        "Pan fine",
+                        "Tilt fine",
+                        "Speed",
+                        "Lamp",
+                        "Color",
+                        null,
+                        "Prism",
+                        "Rot_Prism",
+                        "Gobo_Rot",
+                        "Index",
+                        null,
+                        "Focus",
+                        "Shutter",
+                        "Intensity"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Future Light",
+            "name": "MH-680",
+            "shortName": "MH-680",
+            "physical": {
+                "dimensions": [450, 450, 550],
+                "weight": 16,
+                "power": 500
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Speed": {
+                    "type": "Speed",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 249],
+                            "name": "speed"
+                        },
+                        {
+                            "range": [250, 252],
+                            "name": "black_change",
+                            "center": true
+                        },
+                        {
+                            "range": [253, 255],
+                            "name": "black_move",
+                            "center": true
+                        }
+                    ]
+                },
+                "Lamp": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "fan_speed"
+                        },
+                        {
+                            "range": [128, 139],
+                            "name": "lamp_on",
+                            "center": true
+                        },
+                        {
+                            "range": [140, 239],
+                            "name": "nofunction"
+                        },
+                        {
+                            "range": [230, 239],
+                            "name": "lamp_off",
+                            "center": true
+                        },
+                        {
+                            "range": [240, 255],
+                            "name": "nofunction",
+                            "center": true
+                        }
+                    ]
+                },
+                "Color": {
+                    "type": "MultiColor",
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "open"
+                        },
+                        {
+                            "range": [16, 31],
+                            "name": "blue",
+                            "color": "#0000ff",
+                            "center": true
+                        },
+                        {
+                            "range": [32, 47],
+                            "name": "red",
+                            "color": "#ff0000",
+                            "center": true
+                        },
+                        {
+                            "range": [48, 63],
+                            "name": "green",
+                            "color": "#00ff00",
+                            "center": true
+                        },
+                        {
+                            "range": [64, 79],
+                            "name": "yellow",
+                            "color": "#ffff00",
+                            "center": true
+                        },
+                        {
+                            "range": [80, 95],
+                            "name": "magenta",
+                            "color": "#ca1f7b",
+                            "center": true
+                        },
+                        {
+                            "range": [96, 111],
+                            "name": "cyan",
+                            "color": "#00ffff",
+                            "center": true
+                        },
+                        {
+                            "range": [112, 127],
+                            "name": "lightgreen",
+                            "color": "#90ee90",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 190],
+                            "name": "rainbow_fw"
+                        },
+                        {
+                            "range": [191, 192],
+                            "name": "no_rot",
+                            "center": true
+                        },
+                        {
+                            "range": [193, 255],
+                            "name": "rainbow_bw"
+                        }
+                    ]
+                },
+                "color2": {
+                    "type": "MultiColor",
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "white",
+                            "color": "#ffffff"
+                        },
+                        {
+                            "range": [16, 35],
+                            "name": "lightblue",
+                            "color": "#add8e6",
+                            "center": true
+                        },
+                        {
+                            "range": [36, 51],
+                            "name": "pink",
+                            "color": "#ffc0cb",
+                            "center": true
+                        },
+                        {
+                            "range": [52, 71],
+                            "name": "umbra",
+                            "center": true
+                        },
+                        {
+                            "range": [72, 87],
+                            "name": "gobo1",
+                            "center": true
+                        },
+                        {
+                            "range": [88, 107],
+                            "name": "gobo2",
+                            "center": true
+                        },
+                        {
+                            "range": [108, 127],
+                            "name": "gobo3",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 191],
+                            "name": "macro_ch7"
+                        },
+                        {
+                            "range": [192, 193],
+                            "name": "no_rot"
+                        },
+                        {
+                            "range": [194, 255],
+                            "name": "rainbow_fw"
+                        }
+                    ]
+                },
+                "Prism": {
+                    "type": "Prism",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 95],
+                            "name": "open"
+                        },
+                        {
+                            "range": [96, 159],
+                            "name": "3_prism"
+                        },
+                        {
+                            "range": [160, 167],
+                            "name": "macro1",
+                            "center": true
+                        },
+                        {
+                            "range": [168, 175],
+                            "name": "macro2",
+                            "center": true
+                        },
+                        {
+                            "range": [176, 183],
+                            "name": "macro3",
+                            "center": true
+                        },
+                        {
+                            "range": [184, 191],
+                            "name": "macro4",
+                            "center": true
+                        },
+                        {
+                            "range": [192, 199],
+                            "name": "macro5",
+                            "center": true
+                        },
+                        {
+                            "range": [200, 207],
+                            "name": "macro6",
+                            "center": true
+                        },
+                        {
+                            "range": [208, 215],
+                            "name": "macro7",
+                            "center": true
+                        },
+                        {
+                            "range": [216, 223],
+                            "name": "macro8",
+                            "center": true
+                        },
+                        {
+                            "range": [224, 231],
+                            "name": "macro9",
+                            "center": true
+                        },
+                        {
+                            "range": [232, 239],
+                            "name": "macro10",
+                            "center": true
+                        },
+                        {
+                            "range": [240, 247],
+                            "name": "macro11",
+                            "center": true
+                        },
+                        {
+                            "range": [248, 255],
+                            "name": "macro12",
+                            "center": true
+                        }
+                    ]
+                },
+                "Rot_Prism": {
+                    "type": "Prism",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "no_rot"
+                        },
+                        {
+                            "range": [1, 126],
+                            "name": "rot_fw"
+                        },
+                        {
+                            "range": [127, 128],
+                            "name": "no_rot"
+                        },
+                        {
+                            "range": [129, 255],
+                            "name": "rot_bw"
+                        }
+                    ]
+                },
+                "Gobo_Rot": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 31],
+                            "name": "open"
+                        },
+                        {
+                            "range": [32, 63],
+                            "name": "gobo1",
+                            "center": true
+                        },
+                        {
+                            "range": [64, 95],
+                            "name": "gobo2",
+                            "center": true
+                        },
+                        {
+                            "range": [96, 127],
+                            "name": "gobo3",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 159],
+                            "name": "gobo4",
+                            "center": true
+                        },
+                        {
+                            "range": [160, 223],
+                            "name": "gobo5",
+                            "center": true
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "gobo_rot"
+                        }
+                    ]
+                },
+                "Index": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "index"
+                        },
+                        {
+                            "range": [128, 190],
+                            "name": "goborot_fw"
+                        },
+                        {
+                            "range": [191, 192],
+                            "name": "no_rot"
+                        },
+                        {
+                            "range": [193, 255],
+                            "name": "goborot_bw"
+                        }
+                    ]
+                },
+                "Effect": {
+                    "type": "Effect",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 95],
+                            "name": "zoom"
+                        },
+                        {
+                            "range": [96, 111],
+                            "name": "frost",
+                            "color": "#edf5dd",
+                            "center": true
+                        },
+                        {
+                            "range": [112, 127],
+                            "name": "UV",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 223],
+                            "name": "zoom_correction"
+                        },
+                        {
+                            "range": [224, 239],
+                            "name": "frost",
+                            "color": "#edf5dd",
+                            "center": true
+                        },
+                        {
+                            "range": [240, 255],
+                            "name": "UV",
+                            "center": true
+                        }
+                    ]
+                },
+                "Focus": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Shutter": {
+                    "type": "Shutter",
+                    "defaultValue": 45,
+                    "highlightValue": 45,
+                    "capabilities": [
+                        {
+                            "range": [0, 31],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [32, 63],
+                            "name": "open",
+                            "center": true
+                        },
+                        {
+                            "range": [64, 95],
+                            "name": "strobe"
+                        },
+                        {
+                            "range": [96, 127],
+                            "name": "open",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 159],
+                            "name": "pulse"
+                        },
+                        {
+                            "range": [160, 191],
+                            "name": "open",
+                            "center": true
+                        },
+                        {
+                            "range": [192, 223],
+                            "name": "strobe_rnd"
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "open",
+                            "center": true
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "16-channel Mode",
+                    "shortName": "16ch",
+                    "channels": [
+                        "Pan",
+                        "Tilt",
+                        "Pan fine",
+                        "Tilt fine",
+                        "Speed",
+                        "Lamp",
+                        "Color",
+                        "color2",
+                        "Prism",
+                        "Rot_Prism",
+                        "Gobo_Rot",
+                        "Index",
+                        "Effect",
+                        "Focus",
+                        "Shutter",
+                        "Intensity"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Future Light",
+            "name": "MH-840",
+            "shortName": "MH-840",
+            "physical": {
+                "dimensions": [450, 450, 650],
+                "weight": 33,
+                "power": 800
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Speed": {
+                    "type": "Speed",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 249],
+                            "name": "speed"
+                        },
+                        {
+                            "range": [250, 252],
+                            "name": "black_change",
+                            "center": true
+                        },
+                        {
+                            "range": [253, 255],
+                            "name": "black_move",
+                            "center": true
+                        }
+                    ]
+                },
+                "Lamp": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "fan_speed"
+                        },
+                        {
+                            "range": [128, 139],
+                            "name": "lamp_on",
+                            "center": true
+                        },
+                        {
+                            "range": [140, 239],
+                            "name": "nofunction"
+                        },
+                        {
+                            "range": [230, 239],
+                            "name": "lamp_off",
+                            "center": true
+                        },
+                        {
+                            "range": [240, 255],
+                            "name": "nofunction",
+                            "center": true
+                        }
+                    ]
+                },
+                "Color": {
+                    "type": "MultiColor",
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "open"
+                        },
+                        {
+                            "range": [16, 31],
+                            "name": "red",
+                            "color": "#ff0000",
+                            "center": true
+                        },
+                        {
+                            "range": [32, 47],
+                            "name": "blue",
+                            "color": "#0000ff",
+                            "center": true
+                        },
+                        {
+                            "range": [48, 63],
+                            "name": "green",
+                            "color": "#00ff00",
+                            "center": true
+                        },
+                        {
+                            "range": [64, 79],
+                            "name": "orange",
+                            "color": "#ff7f00",
+                            "center": true
+                        },
+                        {
+                            "range": [80, 95],
+                            "name": "3200k",
+                            "center": true
+                        },
+                        {
+                            "range": [96, 111],
+                            "name": "6000k",
+                            "center": true
+                        },
+                        {
+                            "range": [112, 127],
+                            "name": "UV",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 190],
+                            "name": "rainbow_fw"
+                        },
+                        {
+                            "range": [191, 192],
+                            "name": "no_rot",
+                            "center": true
+                        },
+                        {
+                            "range": [193, 255],
+                            "name": "rainbow_bw"
+                        }
+                    ]
+                },
+                "Cyan": {
+                    "type": "SingleColor",
+                    "color": "Cyan",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Magenta": {
+                    "type": "SingleColor",
+                    "color": "Magenta",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Yellow": {
+                    "type": "SingleColor",
+                    "color": "Yellow",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Speed-1g4h9": {
+                    "name": "Speed",
+                    "type": "Speed",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Macro": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 7],
+                            "name": "open"
+                        },
+                        {
+                            "range": [8, 15],
+                            "name": "macro1",
+                            "center": true
+                        },
+                        {
+                            "range": [16, 23],
+                            "name": "macro2",
+                            "center": true
+                        },
+                        {
+                            "range": [24, 31],
+                            "name": "macro3",
+                            "center": true
+                        },
+                        {
+                            "range": [32, 39],
+                            "name": "macro4",
+                            "center": true
+                        },
+                        {
+                            "range": [40, 47],
+                            "name": "macro5",
+                            "center": true
+                        },
+                        {
+                            "range": [48, 55],
+                            "name": "macro6",
+                            "center": true
+                        },
+                        {
+                            "range": [56, 63],
+                            "name": "macro7",
+                            "center": true
+                        },
+                        {
+                            "range": [64, 71],
+                            "name": "macro8",
+                            "center": true
+                        },
+                        {
+                            "range": [72, 79],
+                            "name": "macro9",
+                            "center": true
+                        },
+                        {
+                            "range": [80, 87],
+                            "name": "macro10",
+                            "center": true
+                        },
+                        {
+                            "range": [88, 95],
+                            "name": "macro11",
+                            "center": true
+                        },
+                        {
+                            "range": [96, 103],
+                            "name": "macro12",
+                            "center": true
+                        },
+                        {
+                            "range": [104, 111],
+                            "name": "macro13",
+                            "center": true
+                        },
+                        {
+                            "range": [112, 119],
+                            "name": "macro14",
+                            "center": true
+                        },
+                        {
+                            "range": [120, 127],
+                            "name": "macro15",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 135],
+                            "name": "macro16",
+                            "center": true
+                        },
+                        {
+                            "range": [136, 143],
+                            "name": "macro17",
+                            "center": true
+                        },
+                        {
+                            "range": [144, 151],
+                            "name": "macro18",
+                            "center": true
+                        },
+                        {
+                            "range": [152, 159],
+                            "name": "macro19",
+                            "center": true
+                        },
+                        {
+                            "range": [160, 167],
+                            "name": "macro20",
+                            "center": true
+                        },
+                        {
+                            "range": [168, 175],
+                            "name": "macro21",
+                            "center": true
+                        },
+                        {
+                            "range": [176, 183],
+                            "name": "macro22",
+                            "center": true
+                        },
+                        {
+                            "range": [184, 191],
+                            "name": "macro23",
+                            "center": true
+                        },
+                        {
+                            "range": [192, 199],
+                            "name": "macro24",
+                            "center": true
+                        },
+                        {
+                            "range": [200, 207],
+                            "name": "macro25",
+                            "center": true
+                        },
+                        {
+                            "range": [208, 215],
+                            "name": "macro26",
+                            "center": true
+                        },
+                        {
+                            "range": [216, 223],
+                            "name": "macro27",
+                            "center": true
+                        },
+                        {
+                            "range": [224, 231],
+                            "name": "macro28",
+                            "center": true
+                        },
+                        {
+                            "range": [232, 239],
+                            "name": "macro29",
+                            "center": true
+                        },
+                        {
+                            "range": [240, 247],
+                            "name": "macro30",
+                            "center": true
+                        },
+                        {
+                            "range": [248, 255],
+                            "name": "macro31",
+                            "center": true
+                        }
+                    ]
+                },
+                "Effect": {
+                    "type": "Effect",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 70],
+                            "name": "circle"
+                        },
+                        {
+                            "range": [71, 230],
+                            "name": "shaper"
+                        },
+                        {
+                            "range": [231, 255],
+                            "name": "frost",
+                            "color": "#edf5dd"
+                        }
+                    ]
+                },
+                "Zoom": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Shutter": {
+                    "type": "Shutter",
+                    "defaultValue": 45,
+                    "highlightValue": 45,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 31],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [32, 63],
+                            "name": "open",
+                            "center": true
+                        },
+                        {
+                            "range": [64, 95],
+                            "name": "strobe"
+                        },
+                        {
+                            "range": [96, 127],
+                            "name": "open"
+                        },
+                        {
+                            "range": [128, 159],
+                            "name": "pulse"
+                        },
+                        {
+                            "range": [160, 191],
+                            "name": "open",
+                            "center": true
+                        },
+                        {
+                            "range": [192, 223],
+                            "name": "strobe_rnd"
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "open",
+                            "center": true
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "16-channel Mode",
+                    "shortName": "16ch",
+                    "channels": [
+                        "Pan",
+                        "Tilt",
+                        "Pan fine",
+                        "Tilt fine",
+                        "Speed",
+                        "Lamp",
+                        "Color",
+                        "Cyan",
+                        "Magenta",
+                        "Yellow",
+                        "Speed-1g4h9",
+                        "Macro",
+                        "Effect",
+                        "Zoom",
+                        "Shutter",
+                        "Intensity"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Future Light",
+            "name": "MH-860",
+            "shortName": "MH-860",
+            "physical": {
+                "dimensions": [450, 450, 650],
+                "weight": 33,
+                "power": 800
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Speed": {
+                    "type": "Speed",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 249],
+                            "name": "speed"
+                        },
+                        {
+                            "range": [250, 252],
+                            "name": "black_change",
+                            "center": true
+                        },
+                        {
+                            "range": [253, 255],
+                            "name": "black_move",
+                            "center": true
+                        }
+                    ]
+                },
+                "Lamp": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "fan_speed"
+                        },
+                        {
+                            "range": [128, 139],
+                            "name": "lamp_on",
+                            "center": true
+                        },
+                        {
+                            "range": [140, 239],
+                            "name": "nofunction"
+                        },
+                        {
+                            "range": [230, 239],
+                            "name": "lamp_off",
+                            "center": true
+                        },
+                        {
+                            "range": [240, 255],
+                            "name": "nofunction",
+                            "center": true
+                        }
+                    ]
+                },
+                "Color1": {
+                    "type": "MultiColor",
+                    "capabilities": [
+                        {
+                            "range": [0, 12],
+                            "name": "open"
+                        },
+                        {
+                            "range": [13, 25],
+                            "name": "lightblue",
+                            "color": "#add8e6",
+                            "center": true
+                        },
+                        {
+                            "range": [26, 37],
+                            "name": "red",
+                            "color": "#ff0000",
+                            "center": true
+                        },
+                        {
+                            "range": [38, 50],
+                            "name": "blue",
+                            "color": "#0000ff",
+                            "center": true
+                        },
+                        {
+                            "range": [51, 63],
+                            "name": "lightgreen",
+                            "color": "#90ee90",
+                            "center": true
+                        },
+                        {
+                            "range": [64, 76],
+                            "name": "yellow",
+                            "color": "#ffff00",
+                            "center": true
+                        },
+                        {
+                            "range": [77, 89],
+                            "name": "magenta",
+                            "color": "#ca1f7b",
+                            "center": true
+                        },
+                        {
+                            "range": [90, 101],
+                            "name": "cyan",
+                            "color": "#00ffff",
+                            "center": true
+                        },
+                        {
+                            "range": [102, 114],
+                            "name": "green",
+                            "color": "#00ff00",
+                            "center": true
+                        },
+                        {
+                            "range": [115, 127],
+                            "name": "orange",
+                            "color": "#ff7f00",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 190],
+                            "name": "rainbow_fw"
+                        },
+                        {
+                            "range": [191, 193],
+                            "name": "no_rot",
+                            "center": true
+                        },
+                        {
+                            "range": [194, 255],
+                            "name": "rainbow_bw"
+                        }
+                    ]
+                },
+                "Color2": {
+                    "type": "MultiColor",
+                    "capabilities": [
+                        {
+                            "range": [0, 11],
+                            "name": "white",
+                            "color": "#ffffff"
+                        },
+                        {
+                            "range": [12, 23],
+                            "name": "darkred",
+                            "color": "#8b0000",
+                            "center": true
+                        },
+                        {
+                            "range": [24, 35],
+                            "name": "darkblue",
+                            "color": "#00008b",
+                            "center": true
+                        },
+                        {
+                            "range": [36, 47],
+                            "name": "pink",
+                            "color": "#ffc0cb",
+                            "center": true
+                        },
+                        {
+                            "range": [48, 59],
+                            "name": "cyan",
+                            "color": "#00ffff",
+                            "center": true
+                        },
+                        {
+                            "range": [60, 71],
+                            "name": "magenta",
+                            "color": "#ca1f7b",
+                            "center": true
+                        },
+                        {
+                            "range": [72, 83],
+                            "name": "yellow",
+                            "color": "#ffff00",
+                            "center": true
+                        },
+                        {
+                            "range": [84, 95],
+                            "name": "6000k",
+                            "center": true
+                        },
+                        {
+                            "range": [96, 107],
+                            "name": "3200k",
+                            "center": true
+                        },
+                        {
+                            "range": [108, 119],
+                            "name": "UV",
+                            "center": true
+                        },
+                        {
+                            "range": [120, 127],
+                            "name": "white",
+                            "color": "#ffffff",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 255],
+                            "name": "macro_ch7"
+                        }
+                    ]
+                },
+                "Prism": {
+                    "type": "Prism",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "open"
+                        },
+                        {
+                            "range": [1, 63],
+                            "name": "rot_fw"
+                        },
+                        {
+                            "range": [64, 64],
+                            "name": "no_rot"
+                        },
+                        {
+                            "range": [65, 127],
+                            "name": "rot_bw"
+                        },
+                        {
+                            "range": [128, 135],
+                            "name": "macro1",
+                            "center": true
+                        },
+                        {
+                            "range": [136, 143],
+                            "name": "macro2",
+                            "center": true
+                        },
+                        {
+                            "range": [144, 151],
+                            "name": "macro3",
+                            "center": true
+                        },
+                        {
+                            "range": [152, 159],
+                            "name": "macro4",
+                            "center": true
+                        },
+                        {
+                            "range": [160, 167],
+                            "name": "macro5",
+                            "center": true
+                        },
+                        {
+                            "range": [168, 175],
+                            "name": "macro6",
+                            "center": true
+                        },
+                        {
+                            "range": [176, 183],
+                            "name": "macro7",
+                            "center": true
+                        },
+                        {
+                            "range": [184, 191],
+                            "name": "macro8",
+                            "center": true
+                        },
+                        {
+                            "range": [192, 199],
+                            "name": "macro9",
+                            "center": true
+                        },
+                        {
+                            "range": [200, 207],
+                            "name": "macro10",
+                            "center": true
+                        },
+                        {
+                            "range": [208, 215],
+                            "name": "macro11",
+                            "center": true
+                        },
+                        {
+                            "range": [216, 223],
+                            "name": "macro12",
+                            "center": true
+                        },
+                        {
+                            "range": [224, 231],
+                            "name": "macro13",
+                            "center": true
+                        },
+                        {
+                            "range": [232, 239],
+                            "name": "macro14",
+                            "center": true
+                        },
+                        {
+                            "range": [240, 247],
+                            "name": "macro15",
+                            "center": true
+                        },
+                        {
+                            "range": [248, 255],
+                            "name": "macro16",
+                            "center": true
+                        }
+                    ]
+                },
+                "Gobo": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 7],
+                            "name": "open"
+                        },
+                        {
+                            "range": [8, 15],
+                            "name": "gobo1",
+                            "center": true
+                        },
+                        {
+                            "range": [16, 23],
+                            "name": "gobo2",
+                            "center": true
+                        },
+                        {
+                            "range": [24, 31],
+                            "name": "gobo3",
+                            "center": true
+                        },
+                        {
+                            "range": [32, 39],
+                            "name": "gobo4",
+                            "center": true
+                        },
+                        {
+                            "range": [40, 47],
+                            "name": "gobo5",
+                            "center": true
+                        },
+                        {
+                            "range": [48, 55],
+                            "name": "gobo6",
+                            "center": true
+                        },
+                        {
+                            "range": [56, 63],
+                            "name": "gobo7",
+                            "center": true
+                        },
+                        {
+                            "range": [64, 71],
+                            "name": "gobo8",
+                            "center": true
+                        },
+                        {
+                            "range": [72, 79],
+                            "name": "gobo9",
+                            "center": true
+                        },
+                        {
+                            "range": [80, 95],
+                            "name": "gobo1_sh",
+                            "center": true
+                        },
+                        {
+                            "range": [96, 111],
+                            "name": "gobo2_sh",
+                            "center": true
+                        },
+                        {
+                            "range": [112, 127],
+                            "name": "gobo3_sh",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 143],
+                            "name": "gobo4_sh",
+                            "center": true
+                        },
+                        {
+                            "range": [144, 159],
+                            "name": "gobo5_sh",
+                            "center": true
+                        },
+                        {
+                            "range": [160, 175],
+                            "name": "gobo6_sh",
+                            "center": true
+                        },
+                        {
+                            "range": [176, 191],
+                            "name": "gobo7_sh",
+                            "center": true
+                        },
+                        {
+                            "range": [192, 207],
+                            "name": "gobo8_sh",
+                            "center": true
+                        },
+                        {
+                            "range": [208, 223],
+                            "name": "gobo9_sh",
+                            "center": true
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "gobo_rot"
+                        }
+                    ]
+                },
+                "Gobo_Rot": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 31],
+                            "name": "open"
+                        },
+                        {
+                            "range": [32, 63],
+                            "name": "gobo1",
+                            "center": true
+                        },
+                        {
+                            "range": [64, 95],
+                            "name": "gobo2",
+                            "center": true
+                        },
+                        {
+                            "range": [96, 127],
+                            "name": "gobo3",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 159],
+                            "name": "gobo4",
+                            "center": true
+                        },
+                        {
+                            "range": [160, 191],
+                            "name": "gobo5",
+                            "center": true
+                        },
+                        {
+                            "range": [192, 223],
+                            "name": "gobo6",
+                            "center": true
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "gobo_rot"
+                        }
+                    ]
+                },
+                "Index": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "index"
+                        },
+                        {
+                            "range": [128, 191],
+                            "name": "goborot_fw"
+                        },
+                        {
+                            "range": [192, 192],
+                            "name": "no_rot"
+                        },
+                        {
+                            "range": [193, 255],
+                            "name": "goborot_bw"
+                        }
+                    ]
+                },
+                "Iris": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 179],
+                            "name": "%"
+                        },
+                        {
+                            "range": [180, 191],
+                            "name": "closed",
+                            "center": true
+                        },
+                        {
+                            "range": [192, 223],
+                            "name": "pulse_cl"
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "pulse_op"
+                        }
+                    ]
+                },
+                "Zoom": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Shutter": {
+                    "type": "Shutter",
+                    "defaultValue": 45,
+                    "highlightValue": 45,
+                    "capabilities": [
+                        {
+                            "range": [0, 31],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [32, 63],
+                            "name": "open",
+                            "center": true
+                        },
+                        {
+                            "range": [64, 95],
+                            "name": "strobe"
+                        },
+                        {
+                            "range": [96, 127],
+                            "name": "open",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 159],
+                            "name": "pulse"
+                        },
+                        {
+                            "range": [160, 191],
+                            "name": "open",
+                            "center": true
+                        },
+                        {
+                            "range": [192, 223],
+                            "name": "strobe_rnd"
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "open",
+                            "center": true
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "16-channel Mode",
+                    "shortName": "16ch",
+                    "channels": [
+                        "Pan",
+                        "Tilt",
+                        "Pan fine",
+                        "Tilt fine",
+                        "Speed",
+                        "Lamp",
+                        "Color1",
+                        "Color2",
+                        "Prism",
+                        "Gobo",
+                        "Gobo_Rot",
+                        "Index",
+                        "Iris",
+                        "Zoom",
+                        "Shutter",
+                        "Intensity"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Future Light",
+            "name": "PHS-200",
+            "shortName": "PHS200",
+            "comment": "cd",
+            "physical": {
+                "dimensions": [350, 350, 500],
+                "weight": 15,
+                "power": 400
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 32768,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 32768,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "P/T speed": {
+                    "type": "Speed",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "track",
+                            "center": true
+                        },
+                        {
+                            "range": [1, 225],
+                            "name": "fade"
+                        },
+                        {
+                            "range": [226, 235],
+                            "name": "move in black",
+                            "center": true
+                        },
+                        {
+                            "range": [236, 245],
+                            "name": "c/g in black",
+                            "center": true
+                        },
+                        {
+                            "range": [246, 255],
+                            "name": "track",
+                            "center": true
+                        }
+                    ]
+                },
+                "Color": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 19],
+                            "name": "open",
+                            "center": true
+                        },
+                        {
+                            "range": [20, 39],
+                            "name": "red",
+                            "color": "#ff0000",
+                            "center": true
+                        },
+                        {
+                            "range": [40, 59],
+                            "name": "dark blue",
+                            "color": "#00008b",
+                            "center": true
+                        },
+                        {
+                            "range": [60, 79],
+                            "name": "dark green",
+                            "color": "#013220",
+                            "center": true
+                        },
+                        {
+                            "range": [80, 99],
+                            "name": "turquoise",
+                            "color": "#40e0d0",
+                            "center": true
+                        },
+                        {
+                            "range": [100, 119],
+                            "name": "salmon pink",
+                            "color": "#ff91a4",
+                            "center": true
+                        },
+                        {
+                            "range": [120, 139],
+                            "name": "yellow",
+                            "color": "#ffff00",
+                            "center": true
+                        },
+                        {
+                            "range": [140, 159],
+                            "name": "green",
+                            "color": "#00ff00",
+                            "center": true
+                        },
+                        {
+                            "range": [160, 179],
+                            "name": "pink",
+                            "color": "#ffc0cb",
+                            "center": true
+                        },
+                        {
+                            "range": [180, 199],
+                            "name": "light blue",
+                            "color": "#add8e6"
+                        },
+                        {
+                            "range": [200, 255],
+                            "name": ">>",
+                            "center": true
+                        }
+                    ]
+                },
+                "Gobo": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 13],
+                            "name": "open",
+                            "center": true
+                        },
+                        {
+                            "range": [14, 27],
+                            "name": "slot1",
+                            "center": true
+                        },
+                        {
+                            "range": [28, 41],
+                            "name": "slot2",
+                            "center": true
+                        },
+                        {
+                            "range": [28, 41],
+                            "name": "slot3",
+                            "center": true
+                        },
+                        {
+                            "range": [56, 69],
+                            "name": "slot4",
+                            "center": true
+                        },
+                        {
+                            "range": [70, 83],
+                            "name": "slot5",
+                            "center": true
+                        },
+                        {
+                            "range": [84, 97],
+                            "name": "slot6",
+                            "center": true
+                        },
+                        {
+                            "range": [98, 115],
+                            "name": "slot7",
+                            "center": true
+                        },
+                        {
+                            "range": [116, 135],
+                            "name": "slot1 sh."
+                        },
+                        {
+                            "range": [136, 155],
+                            "name": "slot2 sh."
+                        },
+                        {
+                            "range": [156, 175],
+                            "name": "slot3 sh."
+                        },
+                        {
+                            "range": [176, 195],
+                            "name": "slot4 sh."
+                        },
+                        {
+                            "range": [196, 215],
+                            "name": "slot5 sh."
+                        },
+                        {
+                            "range": [216, 235],
+                            "name": "slot6 sh."
+                        },
+                        {
+                            "range": [236, 255],
+                            "name": "slot7 sh."
+                        }
+                    ]
+                },
+                "Gobo rot.": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 7],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [8, 127],
+                            "name": ">>"
+                        },
+                        {
+                            "range": [128, 135],
+                            "name": "stop",
+                            "center": true
+                        },
+                        {
+                            "range": [136, 255],
+                            "name": "<<"
+                        }
+                    ]
+                },
+                "Shutter": {
+                    "type": "Shutter",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 31],
+                            "name": "close",
+                            "center": true
+                        },
+                        {
+                            "range": [32, 63],
+                            "name": "open dim.",
+                            "center": true
+                        },
+                        {
+                            "range": [64, 159],
+                            "name": "strobe"
+                        },
+                        {
+                            "range": [160, 191],
+                            "name": "open",
+                            "center": true
+                        },
+                        {
+                            "range": [192, 223],
+                            "name": "random"
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "open",
+                            "center": true
+                        }
+                    ]
+                },
+                "Reset": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 31],
+                            "name": "normal"
+                        },
+                        {
+                            "range": [32, 63],
+                            "name": "c. random"
+                        },
+                        {
+                            "range": [64, 79],
+                            "name": "lamp on",
+                            "center": true
+                        },
+                        {
+                            "range": [80, 85],
+                            "name": "reset",
+                            "center": true
+                        },
+                        {
+                            "range": [96, 111],
+                            "name": "program1",
+                            "center": true
+                        },
+                        {
+                            "range": [112, 127],
+                            "name": "program2",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 143],
+                            "name": "program3",
+                            "center": true
+                        },
+                        {
+                            "range": [144, 159],
+                            "name": "program4",
+                            "center": true
+                        },
+                        {
+                            "range": [160, 175],
+                            "name": "program5",
+                            "center": true
+                        },
+                        {
+                            "range": [176, 191],
+                            "name": "program6",
+                            "center": true
+                        },
+                        {
+                            "range": [192, 207],
+                            "name": "program7",
+                            "center": true
+                        },
+                        {
+                            "range": [208, 223],
+                            "name": "program8",
+                            "center": true
+                        },
+                        {
+                            "range": [224, 239],
+                            "name": "lamp off",
+                            "center": true
+                        },
+                        {
+                            "range": [240, 255],
+                            "name": "normal",
+                            "showInMenu": false,
+                            "center": true
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "8-channel Mode",
+                    "shortName": "8ch",
+                    "channels": [
+                        "Pan",
+                        "Tilt",
+                        "P/T speed",
+                        "Color",
+                        "Gobo",
+                        "Gobo rot.",
+                        "Shutter",
+                        "Reset"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Future Light",
+            "name": "PHS-250",
+            "shortName": "PHS250",
+            "comment": "cd",
+            "physical": {
+                "dimensions": [400, 400, 600],
+                "weight": 23,
+                "power": 430
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "P/T speed": {
+                    "type": "Speed",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 14],
+                            "name": "track",
+                            "center": true
+                        },
+                        {
+                            "range": [15, 225],
+                            "name": "fade"
+                        },
+                        {
+                            "range": [226, 235],
+                            "name": "move in black",
+                            "center": true
+                        },
+                        {
+                            "range": [236, 245],
+                            "name": "c/g in black",
+                            "center": true
+                        },
+                        {
+                            "range": [246, 255],
+                            "name": "track",
+                            "center": true
+                        }
+                    ]
+                },
+                "Color": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 13],
+                            "name": "open",
+                            "center": true
+                        },
+                        {
+                            "range": [14, 27],
+                            "name": "light blue",
+                            "color": "#add8e6",
+                            "center": true
+                        },
+                        {
+                            "range": [28, 41],
+                            "name": "red",
+                            "color": "#ff0000",
+                            "center": true
+                        },
+                        {
+                            "range": [42, 55],
+                            "name": "blue",
+                            "color": "#0000ff",
+                            "center": true
+                        },
+                        {
+                            "range": [56, 69],
+                            "name": "green",
+                            "color": "#00ff00",
+                            "center": true
+                        },
+                        {
+                            "range": [70, 83],
+                            "name": "yellow",
+                            "color": "#ffff00",
+                            "center": true
+                        },
+                        {
+                            "range": [84, 97],
+                            "name": "magenta",
+                            "color": "#ca1f7b",
+                            "center": true
+                        },
+                        {
+                            "range": [98, 111],
+                            "name": "light green",
+                            "color": "#90ee90",
+                            "center": true
+                        },
+                        {
+                            "range": [112, 127],
+                            "name": "dark green",
+                            "color": "#013220",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 187],
+                            "name": ">>"
+                        },
+                        {
+                            "range": [144, 193],
+                            "name": "stop",
+                            "center": true
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "<<"
+                        }
+                    ]
+                },
+                "Gobo1": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 13],
+                            "name": "open",
+                            "center": true
+                        },
+                        {
+                            "range": [14, 27],
+                            "name": "slot1",
+                            "center": true
+                        },
+                        {
+                            "range": [28, 41],
+                            "name": "slot2",
+                            "center": true
+                        },
+                        {
+                            "range": [28, 55],
+                            "name": "slot3",
+                            "center": true
+                        },
+                        {
+                            "range": [56, 69],
+                            "name": "slot4",
+                            "center": true
+                        },
+                        {
+                            "range": [70, 83],
+                            "name": "slot5",
+                            "center": true
+                        },
+                        {
+                            "range": [84, 97],
+                            "name": "slot6",
+                            "center": true
+                        },
+                        {
+                            "range": [98, 111],
+                            "name": "slot7",
+                            "center": true
+                        },
+                        {
+                            "range": [112, 127],
+                            "name": "slot1 sh."
+                        },
+                        {
+                            "range": [128, 143],
+                            "name": "slot2 sh."
+                        },
+                        {
+                            "range": [144, 159],
+                            "name": "slot3 sh."
+                        },
+                        {
+                            "range": [160, 175],
+                            "name": "slot4 sh."
+                        },
+                        {
+                            "range": [176, 191],
+                            "name": "slot5 sh."
+                        },
+                        {
+                            "range": [192, 207],
+                            "name": "slot6 sh."
+                        },
+                        {
+                            "range": [208, 223],
+                            "name": "slot7 sh."
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": ">>"
+                        }
+                    ]
+                },
+                "Gobo2": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 9],
+                            "name": "open",
+                            "center": true
+                        },
+                        {
+                            "range": [10, 19],
+                            "name": "slot1",
+                            "center": true
+                        },
+                        {
+                            "range": [20, 29],
+                            "name": "slot2",
+                            "center": true
+                        },
+                        {
+                            "range": [30, 39],
+                            "name": "slot3",
+                            "center": true
+                        },
+                        {
+                            "range": [40, 49],
+                            "name": "slot4",
+                            "center": true
+                        },
+                        {
+                            "range": [50, 59],
+                            "name": "slot5",
+                            "center": true
+                        },
+                        {
+                            "range": [60, 69],
+                            "name": "slot6",
+                            "center": true
+                        },
+                        {
+                            "range": [70, 89],
+                            "name": "slot1 sh."
+                        },
+                        {
+                            "range": [90, 109],
+                            "name": "slot2 sh."
+                        },
+                        {
+                            "range": [110, 129],
+                            "name": "slot3 sh."
+                        },
+                        {
+                            "range": [130, 149],
+                            "name": "slot4 sh."
+                        },
+                        {
+                            "range": [150, 169],
+                            "name": "slot5 sh."
+                        },
+                        {
+                            "range": [170, 189],
+                            "name": "slot6 sh."
+                        },
+                        {
+                            "range": [190, 255],
+                            "name": ">>"
+                        }
+                    ]
+                },
+                "Gobo2 rot.": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "index"
+                        },
+                        {
+                            "range": [128, 187],
+                            "name": ">>"
+                        },
+                        {
+                            "range": [188, 193],
+                            "name": "stop",
+                            "center": true
+                        },
+                        {
+                            "range": [190, 255],
+                            "name": "<<"
+                        }
+                    ]
+                },
+                "Prisma": {
+                    "type": "Prism",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 3],
+                            "name": "open",
+                            "center": true
+                        },
+                        {
+                            "range": [4, 63],
+                            "name": ">>"
+                        },
+                        {
+                            "range": [64, 67],
+                            "name": "stop",
+                            "center": true
+                        },
+                        {
+                            "range": [68, 127],
+                            "name": "<<"
+                        },
+                        {
+                            "range": [128, 135],
+                            "name": "macro1",
+                            "center": true
+                        },
+                        {
+                            "range": [136, 143],
+                            "name": "macro2",
+                            "center": true
+                        },
+                        {
+                            "range": [144, 151],
+                            "name": "macro3",
+                            "center": true
+                        },
+                        {
+                            "range": [152, 159],
+                            "name": "macro4",
+                            "center": true
+                        },
+                        {
+                            "range": [160, 167],
+                            "name": "macro5",
+                            "center": true
+                        },
+                        {
+                            "range": [168, 175],
+                            "name": "macro6",
+                            "center": true
+                        },
+                        {
+                            "range": [176, 183],
+                            "name": "macro7",
+                            "center": true
+                        },
+                        {
+                            "range": [184, 191],
+                            "name": "macro8",
+                            "center": true
+                        },
+                        {
+                            "range": [192, 199],
+                            "name": "macro9",
+                            "center": true
+                        },
+                        {
+                            "range": [200, 207],
+                            "name": "macro10",
+                            "center": true
+                        },
+                        {
+                            "range": [208, 215],
+                            "name": "macro11",
+                            "center": true
+                        },
+                        {
+                            "range": [216, 223],
+                            "name": "macro12",
+                            "center": true
+                        },
+                        {
+                            "range": [224, 231],
+                            "name": "macro13",
+                            "center": true
+                        },
+                        {
+                            "range": [232, 239],
+                            "name": "macro14",
+                            "center": true
+                        },
+                        {
+                            "range": [240, 247],
+                            "name": "macro15",
+                            "center": true
+                        },
+                        {
+                            "range": [248, 255],
+                            "name": "macro16",
+                            "center": true
+                        }
+                    ]
+                },
+                "Focus": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Shutter": {
+                    "type": "Shutter",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 31],
+                            "name": "close",
+                            "center": true
+                        },
+                        {
+                            "range": [32, 63],
+                            "name": "open dim.",
+                            "center": true
+                        },
+                        {
+                            "range": [64, 159],
+                            "name": "strobe"
+                        },
+                        {
+                            "range": [160, 191],
+                            "name": "open",
+                            "center": true
+                        },
+                        {
+                            "range": [192, 223],
+                            "name": "random"
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "open",
+                            "center": true
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Reset": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 63],
+                            "name": "normal"
+                        },
+                        {
+                            "range": [64, 79],
+                            "name": "lamp on",
+                            "center": true
+                        },
+                        {
+                            "range": [80, 95],
+                            "name": "reset",
+                            "center": true
+                        },
+                        {
+                            "range": [96, 111],
+                            "name": "program1",
+                            "center": true
+                        },
+                        {
+                            "range": [112, 127],
+                            "name": "program2",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 143],
+                            "name": "program3",
+                            "center": true
+                        },
+                        {
+                            "range": [144, 159],
+                            "name": "program4",
+                            "center": true
+                        },
+                        {
+                            "range": [160, 175],
+                            "name": "program5",
+                            "center": true
+                        },
+                        {
+                            "range": [176, 191],
+                            "name": "program6",
+                            "center": true
+                        },
+                        {
+                            "range": [192, 207],
+                            "name": "program7",
+                            "center": true
+                        },
+                        {
+                            "range": [208, 223],
+                            "name": "program8",
+                            "center": true
+                        },
+                        {
+                            "range": [224, 239],
+                            "name": "lamp off",
+                            "center": true
+                        },
+                        {
+                            "range": [240, 255],
+                            "name": "normal",
+                            "showInMenu": false,
+                            "center": true
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "14-channel Mode",
+                    "shortName": "14ch",
+                    "channels": [
+                        "Pan",
+                        "Tilt",
+                        "P/T speed",
+                        "Color",
+                        "Gobo1",
+                        "Gobo2",
+                        "Gobo2 rot.",
+                        "Prisma",
+                        "Focus",
+                        "Shutter",
+                        "Intensity",
+                        "Reset",
+                        "Pan fine",
+                        "Tilt fine"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Future Light",
+            "name": "PHS-260",
+            "shortName": "PHS260",
+            "comment": "cd",
+            "physical": {
+                "dimensions": [420, 420, 500],
+                "weight": 25,
+                "power": 500
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "P/T speed": {
+                    "type": "Speed",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 225],
+                            "name": "track",
+                            "center": true
+                        },
+                        {
+                            "range": [226, 235],
+                            "name": "move in black",
+                            "center": true
+                        },
+                        {
+                            "range": [236, 245],
+                            "name": "c/g in black",
+                            "center": true
+                        },
+                        {
+                            "range": [246, 255],
+                            "name": "track",
+                            "center": true
+                        }
+                    ]
+                },
+                "Color": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 13],
+                            "name": "open",
+                            "center": true
+                        },
+                        {
+                            "range": [14, 27],
+                            "name": "red",
+                            "color": "#ff0000",
+                            "center": true
+                        },
+                        {
+                            "range": [28, 41],
+                            "name": "blue",
+                            "color": "#0000ff",
+                            "center": true
+                        },
+                        {
+                            "range": [42, 55],
+                            "name": "green",
+                            "color": "#00ff00",
+                            "center": true
+                        },
+                        {
+                            "range": [56, 69],
+                            "name": "light yellow",
+                            "color": "#ffffe0",
+                            "center": true
+                        },
+                        {
+                            "range": [70, 83],
+                            "name": "magenta",
+                            "color": "#ca1f7b",
+                            "center": true
+                        },
+                        {
+                            "range": [84, 97],
+                            "name": "orange",
+                            "color": "#ff7f00",
+                            "center": true
+                        },
+                        {
+                            "range": [98, 111],
+                            "name": "UV",
+                            "center": true
+                        },
+                        {
+                            "range": [112, 127],
+                            "name": "pink",
+                            "color": "#ffc0cb",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 187],
+                            "name": ">>"
+                        },
+                        {
+                            "range": [144, 193],
+                            "name": "stop",
+                            "center": true
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "<<"
+                        }
+                    ]
+                },
+                "Gobo1": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 13],
+                            "name": "open",
+                            "center": true
+                        },
+                        {
+                            "range": [14, 27],
+                            "name": "slot1",
+                            "center": true
+                        },
+                        {
+                            "range": [28, 41],
+                            "name": "slot2",
+                            "center": true
+                        },
+                        {
+                            "range": [28, 55],
+                            "name": "slot3",
+                            "center": true
+                        },
+                        {
+                            "range": [56, 69],
+                            "name": "slot4",
+                            "center": true
+                        },
+                        {
+                            "range": [70, 83],
+                            "name": "slot5",
+                            "center": true
+                        },
+                        {
+                            "range": [84, 97],
+                            "name": "slot6",
+                            "center": true
+                        },
+                        {
+                            "range": [98, 111],
+                            "name": "slot7",
+                            "center": true
+                        },
+                        {
+                            "range": [112, 127],
+                            "name": "slot1 sh."
+                        },
+                        {
+                            "range": [128, 143],
+                            "name": "slot2 sh."
+                        },
+                        {
+                            "range": [144, 159],
+                            "name": "slot3 sh."
+                        },
+                        {
+                            "range": [160, 175],
+                            "name": "slot4 sh."
+                        },
+                        {
+                            "range": [176, 191],
+                            "name": "slot5 sh."
+                        },
+                        {
+                            "range": [192, 207],
+                            "name": "slot6 sh."
+                        },
+                        {
+                            "range": [208, 223],
+                            "name": "slot7 sh."
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": ">>"
+                        }
+                    ]
+                },
+                "Gobo2": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 9],
+                            "name": "open",
+                            "center": true
+                        },
+                        {
+                            "range": [10, 19],
+                            "name": "slot1",
+                            "center": true
+                        },
+                        {
+                            "range": [20, 29],
+                            "name": "slot2",
+                            "center": true
+                        },
+                        {
+                            "range": [30, 39],
+                            "name": "slot3",
+                            "center": true
+                        },
+                        {
+                            "range": [40, 49],
+                            "name": "slot4",
+                            "center": true
+                        },
+                        {
+                            "range": [50, 59],
+                            "name": "slot5",
+                            "center": true
+                        },
+                        {
+                            "range": [60, 69],
+                            "name": "slot6",
+                            "center": true
+                        },
+                        {
+                            "range": [70, 79],
+                            "name": "slot7"
+                        },
+                        {
+                            "range": [80, 99],
+                            "name": "slot1 sh."
+                        },
+                        {
+                            "range": [100, 119],
+                            "name": "slot2 sh."
+                        },
+                        {
+                            "range": [120, 139],
+                            "name": "slot3 sh."
+                        },
+                        {
+                            "range": [140, 159],
+                            "name": "slot4 sh."
+                        },
+                        {
+                            "range": [160, 179],
+                            "name": "slot5 sh."
+                        },
+                        {
+                            "range": [180, 199],
+                            "name": "slot6 sh."
+                        },
+                        {
+                            "range": [200, 219],
+                            "name": "slot7 sh."
+                        },
+                        {
+                            "range": [220, 255],
+                            "name": ">>"
+                        }
+                    ]
+                },
+                "Gobo2 rot.": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "index"
+                        },
+                        {
+                            "range": [128, 187],
+                            "name": ">>"
+                        },
+                        {
+                            "range": [188, 193],
+                            "name": "stop",
+                            "center": true
+                        },
+                        {
+                            "range": [190, 255],
+                            "name": "<<"
+                        }
+                    ]
+                },
+                "Prisma": {
+                    "type": "Prism",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 3],
+                            "name": "open",
+                            "center": true
+                        },
+                        {
+                            "range": [4, 63],
+                            "name": ">>"
+                        },
+                        {
+                            "range": [64, 67],
+                            "name": "stop",
+                            "center": true
+                        },
+                        {
+                            "range": [68, 127],
+                            "name": "<<"
+                        },
+                        {
+                            "range": [128, 135],
+                            "name": "macro1",
+                            "center": true
+                        },
+                        {
+                            "range": [136, 143],
+                            "name": "macro2",
+                            "center": true
+                        },
+                        {
+                            "range": [144, 151],
+                            "name": "macro3",
+                            "center": true
+                        },
+                        {
+                            "range": [152, 159],
+                            "name": "macro4",
+                            "center": true
+                        },
+                        {
+                            "range": [160, 167],
+                            "name": "macro5",
+                            "center": true
+                        },
+                        {
+                            "range": [168, 175],
+                            "name": "macro6",
+                            "center": true
+                        },
+                        {
+                            "range": [176, 183],
+                            "name": "macro7",
+                            "center": true
+                        },
+                        {
+                            "range": [184, 191],
+                            "name": "macro8",
+                            "center": true
+                        },
+                        {
+                            "range": [192, 199],
+                            "name": "macro9",
+                            "center": true
+                        },
+                        {
+                            "range": [200, 207],
+                            "name": "macro10",
+                            "center": true
+                        },
+                        {
+                            "range": [208, 215],
+                            "name": "macro11",
+                            "center": true
+                        },
+                        {
+                            "range": [216, 223],
+                            "name": "macro12",
+                            "center": true
+                        },
+                        {
+                            "range": [224, 231],
+                            "name": "macro13",
+                            "center": true
+                        },
+                        {
+                            "range": [232, 239],
+                            "name": "macro14",
+                            "center": true
+                        },
+                        {
+                            "range": [240, 247],
+                            "name": "macro15",
+                            "center": true
+                        },
+                        {
+                            "range": [248, 255],
+                            "name": "macro16",
+                            "center": true
+                        }
+                    ]
+                },
+                "Focus": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Shutter": {
+                    "type": "Shutter",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 31],
+                            "name": "close",
+                            "center": true
+                        },
+                        {
+                            "range": [32, 63],
+                            "name": "open",
+                            "center": true
+                        },
+                        {
+                            "range": [64, 95],
+                            "name": "strobe"
+                        },
+                        {
+                            "range": [96, 127],
+                            "name": "open"
+                        },
+                        {
+                            "range": [128, 159],
+                            "name": "pulse"
+                        },
+                        {
+                            "range": [160, 191],
+                            "name": "open",
+                            "center": true
+                        },
+                        {
+                            "range": [192, 223],
+                            "name": "random"
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "open",
+                            "center": true
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Frost": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 191],
+                            "name": "%"
+                        },
+                        {
+                            "range": [192, 223],
+                            "name": "pulse opening"
+                        },
+                        {
+                            "range": [224, 254],
+                            "name": "pulse closing"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "full"
+                        }
+                    ]
+                },
+                "Reset": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 31],
+                            "name": "c. change1"
+                        },
+                        {
+                            "range": [32, 63],
+                            "name": "c. change2"
+                        },
+                        {
+                            "range": [64, 79],
+                            "name": "lamp on",
+                            "center": true
+                        },
+                        {
+                            "range": [80, 95],
+                            "name": "reset",
+                            "center": true
+                        },
+                        {
+                            "range": [96, 111],
+                            "name": "program1",
+                            "center": true
+                        },
+                        {
+                            "range": [112, 127],
+                            "name": "program2",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 143],
+                            "name": "program3",
+                            "center": true
+                        },
+                        {
+                            "range": [144, 159],
+                            "name": "program4",
+                            "center": true
+                        },
+                        {
+                            "range": [160, 175],
+                            "name": "program5",
+                            "center": true
+                        },
+                        {
+                            "range": [176, 191],
+                            "name": "program6",
+                            "center": true
+                        },
+                        {
+                            "range": [192, 207],
+                            "name": "program7",
+                            "center": true
+                        },
+                        {
+                            "range": [208, 223],
+                            "name": "program8",
+                            "center": true
+                        },
+                        {
+                            "range": [224, 239],
+                            "name": "lamp off",
+                            "center": true
+                        },
+                        {
+                            "range": [240, 255],
+                            "name": "normal",
+                            "showInMenu": false,
+                            "center": true
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "15-channel Mode",
+                    "shortName": "15ch",
+                    "channels": [
+                        "Pan",
+                        "Tilt",
+                        "P/T speed",
+                        "Color",
+                        "Gobo1",
+                        "Gobo2",
+                        "Gobo2 rot.",
+                        "Prisma",
+                        "Focus",
+                        "Shutter",
+                        "Intensity",
+                        "Frost",
+                        "Reset",
+                        "Pan fine",
+                        "Tilt fine"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Future Light",
+            "name": "SC-240",
+            "shortName": "SC-240",
+            "comment": "Scaner",
+            "physical": {
+                "dimensions": [280, 160, 470],
+                "weight": 10,
+                "power": 250
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Color": {
+                    "type": "MultiColor",
+                    "capabilities": [
+                        {
+                            "range": [0, 7],
+                            "name": "open",
+                            "center": true
+                        },
+                        {
+                            "range": [8, 15],
+                            "name": "turquoise",
+                            "color": "#40e0d0",
+                            "center": true
+                        },
+                        {
+                            "range": [16, 23],
+                            "name": "red",
+                            "color": "#ff0000",
+                            "center": true
+                        },
+                        {
+                            "range": [24, 31],
+                            "name": "cyan",
+                            "color": "#00ffff",
+                            "center": true
+                        },
+                        {
+                            "range": [32, 39],
+                            "name": "lightgreen",
+                            "color": "#90ee90",
+                            "center": true
+                        },
+                        {
+                            "range": [40, 47],
+                            "name": "magenta",
+                            "color": "#ca1f7b",
+                            "center": true
+                        },
+                        {
+                            "range": [48, 55],
+                            "name": "lightblue",
+                            "color": "#add8e6",
+                            "center": true
+                        },
+                        {
+                            "range": [56, 63],
+                            "name": "yellow",
+                            "color": "#ffff00",
+                            "center": true
+                        },
+                        {
+                            "range": [64, 71],
+                            "name": "green",
+                            "color": "#00ff00",
+                            "center": true
+                        },
+                        {
+                            "range": [72, 79],
+                            "name": "pink",
+                            "color": "#ffc0cb",
+                            "center": true
+                        },
+                        {
+                            "range": [80, 87],
+                            "name": "blue",
+                            "color": "#0000ff",
+                            "center": true
+                        },
+                        {
+                            "range": [88, 95],
+                            "name": "orange",
+                            "color": "#ff7f00",
+                            "center": true
+                        },
+                        {
+                            "range": [96, 103],
+                            "name": "UV",
+                            "center": true
+                        },
+                        {
+                            "range": [104, 111],
+                            "name": "red/blue",
+                            "center": true
+                        },
+                        {
+                            "range": [112, 119],
+                            "name": "yellow/gn",
+                            "center": true
+                        },
+                        {
+                            "range": [120, 127],
+                            "name": "blue/magenta",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 190],
+                            "name": "rainbow_fw"
+                        },
+                        {
+                            "range": [191, 192],
+                            "name": "no_rot"
+                        },
+                        {
+                            "range": [193, 255],
+                            "name": "rainbow_bw"
+                        }
+                    ]
+                },
+                "Gobo": {
+                    "type": "Gobo",
+                    "defaultValue": 30,
+                    "highlightValue": 30,
+                    "capabilities": [
+                        {
+                            "range": [0, 5],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [6, 63],
+                            "name": "nofunction"
+                        },
+                        {
+                            "range": [64, 127],
+                            "name": "strobe"
+                        },
+                        {
+                            "range": [128, 132],
+                            "name": "closed",
+                            "center": true
+                        },
+                        {
+                            "range": [133, 135],
+                            "name": "reset"
+                        },
+                        {
+                            "range": [136, 143],
+                            "name": "nofunction"
+                        },
+                        {
+                            "range": [144, 151],
+                            "name": "closed",
+                            "center": true
+                        },
+                        {
+                            "range": [152, 159],
+                            "name": "gobo1",
+                            "center": true
+                        },
+                        {
+                            "range": [160, 167],
+                            "name": "gobo2",
+                            "center": true
+                        },
+                        {
+                            "range": [168, 175],
+                            "name": "gobo3",
+                            "center": true
+                        },
+                        {
+                            "range": [176, 183],
+                            "name": "gobo4",
+                            "center": true
+                        },
+                        {
+                            "range": [184, 191],
+                            "name": "gobo5",
+                            "center": true
+                        },
+                        {
+                            "range": [192, 199],
+                            "name": "gobo6",
+                            "center": true
+                        },
+                        {
+                            "range": [200, 207],
+                            "name": "gobo7",
+                            "center": true
+                        },
+                        {
+                            "range": [208, 215],
+                            "name": "gobo8",
+                            "center": true
+                        },
+                        {
+                            "range": [216, 223],
+                            "name": "gobo9",
+                            "center": true
+                        },
+                        {
+                            "range": [224, 231],
+                            "name": "gobo10",
+                            "center": true
+                        },
+                        {
+                            "range": [232, 239],
+                            "name": "gobo11",
+                            "center": true
+                        },
+                        {
+                            "range": [240, 247],
+                            "name": "gobo12",
+                            "center": true
+                        },
+                        {
+                            "range": [248, 255],
+                            "name": "gobo13",
+                            "center": true
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "4-channel Mode",
+                    "shortName": "4ch",
+                    "channels": [
+                        "Pan",
+                        "Tilt",
+                        "Color",
+                        "Gobo"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Future Light",
+            "name": "SC-250",
+            "shortName": "SC-250",
+            "comment": "Revision 1.1E",
+            "physical": {
+                "dimensions": [280, 160, 470],
+                "weight": 10,
+                "power": 250
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Color": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 18],
+                            "name": "white",
+                            "color": "#ffffff"
+                        },
+                        {
+                            "range": [18, 35],
+                            "name": "dark blue",
+                            "color": "#00008b"
+                        },
+                        {
+                            "range": [36, 53],
+                            "name": "pink",
+                            "color": "#ffc0cb"
+                        },
+                        {
+                            "range": [54, 71],
+                            "name": "light green",
+                            "color": "#90ee90"
+                        },
+                        {
+                            "range": [72, 89],
+                            "name": "orange",
+                            "color": "#ff7f00"
+                        },
+                        {
+                            "range": [90, 107],
+                            "name": "light blue",
+                            "color": "#add8e6"
+                        },
+                        {
+                            "range": [108, 126],
+                            "name": "yellow",
+                            "color": "#ffff00"
+                        },
+                        {
+                            "range": [127, 127],
+                            "name": "cherry red"
+                        },
+                        {
+                            "range": [128, 191],
+                            "name": "rainbow CW"
+                        },
+                        {
+                            "range": [192, 255],
+                            "name": "rainbow CCW"
+                        }
+                    ]
+                },
+                "Gobo": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "open"
+                        },
+                        {
+                            "range": [16, 31],
+                            "name": "Gobo 1"
+                        },
+                        {
+                            "range": [32, 47],
+                            "name": "Gobo 2"
+                        },
+                        {
+                            "range": [48, 63],
+                            "name": "Gobo 3"
+                        },
+                        {
+                            "range": [64, 79],
+                            "name": "Gobo 4"
+                        },
+                        {
+                            "range": [80, 95],
+                            "name": "Gobo 5"
+                        },
+                        {
+                            "range": [96, 111],
+                            "name": "Gobo 6"
+                        },
+                        {
+                            "range": [112, 127],
+                            "name": "Gobo 7"
+                        },
+                        {
+                            "range": [128, 191],
+                            "name": "Rot CW"
+                        },
+                        {
+                            "range": [192, 255],
+                            "name": "Rot CCW"
+                        }
+                    ]
+                },
+                "Gobo Rot": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [16, 135],
+                            "name": "Rot CW"
+                        },
+                        {
+                            "range": [136, 255],
+                            "name": "Rot CCW"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 128],
+                            "name": "%"
+                        },
+                        {
+                            "range": [129, 131],
+                            "name": "reset"
+                        },
+                        {
+                            "range": [132, 139],
+                            "name": "open"
+                        },
+                        {
+                            "range": [140, 199],
+                            "name": "strobe"
+                        },
+                        {
+                            "range": [200, 249],
+                            "name": "random strobe"
+                        },
+                        {
+                            "range": [250, 255],
+                            "name": "open"
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "6-channel Mode",
+                    "shortName": "6ch",
+                    "channels": [
+                        "Pan",
+                        "Tilt",
+                        "Color",
+                        "Gobo",
+                        "Gobo Rot",
+                        "Intensity"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Future Light",
+            "name": "SC-380",
+            "shortName": "SC-380",
+            "physical": {
+                "dimensions": [300, 200, 600],
+                "weight": 20,
+                "power": 500
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Color": {
+                    "type": "MultiColor",
+                    "capabilities": [
+                        {
+                            "range": [0, 7],
+                            "name": "open",
+                            "center": true
+                        },
+                        {
+                            "range": [8, 15],
+                            "name": "turquoise",
+                            "color": "#40e0d0",
+                            "center": true
+                        },
+                        {
+                            "range": [16, 23],
+                            "name": "red",
+                            "color": "#ff0000",
+                            "center": true
+                        },
+                        {
+                            "range": [24, 31],
+                            "name": "cyan",
+                            "color": "#00ffff",
+                            "center": true
+                        },
+                        {
+                            "range": [32, 39],
+                            "name": "lightgreen",
+                            "color": "#90ee90",
+                            "center": true
+                        },
+                        {
+                            "range": [40, 47],
+                            "name": "magenta",
+                            "color": "#ca1f7b",
+                            "center": true
+                        },
+                        {
+                            "range": [48, 55],
+                            "name": "lightblue",
+                            "color": "#add8e6",
+                            "center": true
+                        },
+                        {
+                            "range": [56, 63],
+                            "name": "yellow",
+                            "color": "#ffff00",
+                            "center": true
+                        },
+                        {
+                            "range": [64, 71],
+                            "name": "green",
+                            "color": "#00ff00",
+                            "center": true
+                        },
+                        {
+                            "range": [72, 79],
+                            "name": "pink",
+                            "color": "#ffc0cb",
+                            "center": true
+                        },
+                        {
+                            "range": [80, 87],
+                            "name": "blue",
+                            "color": "#0000ff",
+                            "center": true
+                        },
+                        {
+                            "range": [88, 95],
+                            "name": "orange",
+                            "color": "#ff7f00",
+                            "center": true
+                        },
+                        {
+                            "range": [96, 103],
+                            "name": "UV",
+                            "center": true
+                        },
+                        {
+                            "range": [104, 111],
+                            "name": "red/blue",
+                            "center": true
+                        },
+                        {
+                            "range": [112, 119],
+                            "name": "yellow/gn",
+                            "center": true
+                        },
+                        {
+                            "range": [120, 127],
+                            "name": "blue/magenta",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 190],
+                            "name": "rainbow_fw"
+                        },
+                        {
+                            "range": [191, 192],
+                            "name": "no_rot"
+                        },
+                        {
+                            "range": [193, 255],
+                            "name": "rainbow_bw"
+                        }
+                    ]
+                },
+                "Gobo": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 23],
+                            "name": "closed",
+                            "center": true
+                        },
+                        {
+                            "range": [24, 47],
+                            "name": "gobo1",
+                            "center": true
+                        },
+                        {
+                            "range": [48, 79],
+                            "name": "gobo2",
+                            "center": true
+                        },
+                        {
+                            "range": [80, 103],
+                            "name": "gobo3",
+                            "center": true
+                        },
+                        {
+                            "range": [104, 127],
+                            "name": "gobo4",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 151],
+                            "name": "gobo5",
+                            "center": true
+                        },
+                        {
+                            "range": [152, 175],
+                            "name": "gobo6",
+                            "center": true
+                        },
+                        {
+                            "range": [176, 207],
+                            "name": "gobo7",
+                            "center": true
+                        },
+                        {
+                            "range": [208, 231],
+                            "name": "gobo8",
+                            "center": true
+                        },
+                        {
+                            "range": [232, 255],
+                            "name": "gobo9",
+                            "center": true
+                        }
+                    ]
+                },
+                "Gobo_Rot": {
+                    "type": "Gobo",
+                    "defaultValue": 192,
+                    "highlightValue": 192,
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "index"
+                        },
+                        {
+                            "range": [128, 191],
+                            "name": "rot_fw"
+                        },
+                        {
+                            "range": [192, 192],
+                            "name": "no_rot"
+                        },
+                        {
+                            "range": [193, 255],
+                            "name": "rot_bw"
+                        }
+                    ]
+                },
+                "Shutter": {
+                    "type": "Shutter",
+                    "defaultValue": 64,
+                    "highlightValue": 64,
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [1, 63],
+                            "name": "dimmer"
+                        },
+                        {
+                            "range": [64, 95],
+                            "name": "nofunction"
+                        },
+                        {
+                            "range": [96, 127],
+                            "name": "strobe"
+                        },
+                        {
+                            "range": [128, 139],
+                            "name": "reset"
+                        },
+                        {
+                            "range": [140, 159],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [160, 175],
+                            "name": "pulse_fw"
+                        },
+                        {
+                            "range": [176, 191],
+                            "name": "pulse_bw"
+                        },
+                        {
+                            "range": [192, 223],
+                            "name": "strobe_rnd"
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "nofunction"
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "6-channel Mode",
+                    "shortName": "6ch",
+                    "channels": [
+                        "Pan",
+                        "Tilt",
+                        "Color",
+                        "Gobo",
+                        "Gobo_Rot",
+                        "Shutter"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Future Light",
+            "name": "SC-740",
+            "shortName": "SC-740",
+            "physical": {
+                "dimensions": [350, 250, 1000],
+                "weight": 40,
+                "power": 1000
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Speed": {
+                    "type": "Speed",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 249],
+                            "name": "%"
+                        },
+                        {
+                            "range": [250, 255],
+                            "name": "max",
+                            "center": true
+                        }
+                    ]
+                },
+                "Lamp": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "fan_speed"
+                        },
+                        {
+                            "range": [128, 139],
+                            "name": "lamp_on",
+                            "center": true
+                        },
+                        {
+                            "range": [140, 229],
+                            "name": "nofunction"
+                        },
+                        {
+                            "range": [230, 239],
+                            "name": "lamp_off",
+                            "center": true
+                        },
+                        {
+                            "range": [240, 255],
+                            "name": "nofunction"
+                        }
+                    ]
+                },
+                "Color": {
+                    "type": "MultiColor",
+                    "capabilities": [
+                        {
+                            "range": [0, 7],
+                            "name": "open",
+                            "center": true
+                        },
+                        {
+                            "range": [8, 15],
+                            "name": "turquoise",
+                            "color": "#40e0d0",
+                            "center": true
+                        },
+                        {
+                            "range": [16, 23],
+                            "name": "red",
+                            "color": "#ff0000",
+                            "center": true
+                        },
+                        {
+                            "range": [24, 31],
+                            "name": "cyan",
+                            "color": "#00ffff",
+                            "center": true
+                        },
+                        {
+                            "range": [32, 39],
+                            "name": "lightgreen",
+                            "color": "#90ee90",
+                            "center": true
+                        },
+                        {
+                            "range": [40, 47],
+                            "name": "magenta",
+                            "color": "#ca1f7b",
+                            "center": true
+                        },
+                        {
+                            "range": [48, 55],
+                            "name": "lightblue",
+                            "color": "#add8e6",
+                            "center": true
+                        },
+                        {
+                            "range": [56, 63],
+                            "name": "yellow",
+                            "color": "#ffff00",
+                            "center": true
+                        },
+                        {
+                            "range": [64, 71],
+                            "name": "green",
+                            "color": "#00ff00",
+                            "center": true
+                        },
+                        {
+                            "range": [72, 79],
+                            "name": "pink",
+                            "color": "#ffc0cb",
+                            "center": true
+                        },
+                        {
+                            "range": [80, 87],
+                            "name": "blue",
+                            "color": "#0000ff",
+                            "center": true
+                        },
+                        {
+                            "range": [88, 95],
+                            "name": "orange",
+                            "color": "#ff7f00",
+                            "center": true
+                        },
+                        {
+                            "range": [96, 103],
+                            "name": "UV",
+                            "center": true
+                        },
+                        {
+                            "range": [104, 111],
+                            "name": "red/blue",
+                            "center": true
+                        },
+                        {
+                            "range": [112, 119],
+                            "name": "yellow/gn",
+                            "center": true
+                        },
+                        {
+                            "range": [120, 127],
+                            "name": "blue/magenta",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 190],
+                            "name": "rainbow_fw"
+                        },
+                        {
+                            "range": [191, 192],
+                            "name": "no_rot"
+                        },
+                        {
+                            "range": [193, 255],
+                            "name": "rainbow_bw"
+                        }
+                    ]
+                },
+                "Gobo": {
+                    "type": "Gobo",
+                    "defaultValue": 50,
+                    "highlightValue": 50,
+                    "capabilities": [
+                        {
+                            "range": [0, 45],
+                            "name": "dimmer"
+                        },
+                        {
+                            "range": [46, 63],
+                            "name": "open"
+                        },
+                        {
+                            "range": [64, 127],
+                            "name": "strobe"
+                        },
+                        {
+                            "range": [128, 140],
+                            "name": "closed",
+                            "center": true
+                        },
+                        {
+                            "range": [141, 153],
+                            "name": "gobo1",
+                            "center": true
+                        },
+                        {
+                            "range": [154, 166],
+                            "name": "gobo2",
+                            "center": true
+                        },
+                        {
+                            "range": [167, 179],
+                            "name": "gobo3",
+                            "center": true
+                        },
+                        {
+                            "range": [180, 191],
+                            "name": "gobo4",
+                            "center": true
+                        },
+                        {
+                            "range": [192, 204],
+                            "name": "gobo5",
+                            "center": true
+                        },
+                        {
+                            "range": [205, 217],
+                            "name": "gobo6",
+                            "center": true
+                        },
+                        {
+                            "range": [218, 230],
+                            "name": "gobo7",
+                            "center": true
+                        },
+                        {
+                            "range": [231, 243],
+                            "name": "gobo8",
+                            "center": true
+                        },
+                        {
+                            "range": [244, 255],
+                            "name": "gobo9",
+                            "center": true
+                        }
+                    ]
+                },
+                "Effect": {
+                    "type": "Effect",
+                    "defaultValue": 80,
+                    "highlightValue": 80,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [64, 95],
+                            "name": "open",
+                            "center": true
+                        },
+                        {
+                            "range": [96, 127],
+                            "name": "frost",
+                            "color": "#edf5dd"
+                        },
+                        {
+                            "range": [128, 159],
+                            "name": "prism",
+                            "center": true
+                        },
+                        {
+                            "range": [160, 191],
+                            "name": "3200k",
+                            "center": true
+                        },
+                        {
+                            "range": [192, 223],
+                            "name": "5600k",
+                            "center": true
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "UV",
+                            "center": true
+                        }
+                    ]
+                },
+                "Rot.Gobo": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [32, 63],
+                            "name": "gobo1"
+                        },
+                        {
+                            "range": [64, 95],
+                            "name": "gobo2"
+                        },
+                        {
+                            "range": [96, 127],
+                            "name": "gobo3"
+                        },
+                        {
+                            "range": [128, 159],
+                            "name": "gobo4"
+                        },
+                        {
+                            "range": [160, 191],
+                            "name": "gobo5"
+                        },
+                        {
+                            "range": [192, 223],
+                            "name": "gobo6"
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "speed"
+                        },
+                        {
+                            "range": [0, 31],
+                            "name": "open"
+                        }
+                    ]
+                },
+                "Index": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "index"
+                        },
+                        {
+                            "range": [128, 191],
+                            "name": "rot_fw"
+                        },
+                        {
+                            "range": [192, 192],
+                            "name": "no_rot"
+                        },
+                        {
+                            "range": [193, 255],
+                            "name": "rot_bw"
+                        }
+                    ]
+                },
+                "Iris": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 179],
+                            "name": "dimmer"
+                        },
+                        {
+                            "range": [180, 191],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [192, 223],
+                            "name": "pulse_cl"
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "pulse_op"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "13-channel Mode",
+                    "shortName": "13ch",
+                    "channels": [
+                        "Pan",
+                        "Tilt",
+                        "Pan fine",
+                        "Tilt fine",
+                        "Speed",
+                        "Lamp",
+                        "Color",
+                        "Gobo",
+                        "Effect",
+                        null,
+                        "Rot.Gobo",
+                        "Index",
+                        "Iris"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Future Light",
+            "name": "SC-780",
+            "shortName": "SC-780",
+            "physical": {
+                "dimensions": [350, 250, 1000],
+                "weight": 40,
+                "power": 1000
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Speed": {
+                    "type": "Speed",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 249],
+                            "name": "%"
+                        },
+                        {
+                            "range": [250, 255],
+                            "name": "max",
+                            "center": true
+                        }
+                    ]
+                },
+                "Lamp": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "fan_speed"
+                        },
+                        {
+                            "range": [128, 139],
+                            "name": "lamp_on",
+                            "center": true
+                        },
+                        {
+                            "range": [140, 229],
+                            "name": "nofunction"
+                        },
+                        {
+                            "range": [230, 239],
+                            "name": "lamp_off",
+                            "center": true
+                        },
+                        {
+                            "range": [240, 255],
+                            "name": "nofunction"
+                        }
+                    ]
+                },
+                "Color": {
+                    "type": "MultiColor",
+                    "capabilities": [
+                        {
+                            "range": [0, 7],
+                            "name": "open",
+                            "center": true
+                        },
+                        {
+                            "range": [8, 15],
+                            "name": "turquoise",
+                            "color": "#40e0d0",
+                            "center": true
+                        },
+                        {
+                            "range": [16, 23],
+                            "name": "red",
+                            "color": "#ff0000",
+                            "center": true
+                        },
+                        {
+                            "range": [24, 31],
+                            "name": "cyan",
+                            "color": "#00ffff",
+                            "center": true
+                        },
+                        {
+                            "range": [32, 39],
+                            "name": "lightgreen",
+                            "color": "#90ee90",
+                            "center": true
+                        },
+                        {
+                            "range": [40, 47],
+                            "name": "magenta",
+                            "color": "#ca1f7b",
+                            "center": true
+                        },
+                        {
+                            "range": [48, 55],
+                            "name": "lightblue",
+                            "color": "#add8e6",
+                            "center": true
+                        },
+                        {
+                            "range": [56, 63],
+                            "name": "yellow",
+                            "color": "#ffff00",
+                            "center": true
+                        },
+                        {
+                            "range": [64, 71],
+                            "name": "green",
+                            "color": "#00ff00",
+                            "center": true
+                        },
+                        {
+                            "range": [72, 79],
+                            "name": "pink",
+                            "color": "#ffc0cb",
+                            "center": true
+                        },
+                        {
+                            "range": [80, 87],
+                            "name": "blue",
+                            "color": "#0000ff",
+                            "center": true
+                        },
+                        {
+                            "range": [88, 95],
+                            "name": "orange",
+                            "color": "#ff7f00",
+                            "center": true
+                        },
+                        {
+                            "range": [96, 103],
+                            "name": "UV",
+                            "center": true
+                        },
+                        {
+                            "range": [104, 111],
+                            "name": "red/blue",
+                            "center": true
+                        },
+                        {
+                            "range": [112, 119],
+                            "name": "yellow/gn",
+                            "center": true
+                        },
+                        {
+                            "range": [120, 127],
+                            "name": "blue/magenta",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 190],
+                            "name": "rainbow_fw"
+                        },
+                        {
+                            "range": [191, 192],
+                            "name": "no_rot"
+                        },
+                        {
+                            "range": [193, 255],
+                            "name": "rainbow_bw"
+                        }
+                    ]
+                },
+                "Gobo": {
+                    "type": "Gobo",
+                    "defaultValue": 50,
+                    "highlightValue": 50,
+                    "capabilities": [
+                        {
+                            "range": [0, 45],
+                            "name": "dimmer"
+                        },
+                        {
+                            "range": [46, 63],
+                            "name": "open"
+                        },
+                        {
+                            "range": [64, 127],
+                            "name": "strobe"
+                        },
+                        {
+                            "range": [128, 140],
+                            "name": "closed",
+                            "center": true
+                        },
+                        {
+                            "range": [141, 153],
+                            "name": "gobo1",
+                            "center": true
+                        },
+                        {
+                            "range": [154, 166],
+                            "name": "gobo2",
+                            "center": true
+                        },
+                        {
+                            "range": [167, 179],
+                            "name": "gobo3",
+                            "center": true
+                        },
+                        {
+                            "range": [180, 191],
+                            "name": "gobo4",
+                            "center": true
+                        },
+                        {
+                            "range": [192, 204],
+                            "name": "gobo5",
+                            "center": true
+                        },
+                        {
+                            "range": [205, 217],
+                            "name": "gobo6",
+                            "center": true
+                        },
+                        {
+                            "range": [218, 230],
+                            "name": "gobo7",
+                            "center": true
+                        },
+                        {
+                            "range": [231, 243],
+                            "name": "gobo8",
+                            "center": true
+                        },
+                        {
+                            "range": [244, 255],
+                            "name": "gobo9",
+                            "center": true
+                        }
+                    ]
+                },
+                "Effect": {
+                    "type": "Effect",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 95],
+                            "name": "open",
+                            "center": true
+                        },
+                        {
+                            "range": [96, 127],
+                            "name": "frost",
+                            "color": "#edf5dd"
+                        },
+                        {
+                            "range": [128, 159],
+                            "name": "prism",
+                            "center": true
+                        },
+                        {
+                            "range": [160, 191],
+                            "name": "3200k",
+                            "center": true
+                        },
+                        {
+                            "range": [192, 223],
+                            "name": "5600k",
+                            "center": true
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "UV",
+                            "center": true
+                        }
+                    ]
+                },
+                "Rot.Gobo": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [32, 63],
+                            "name": "gobo1"
+                        },
+                        {
+                            "range": [64, 95],
+                            "name": "gobo2"
+                        },
+                        {
+                            "range": [96, 127],
+                            "name": "gobo3"
+                        },
+                        {
+                            "range": [128, 159],
+                            "name": "gobo4"
+                        },
+                        {
+                            "range": [160, 191],
+                            "name": "gobo5"
+                        },
+                        {
+                            "range": [192, 223],
+                            "name": "gobo6"
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "speed"
+                        },
+                        {
+                            "range": [0, 31],
+                            "name": "open"
+                        }
+                    ]
+                },
+                "Index": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "index"
+                        },
+                        {
+                            "range": [128, 191],
+                            "name": "rot_fw"
+                        },
+                        {
+                            "range": [192, 192],
+                            "name": "no_rot"
+                        },
+                        {
+                            "range": [193, 255],
+                            "name": "rot_bw"
+                        }
+                    ]
+                },
+                "Iris": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 179],
+                            "name": "dimmer"
+                        },
+                        {
+                            "range": [180, 191],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [192, 223],
+                            "name": "pulse_cl"
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "pulse_op"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "13-channel Mode",
+                    "shortName": "13ch",
+                    "channels": [
+                        "Pan",
+                        "Tilt",
+                        "Pan fine",
+                        "Tilt fine",
+                        "Speed",
+                        "Lamp",
+                        "Color",
+                        "Gobo",
+                        "Effect",
+                        null,
+                        "Rot.Gobo",
+                        "Index",
+                        "Iris"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Future Light",
+            "name": "SC-980",
+            "shortName": "SC-980",
+            "physical": {
+                "dimensions": [410, 230, 1060],
+                "weight": 57,
+                "power": 1500
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Speed": {
+                    "type": "Speed",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 249],
+                            "name": "%"
+                        },
+                        {
+                            "range": [250, 255],
+                            "name": "max",
+                            "center": true
+                        }
+                    ]
+                },
+                "Lamp": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "fan_speed"
+                        },
+                        {
+                            "range": [128, 139],
+                            "name": "lamp_on",
+                            "center": true
+                        },
+                        {
+                            "range": [140, 229],
+                            "name": "nofunction"
+                        },
+                        {
+                            "range": [230, 239],
+                            "name": "lamp_off",
+                            "center": true
+                        },
+                        {
+                            "range": [240, 255],
+                            "name": "nofunction"
+                        }
+                    ]
+                },
+                "Color1": {
+                    "type": "MultiColor",
+                    "capabilities": [
+                        {
+                            "range": [0, 13],
+                            "name": "open"
+                        },
+                        {
+                            "range": [14, 27],
+                            "name": "red",
+                            "color": "#ff0000",
+                            "center": true
+                        },
+                        {
+                            "range": [28, 42],
+                            "name": "blue",
+                            "color": "#0000ff",
+                            "center": true
+                        },
+                        {
+                            "range": [43, 56],
+                            "name": "green",
+                            "color": "#00ff00",
+                            "center": true
+                        },
+                        {
+                            "range": [57, 70],
+                            "name": "yellow",
+                            "color": "#ffff00",
+                            "center": true
+                        },
+                        {
+                            "range": [71, 84],
+                            "name": "magenta",
+                            "color": "#ca1f7b",
+                            "center": true
+                        },
+                        {
+                            "range": [85, 99],
+                            "name": "cyan",
+                            "color": "#00ffff",
+                            "center": true
+                        },
+                        {
+                            "range": [100, 113],
+                            "name": "turqouis",
+                            "center": true
+                        },
+                        {
+                            "range": [114, 126],
+                            "name": "orange",
+                            "color": "#ff7f00",
+                            "center": true
+                        },
+                        {
+                            "range": [127, 127],
+                            "name": "white",
+                            "color": "#ffffff",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 189],
+                            "name": "rainbow_fw"
+                        },
+                        {
+                            "range": [190, 193],
+                            "name": "no_rot",
+                            "center": true
+                        },
+                        {
+                            "range": [194, 255],
+                            "name": "rainbow_bw"
+                        }
+                    ]
+                },
+                "Color2": {
+                    "type": "MultiColor",
+                    "capabilities": [
+                        {
+                            "range": [0, 13],
+                            "name": "open"
+                        },
+                        {
+                            "range": [14, 27],
+                            "name": "pink",
+                            "color": "#ffc0cb",
+                            "center": true
+                        },
+                        {
+                            "range": [28, 42],
+                            "name": "yellow/gn",
+                            "center": true
+                        },
+                        {
+                            "range": [43, 56],
+                            "name": "lightblue",
+                            "color": "#add8e6",
+                            "center": true
+                        },
+                        {
+                            "range": [57, 70],
+                            "name": "yellow",
+                            "color": "#ffff00",
+                            "center": true
+                        },
+                        {
+                            "range": [71, 84],
+                            "name": "magenta",
+                            "color": "#ca1f7b",
+                            "center": true
+                        },
+                        {
+                            "range": [85, 99],
+                            "name": "5600k",
+                            "center": true
+                        },
+                        {
+                            "range": [100, 113],
+                            "name": "3200k",
+                            "center": true
+                        },
+                        {
+                            "range": [114, 126],
+                            "name": "UV",
+                            "center": true
+                        },
+                        {
+                            "range": [127, 127],
+                            "name": "white",
+                            "color": "#ffffff",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 255],
+                            "name": "macro_ch7",
+                            "center": true
+                        }
+                    ]
+                },
+                "Effect": {
+                    "type": "Effect",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 95],
+                            "name": "open"
+                        },
+                        {
+                            "range": [96, 127],
+                            "name": "frost",
+                            "color": "#edf5dd"
+                        },
+                        {
+                            "range": [128, 159],
+                            "name": "prism3_rot",
+                            "center": true
+                        },
+                        {
+                            "range": [160, 191],
+                            "name": "prism5_rot",
+                            "center": true
+                        },
+                        {
+                            "range": [192, 223],
+                            "name": "prism3D_rot",
+                            "center": true
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "index_3D"
+                        }
+                    ]
+                },
+                "Gobo": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 31],
+                            "name": "open",
+                            "center": true
+                        },
+                        {
+                            "range": [32, 63],
+                            "name": "gobo1",
+                            "center": true
+                        },
+                        {
+                            "range": [64, 95],
+                            "name": "gobo2",
+                            "center": true
+                        },
+                        {
+                            "range": [96, 127],
+                            "name": "gobo3",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 159],
+                            "name": "gobo4",
+                            "center": true
+                        },
+                        {
+                            "range": [160, 191],
+                            "name": "gobo5",
+                            "center": true
+                        },
+                        {
+                            "range": [192, 255],
+                            "name": "gobo_rot"
+                        }
+                    ]
+                },
+                "Gobo_Rot": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 31],
+                            "name": "open",
+                            "center": true
+                        },
+                        {
+                            "range": [32, 63],
+                            "name": "gobo1",
+                            "center": true
+                        },
+                        {
+                            "range": [64, 95],
+                            "name": "gobo2",
+                            "center": true
+                        },
+                        {
+                            "range": [96, 127],
+                            "name": "gobo3",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 159],
+                            "name": "gobo4",
+                            "center": true
+                        },
+                        {
+                            "range": [192, 255],
+                            "name": "nofunction"
+                        }
+                    ]
+                },
+                "Index": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "index"
+                        },
+                        {
+                            "range": [129, 190],
+                            "name": "rot_fw"
+                        },
+                        {
+                            "range": [191, 192],
+                            "name": "no_rot"
+                        },
+                        {
+                            "range": [193, 255],
+                            "name": "rot_bw"
+                        }
+                    ]
+                },
+                "Iris": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 179],
+                            "name": "open"
+                        },
+                        {
+                            "range": [180, 191],
+                            "name": "closed",
+                            "center": true
+                        },
+                        {
+                            "range": [192, 223],
+                            "name": "pulse_cl"
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "pulse_op"
+                        }
+                    ]
+                },
+                "Zoom": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Shutter": {
+                    "type": "Shutter",
+                    "defaultValue": 45,
+                    "highlightValue": 45,
+                    "capabilities": [
+                        {
+                            "range": [0, 31],
+                            "name": "closed",
+                            "center": true
+                        },
+                        {
+                            "range": [32, 63],
+                            "name": "open",
+                            "center": true
+                        },
+                        {
+                            "range": [64, 95],
+                            "name": "strobe"
+                        },
+                        {
+                            "range": [96, 127],
+                            "name": "open",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 159],
+                            "name": "pulse",
+                            "center": true
+                        },
+                        {
+                            "range": [160, 191],
+                            "name": "open",
+                            "center": true
+                        },
+                        {
+                            "range": [192, 223],
+                            "name": "strobe_rnd",
+                            "center": true
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "open",
+                            "center": true
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "16-channel Mode",
+                    "shortName": "16ch",
+                    "channels": [
+                        "Pan",
+                        "Tilt",
+                        "Pan fine",
+                        "Tilt fine",
+                        "Speed",
+                        "Lamp",
+                        "Color1",
+                        "Color2",
+                        "Effect",
+                        "Gobo",
+                        "Gobo_Rot",
+                        "Index",
+                        "Iris",
+                        "Zoom",
+                        "Shutter",
+                        "Intensity"
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/fixtures/imports/ecue-MainLibrary/G-LEC.json
+++ b/fixtures/imports/ecue-MainLibrary/G-LEC.json
@@ -1,0 +1,60 @@
+{
+    "manufacturers": {
+        "G-LEC": {
+            "name": "G-LEC"
+        }
+    },
+    "fixtures": [
+        {
+            "manufacturer": "G-LEC",
+            "name": "G-Lec Lite",
+            "shortName": "G-Lec lite",
+            "comment": "no technical data found.",
+            "physical": {
+                "dimensions": [100, 100, 100]
+            },
+            "availableChannels": {
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                }
+            },
+            "modes": [
+                {
+                    "name": "4-channel Mode",
+                    "shortName": "4ch",
+                    "channels": [
+                        "Intensity",
+                        "Red",
+                        "Green",
+                        "Blue"
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/fixtures/imports/ecue-MainLibrary/GLP.json
+++ b/fixtures/imports/ecue-MainLibrary/GLP.json
@@ -1,0 +1,7621 @@
+{
+    "manufacturers": {
+        "GLP": {
+            "name": "GLP",
+            "website": "www.glp.de"
+        }
+    },
+    "fixtures": [
+        {
+            "manufacturer": "GLP",
+            "name": "Impression normale mode 14 Ch",
+            "shortName": "impression",
+            "comment": "ab Software 1.50/27",
+            "physical": {
+                "dimensions": [370, 370, 370],
+                "weight": 8,
+                "power": 350
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "_Color Preset": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 7],
+                            "name": "open"
+                        },
+                        {
+                            "range": [8, 15],
+                            "name": "red",
+                            "color": "#ff0000"
+                        },
+                        {
+                            "range": [16, 23],
+                            "name": "amber",
+                            "color": "#ffbf00"
+                        },
+                        {
+                            "range": [24, 31],
+                            "name": "yellow warm"
+                        },
+                        {
+                            "range": [32, 39],
+                            "name": "yellow",
+                            "color": "#ffff00"
+                        },
+                        {
+                            "range": [40, 47],
+                            "name": "green",
+                            "color": "#00ff00"
+                        },
+                        {
+                            "range": [48, 55],
+                            "name": "turquoise",
+                            "color": "#40e0d0"
+                        },
+                        {
+                            "range": [56, 63],
+                            "name": "cyan",
+                            "color": "#00ffff"
+                        },
+                        {
+                            "range": [64, 71],
+                            "name": "blue",
+                            "color": "#0000ff"
+                        },
+                        {
+                            "range": [72, 79],
+                            "name": "lavender",
+                            "color": "#b57edc"
+                        },
+                        {
+                            "range": [80, 87],
+                            "name": "mauve",
+                            "color": "#e0b0ff"
+                        },
+                        {
+                            "range": [88, 95],
+                            "name": "magenta",
+                            "color": "#ca1f7b"
+                        },
+                        {
+                            "range": [96, 103],
+                            "name": "pink",
+                            "color": "#ffc0cb"
+                        },
+                        {
+                            "range": [104, 111],
+                            "name": "white 3200K"
+                        },
+                        {
+                            "range": [112, 119],
+                            "name": "white 5600K"
+                        },
+                        {
+                            "range": [120, 127],
+                            "name": "white 7200K"
+                        },
+                        {
+                            "range": [128, 128],
+                            "name": "rainbow stop"
+                        },
+                        {
+                            "range": [129, 223],
+                            "name": "rainbow s-f"
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "rainbow random"
+                        }
+                    ]
+                },
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Shutter": {
+                    "type": "Shutter",
+                    "highlightValue": 80,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [16, 47],
+                            "name": "pulse random"
+                        },
+                        {
+                            "range": [48, 79],
+                            "name": "dim shut"
+                        },
+                        {
+                            "range": [80, 111],
+                            "name": "shut dim"
+                        },
+                        {
+                            "range": [112, 143],
+                            "name": "dim dim"
+                        },
+                        {
+                            "range": [144, 0],
+                            "name": "2-10Hz"
+                        },
+                        {
+                            "range": [240, 255],
+                            "name": "open"
+                        }
+                    ]
+                },
+                "Dimmer": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "_CTC": {
+                    "type": "MultiColor",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 6],
+                            "name": "no correction"
+                        },
+                        {
+                            "range": [7, 255],
+                            "name": "3200K-7200K"
+                        }
+                    ]
+                },
+                "Special": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "Max Power Mode"
+                        },
+                        {
+                            "range": [16, 111],
+                            "name": "White-Mode"
+                        },
+                        {
+                            "range": [112, 127],
+                            "name": "color cha c+1"
+                        },
+                        {
+                            "range": [128, 223],
+                            "name": "color cha c+2"
+                        },
+                        {
+                            "range": [224, 249],
+                            "name": "fan quite"
+                        },
+                        {
+                            "range": [250, 255],
+                            "name": "reset"
+                        }
+                    ]
+                },
+                "Movement": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "no movement"
+                        },
+                        {
+                            "range": [1, 31],
+                            "name": "pan"
+                        },
+                        {
+                            "range": [32, 63],
+                            "name": "tilt"
+                        },
+                        {
+                            "range": [64, 95],
+                            "name": "pan/tilt"
+                        },
+                        {
+                            "range": [96, 127],
+                            "name": "pan/tilt (inver"
+                        },
+                        {
+                            "range": [128, 0],
+                            "name": "circle"
+                        },
+                        {
+                            "range": [160, 0],
+                            "name": "circle (invers)"
+                        },
+                        {
+                            "range": [192, 223],
+                            "name": "horizontal8"
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "random"
+                        }
+                    ]
+                },
+                "P/T speed": {
+                    "type": "Speed",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "realtime"
+                        },
+                        {
+                            "range": [16, 255],
+                            "name": "speed s-f"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "17-channel Mode",
+                    "shortName": "17ch",
+                    "channels": [
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "_Color Preset",
+                        "Red",
+                        "Green",
+                        "Blue",
+                        "Shutter",
+                        "Dimmer",
+                        "_CTC",
+                        "Special",
+                        "Movement",
+                        null,
+                        null,
+                        null,
+                        "P/T speed"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "GLP",
+            "name": "Impression XL normale mode 14 Ch",
+            "shortName": "impression XL",
+            "comment": "ab Software 1.03/03",
+            "physical": {
+                "dimensions": [550, 550, 550],
+                "weight": 22,
+                "power": 1200
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "_Color Preset": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 7],
+                            "name": "open"
+                        },
+                        {
+                            "range": [8, 15],
+                            "name": "red",
+                            "color": "#ff0000"
+                        },
+                        {
+                            "range": [16, 23],
+                            "name": "amber",
+                            "color": "#ffbf00"
+                        },
+                        {
+                            "range": [24, 31],
+                            "name": "yellow warm"
+                        },
+                        {
+                            "range": [32, 39],
+                            "name": "yellow",
+                            "color": "#ffff00"
+                        },
+                        {
+                            "range": [40, 47],
+                            "name": "green",
+                            "color": "#00ff00"
+                        },
+                        {
+                            "range": [48, 55],
+                            "name": "turquoise",
+                            "color": "#40e0d0"
+                        },
+                        {
+                            "range": [56, 63],
+                            "name": "cyan",
+                            "color": "#00ffff"
+                        },
+                        {
+                            "range": [64, 71],
+                            "name": "blue",
+                            "color": "#0000ff"
+                        },
+                        {
+                            "range": [72, 79],
+                            "name": "lavender",
+                            "color": "#b57edc"
+                        },
+                        {
+                            "range": [80, 87],
+                            "name": "mauve",
+                            "color": "#e0b0ff"
+                        },
+                        {
+                            "range": [88, 95],
+                            "name": "magenta",
+                            "color": "#ca1f7b"
+                        },
+                        {
+                            "range": [96, 103],
+                            "name": "pink",
+                            "color": "#ffc0cb"
+                        },
+                        {
+                            "range": [104, 111],
+                            "name": "white 3200K"
+                        },
+                        {
+                            "range": [112, 119],
+                            "name": "white 5600K"
+                        },
+                        {
+                            "range": [120, 127],
+                            "name": "white 7200K"
+                        },
+                        {
+                            "range": [128, 128],
+                            "name": "rainbow stop"
+                        },
+                        {
+                            "range": [129, 223],
+                            "name": "rainbow s-f"
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "rainbow random"
+                        }
+                    ]
+                },
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Shutter": {
+                    "type": "Shutter",
+                    "highlightValue": 80,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [16, 47],
+                            "name": "pulse random"
+                        },
+                        {
+                            "range": [48, 79],
+                            "name": "dim shut"
+                        },
+                        {
+                            "range": [80, 111],
+                            "name": "shut dim"
+                        },
+                        {
+                            "range": [112, 143],
+                            "name": "dim dim"
+                        },
+                        {
+                            "range": [144, 0],
+                            "name": "2-10Hz"
+                        },
+                        {
+                            "range": [200, 239],
+                            "name": "Strobe effect s"
+                        },
+                        {
+                            "range": [240, 255],
+                            "name": "open"
+                        }
+                    ]
+                },
+                "Dimmer": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "_CTC": {
+                    "type": "MultiColor",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "no correction"
+                        },
+                        {
+                            "range": [1, 255],
+                            "name": "3200K-7200K"
+                        }
+                    ]
+                },
+                "Special": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "Max Power Mode"
+                        },
+                        {
+                            "range": [16, 111],
+                            "name": "White-Mode"
+                        },
+                        {
+                            "range": [112, 127],
+                            "name": "color cha c+1"
+                        },
+                        {
+                            "range": [128, 223],
+                            "name": "color cha c+2"
+                        },
+                        {
+                            "range": [224, 249],
+                            "name": "fan quite"
+                        },
+                        {
+                            "range": [250, 255],
+                            "name": "reset"
+                        }
+                    ]
+                },
+                "Movement": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "no movement"
+                        },
+                        {
+                            "range": [1, 31],
+                            "name": "pan"
+                        },
+                        {
+                            "range": [32, 63],
+                            "name": "tilt"
+                        },
+                        {
+                            "range": [64, 95],
+                            "name": "pan/tilt"
+                        },
+                        {
+                            "range": [96, 127],
+                            "name": "pan/tilt (inver"
+                        },
+                        {
+                            "range": [128, 0],
+                            "name": "circle"
+                        },
+                        {
+                            "range": [160, 0],
+                            "name": "circle (invers)"
+                        },
+                        {
+                            "range": [192, 223],
+                            "name": "horizontal8"
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "random"
+                        }
+                    ]
+                },
+                "P/T speed": {
+                    "type": "Speed",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "realtime"
+                        },
+                        {
+                            "range": [16, 255],
+                            "name": "speed s-f"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "17-channel Mode",
+                    "shortName": "17ch",
+                    "channels": [
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "_Color Preset",
+                        "Red",
+                        "Green",
+                        "Blue",
+                        "Shutter",
+                        "Dimmer",
+                        "_CTC",
+                        "Special",
+                        "Movement",
+                        null,
+                        null,
+                        null,
+                        "P/T speed"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "GLP",
+            "name": "Joy150",
+            "shortName": "Joy150",
+            "physical": {
+                "dimensions": [300, 200, 600],
+                "weight": 12,
+                "power": 200
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Color": {
+                    "type": "MultiColor",
+                    "capabilities": [
+                        {
+                            "range": [0, 3],
+                            "name": "open"
+                        },
+                        {
+                            "range": [8, 11],
+                            "name": "color1",
+                            "center": true
+                        },
+                        {
+                            "range": [16, 19],
+                            "name": "color2",
+                            "center": true
+                        },
+                        {
+                            "range": [24, 27],
+                            "name": "color3",
+                            "center": true
+                        },
+                        {
+                            "range": [32, 35],
+                            "name": "color4",
+                            "center": true
+                        },
+                        {
+                            "range": [48, 51],
+                            "name": "color6",
+                            "center": true
+                        },
+                        {
+                            "range": [56, 59],
+                            "name": "color7",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 253],
+                            "name": "rot.color"
+                        },
+                        {
+                            "range": [254, 254],
+                            "name": "audio_ch_sl"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "audio_ch_ff"
+                        }
+                    ]
+                },
+                "Gobo": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "Gobo1"
+                        },
+                        {
+                            "range": [16, 31],
+                            "name": "Gobo2"
+                        },
+                        {
+                            "range": [32, 47],
+                            "name": "Gobo3"
+                        },
+                        {
+                            "range": [48, 63],
+                            "name": "Gobo4"
+                        },
+                        {
+                            "range": [64, 79],
+                            "name": "Gobo5"
+                        },
+                        {
+                            "range": [80, 96],
+                            "name": "Gobo6"
+                        },
+                        {
+                            "range": [96, 127],
+                            "name": "Gobo7"
+                        },
+                        {
+                            "range": [128, 253],
+                            "name": "rot.gobo"
+                        },
+                        {
+                            "range": [254, 254],
+                            "name": "audio_ch_sl"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "audio_ch_ff"
+                        }
+                    ]
+                },
+                "Shutter": {
+                    "type": "Shutter",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [16, 239],
+                            "name": "frequenze"
+                        },
+                        {
+                            "range": [240, 255],
+                            "name": "open"
+                        }
+                    ]
+                },
+                "Gobo_Rot": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "position"
+                        },
+                        {
+                            "range": [128, 253],
+                            "name": "rotation"
+                        },
+                        {
+                            "range": [254, 254],
+                            "name": "audio_ch_sl"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "audio_ch_ff"
+                        }
+                    ]
+                },
+                "Special": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "none"
+                        },
+                        {
+                            "range": [16, 31],
+                            "name": "wipe_10"
+                        },
+                        {
+                            "range": [32, 47],
+                            "name": "wipe_20"
+                        },
+                        {
+                            "range": [48, 63],
+                            "name": "wipe_30"
+                        },
+                        {
+                            "range": [64, 79],
+                            "name": "chaser_c+c1"
+                        },
+                        {
+                            "range": [80, 95],
+                            "name": "chaser_c+c2"
+                        },
+                        {
+                            "range": [96, 127],
+                            "name": "audio_move"
+                        },
+                        {
+                            "range": [192, 207],
+                            "name": "engage_program_"
+                        },
+                        {
+                            "range": [208, 223],
+                            "name": "program_receive"
+                        },
+                        {
+                            "range": [224, 239],
+                            "name": "program_send"
+                        },
+                        {
+                            "range": [240, 249],
+                            "name": "nofunction"
+                        },
+                        {
+                            "range": [250, 255],
+                            "name": "reset"
+                        }
+                    ]
+                },
+                "Speed": {
+                    "type": "Speed",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "relative"
+                        },
+                        {
+                            "range": [16, 255],
+                            "name": "speed"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "13-channel Mode",
+                    "shortName": "13ch",
+                    "channels": [
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "Color",
+                        "Gobo",
+                        "Shutter",
+                        "Gobo_Rot",
+                        "Special",
+                        "Speed"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "GLP",
+            "name": "Joy300",
+            "shortName": "Joy300",
+            "physical": {
+                "dimensions": [300, 200, 600],
+                "weight": 14,
+                "power": 400
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Color": {
+                    "type": "MultiColor",
+                    "capabilities": [
+                        {
+                            "range": [0, 3],
+                            "name": "open"
+                        },
+                        {
+                            "range": [8, 11],
+                            "name": "color1",
+                            "center": true
+                        },
+                        {
+                            "range": [16, 19],
+                            "name": "color2",
+                            "center": true
+                        },
+                        {
+                            "range": [24, 27],
+                            "name": "color3",
+                            "center": true
+                        },
+                        {
+                            "range": [32, 35],
+                            "name": "color4",
+                            "center": true
+                        },
+                        {
+                            "range": [48, 51],
+                            "name": "color6",
+                            "center": true
+                        },
+                        {
+                            "range": [56, 59],
+                            "name": "color7",
+                            "center": true
+                        },
+                        {
+                            "range": [64, 67],
+                            "name": "mix_color1",
+                            "center": true
+                        },
+                        {
+                            "range": [68, 71],
+                            "name": "mix_color2",
+                            "center": true
+                        },
+                        {
+                            "range": [72, 75],
+                            "name": "mix_color3",
+                            "center": true
+                        },
+                        {
+                            "range": [76, 79],
+                            "name": "mix_color4",
+                            "center": true
+                        },
+                        {
+                            "range": [80, 83],
+                            "name": "mix_color5",
+                            "center": true
+                        },
+                        {
+                            "range": [84, 87],
+                            "name": "mix_color6",
+                            "center": true
+                        },
+                        {
+                            "range": [88, 91],
+                            "name": "mix_color7",
+                            "center": true
+                        },
+                        {
+                            "range": [92, 95],
+                            "name": "mix_color8",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 253],
+                            "name": "rot_color"
+                        },
+                        {
+                            "range": [254, 254],
+                            "name": "audio_ch_sl"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "audio_ch_ff"
+                        }
+                    ]
+                },
+                "Gobo": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "Gobo1"
+                        },
+                        {
+                            "range": [16, 31],
+                            "name": "Gobo2"
+                        },
+                        {
+                            "range": [32, 47],
+                            "name": "Gobo3"
+                        },
+                        {
+                            "range": [48, 63],
+                            "name": "Gobo4"
+                        },
+                        {
+                            "range": [64, 79],
+                            "name": "Gobo5"
+                        },
+                        {
+                            "range": [80, 96],
+                            "name": "Gobo6"
+                        },
+                        {
+                            "range": [96, 127],
+                            "name": "Gobo7"
+                        },
+                        {
+                            "range": [128, 253],
+                            "name": "rot.gobo"
+                        },
+                        {
+                            "range": [254, 254],
+                            "name": "audio_ch_sl"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "audio_ch_ff"
+                        }
+                    ]
+                },
+                "Shutter": {
+                    "type": "Shutter",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [16, 239],
+                            "name": "frequenze"
+                        },
+                        {
+                            "range": [240, 255],
+                            "name": "open"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Gobo_Rot": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "position"
+                        },
+                        {
+                            "range": [128, 253],
+                            "name": "rotation"
+                        },
+                        {
+                            "range": [254, 254],
+                            "name": "audio_ch_sl"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "audio_ch_ff"
+                        }
+                    ]
+                },
+                "Effect": {
+                    "type": "Effect",
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "open"
+                        },
+                        {
+                            "range": [16, 31],
+                            "name": "color8"
+                        },
+                        {
+                            "range": [32, 47],
+                            "name": "color9"
+                        },
+                        {
+                            "range": [48, 63],
+                            "name": "color10"
+                        },
+                        {
+                            "range": [64, 79],
+                            "name": "prism_3"
+                        },
+                        {
+                            "range": [80, 96],
+                            "name": "frost",
+                            "color": "#edf5dd"
+                        },
+                        {
+                            "range": [96, 111],
+                            "name": "correction"
+                        },
+                        {
+                            "range": [112, 127],
+                            "name": "prism_5"
+                        },
+                        {
+                            "range": [254, 254],
+                            "name": "audio_ch_sl"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "audio_ch_ff"
+                        }
+                    ]
+                },
+                "Special": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "none"
+                        },
+                        {
+                            "range": [16, 31],
+                            "name": "wipe_10"
+                        },
+                        {
+                            "range": [32, 47],
+                            "name": "wipe_20"
+                        },
+                        {
+                            "range": [48, 63],
+                            "name": "wipe_30"
+                        },
+                        {
+                            "range": [64, 79],
+                            "name": "chaser_c+c1"
+                        },
+                        {
+                            "range": [80, 95],
+                            "name": "chaser_c+c2"
+                        },
+                        {
+                            "range": [96, 127],
+                            "name": "audio_move"
+                        },
+                        {
+                            "range": [192, 207],
+                            "name": "engage_program_"
+                        },
+                        {
+                            "range": [208, 223],
+                            "name": "program_receive"
+                        },
+                        {
+                            "range": [224, 239],
+                            "name": "program_send"
+                        },
+                        {
+                            "range": [240, 249],
+                            "name": "nofunction"
+                        },
+                        {
+                            "range": [250, 255],
+                            "name": "reset"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "15-channel Mode",
+                    "shortName": "15ch",
+                    "channels": [
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "Color",
+                        "Gobo",
+                        "Shutter",
+                        "Intensity",
+                        "Gobo_Rot",
+                        "Effect",
+                        "Special"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "GLP",
+            "name": "Max250",
+            "shortName": "Max250",
+            "physical": {
+                "dimensions": [300, 300, 500]
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Speed_Arm": {
+                    "type": "Speed",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Speed_Head": {
+                    "type": "Speed",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Move": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "H_min:A_min"
+                        },
+                        {
+                            "range": [16, 31],
+                            "name": "H_min:A_max"
+                        },
+                        {
+                            "range": [32, 47],
+                            "name": "H_max:A_min"
+                        },
+                        {
+                            "range": [43, 63],
+                            "name": "H_max:A_max"
+                        },
+                        {
+                            "range": [64, 79],
+                            "name": "H_rot_l:A_min"
+                        },
+                        {
+                            "range": [80, 95],
+                            "name": "H_rot_l:A_max"
+                        },
+                        {
+                            "range": [96, 111],
+                            "name": "H_rot_r:A_min"
+                        },
+                        {
+                            "range": [112, 127],
+                            "name": "H_rot_r:A_max"
+                        },
+                        {
+                            "range": [128, 143],
+                            "name": "H_min:A_rot_l"
+                        },
+                        {
+                            "range": [144, 159],
+                            "name": "H_max:A_rot_l"
+                        },
+                        {
+                            "range": [160, 175],
+                            "name": "H_min:A_rot_r"
+                        },
+                        {
+                            "range": [176, 191],
+                            "name": "H_max:A_rot_r"
+                        },
+                        {
+                            "range": [192, 207],
+                            "name": "H_rot_l:A_rot_l"
+                        },
+                        {
+                            "range": [208, 215],
+                            "name": "H_rot_r:A_rot_r"
+                        },
+                        {
+                            "range": [216, 231],
+                            "name": "H_rot_l:A_rot_r"
+                        },
+                        {
+                            "range": [232, 254],
+                            "name": "H_rot_r:A_rot_l"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "Reset_all"
+                        }
+                    ]
+                },
+                "Color": {
+                    "type": "MultiColor",
+                    "defaultValue": 167,
+                    "highlightValue": 167,
+                    "capabilities": [
+                        {
+                            "range": [0, 3],
+                            "name": "5600k",
+                            "center": true
+                        },
+                        {
+                            "range": [4, 7],
+                            "name": "halfcolor1",
+                            "center": true
+                        },
+                        {
+                            "range": [8, 11],
+                            "name": "blue107",
+                            "center": true
+                        },
+                        {
+                            "range": [12, 15],
+                            "name": "halfcolor2",
+                            "center": true
+                        },
+                        {
+                            "range": [16, 19],
+                            "name": "blue110",
+                            "center": true
+                        },
+                        {
+                            "range": [20, 23],
+                            "name": "halfcolor3",
+                            "center": true
+                        },
+                        {
+                            "range": [24, 27],
+                            "name": "blue101",
+                            "center": true
+                        },
+                        {
+                            "range": [28, 31],
+                            "name": "halfcolor4",
+                            "center": true
+                        },
+                        {
+                            "range": [32, 35],
+                            "name": "cyan401",
+                            "center": true
+                        },
+                        {
+                            "range": [36, 39],
+                            "name": "halfcolor5",
+                            "center": true
+                        },
+                        {
+                            "range": [48, 51],
+                            "name": "green201",
+                            "center": true
+                        },
+                        {
+                            "range": [44, 47],
+                            "name": "halfcolor6",
+                            "center": true
+                        },
+                        {
+                            "range": [48, 51],
+                            "name": "green204",
+                            "center": true
+                        },
+                        {
+                            "range": [52, 55],
+                            "name": "halfcolor7",
+                            "center": true
+                        },
+                        {
+                            "range": [56, 59],
+                            "name": "yellow601",
+                            "center": true
+                        },
+                        {
+                            "range": [60, 63],
+                            "name": "halfcolor8",
+                            "center": true
+                        },
+                        {
+                            "range": [64, 67],
+                            "name": "orange306",
+                            "center": true
+                        },
+                        {
+                            "range": [68, 71],
+                            "name": "halfcolor9",
+                            "center": true
+                        },
+                        {
+                            "range": [72, 75],
+                            "name": "red304",
+                            "center": true
+                        },
+                        {
+                            "range": [76, 79],
+                            "name": "halfcolor10",
+                            "center": true
+                        },
+                        {
+                            "range": [80, 83],
+                            "name": "pink303",
+                            "center": true
+                        },
+                        {
+                            "range": [84, 87],
+                            "name": "halfcolor11",
+                            "center": true
+                        },
+                        {
+                            "range": [88, 91],
+                            "name": "magenta501",
+                            "center": true
+                        },
+                        {
+                            "range": [92, 95],
+                            "name": "halfcolor12",
+                            "center": true
+                        },
+                        {
+                            "range": [96, 99],
+                            "name": "magenta507",
+                            "center": true
+                        },
+                        {
+                            "range": [100, 103],
+                            "name": "halfcolor13",
+                            "center": true
+                        },
+                        {
+                            "range": [104, 107],
+                            "name": "cyan104",
+                            "center": true
+                        },
+                        {
+                            "range": [108, 111],
+                            "name": "halfcolor14",
+                            "center": true
+                        },
+                        {
+                            "range": [112, 115],
+                            "name": "orange302",
+                            "center": true
+                        },
+                        {
+                            "range": [116, 119],
+                            "name": "halfcolor15",
+                            "center": true
+                        },
+                        {
+                            "range": [120, 123],
+                            "name": "t"
+                        },
+                        {
+                            "range": [124, 127],
+                            "name": "halfcolor16",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 131],
+                            "name": "pink310",
+                            "center": true
+                        },
+                        {
+                            "range": [132, 135],
+                            "name": "halfcolor17",
+                            "center": true
+                        },
+                        {
+                            "range": [136, 139],
+                            "name": "yellow603",
+                            "center": true
+                        },
+                        {
+                            "range": [140, 143],
+                            "name": "halfcolor18",
+                            "center": true
+                        },
+                        {
+                            "range": [144, 147],
+                            "name": "UVblue108",
+                            "center": true
+                        },
+                        {
+                            "range": [148, 151],
+                            "name": "halfcolor19",
+                            "center": true
+                        },
+                        {
+                            "range": [152, 155],
+                            "name": "red301",
+                            "center": true
+                        },
+                        {
+                            "range": [156, 159],
+                            "name": "halfcolor20",
+                            "center": true
+                        },
+                        {
+                            "range": [160, 175],
+                            "name": "open",
+                            "center": true
+                        },
+                        {
+                            "range": [176, 255],
+                            "name": "rotation"
+                        }
+                    ]
+                },
+                "Gobo": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 7],
+                            "name": "gobo1",
+                            "center": true
+                        },
+                        {
+                            "range": [8, 15],
+                            "name": "gobo2",
+                            "center": true
+                        },
+                        {
+                            "range": [16, 23],
+                            "name": "gobo3",
+                            "center": true
+                        },
+                        {
+                            "range": [24, 31],
+                            "name": "gobo4",
+                            "center": true
+                        },
+                        {
+                            "range": [32, 39],
+                            "name": "gobo5",
+                            "center": true
+                        },
+                        {
+                            "range": [40, 47],
+                            "name": "gobo6",
+                            "center": true
+                        },
+                        {
+                            "range": [48, 55],
+                            "name": "gobo7",
+                            "center": true
+                        },
+                        {
+                            "range": [56, 63],
+                            "name": "gobo8",
+                            "center": true
+                        },
+                        {
+                            "range": [64, 71],
+                            "name": "gobo9",
+                            "center": true
+                        },
+                        {
+                            "range": [72, 79],
+                            "name": "gobo10",
+                            "center": true
+                        },
+                        {
+                            "range": [80, 87],
+                            "name": "gobo11",
+                            "center": true
+                        },
+                        {
+                            "range": [88, 95],
+                            "name": "gobo12",
+                            "center": true
+                        },
+                        {
+                            "range": [96, 103],
+                            "name": "gobo13",
+                            "center": true
+                        },
+                        {
+                            "range": [104, 111],
+                            "name": "gobo14",
+                            "center": true
+                        },
+                        {
+                            "range": [112, 119],
+                            "name": "gobo15",
+                            "center": true
+                        },
+                        {
+                            "range": [120, 127],
+                            "name": "gobo16",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 135],
+                            "name": "gobo17",
+                            "center": true
+                        },
+                        {
+                            "range": [136, 143],
+                            "name": "gobo18",
+                            "center": true
+                        },
+                        {
+                            "range": [144, 151],
+                            "name": "gobo19",
+                            "center": true
+                        },
+                        {
+                            "range": [152, 159],
+                            "name": "gobo20",
+                            "center": true
+                        },
+                        {
+                            "range": [160, 175],
+                            "name": "gobo21",
+                            "center": true
+                        },
+                        {
+                            "range": [176, 208],
+                            "name": "rotation"
+                        },
+                        {
+                            "range": [209, 255],
+                            "name": "rot_stop",
+                            "center": true
+                        }
+                    ]
+                },
+                "Shutter": {
+                    "type": "Shutter",
+                    "defaultValue": 11,
+                    "highlightValue": 11,
+                    "capabilities": [
+                        {
+                            "range": [0, 7],
+                            "name": "closed1"
+                        },
+                        {
+                            "range": [8, 15],
+                            "name": "open",
+                            "center": true
+                        },
+                        {
+                            "range": [16, 23],
+                            "name": "closed2",
+                            "center": true
+                        },
+                        {
+                            "range": [24, 127],
+                            "name": "frequency"
+                        },
+                        {
+                            "range": [128, 255],
+                            "name": "color_gobo_spee"
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "8-channel Mode",
+                    "shortName": "8ch",
+                    "channels": [
+                        "Pan",
+                        "Tilt",
+                        "Speed_Arm",
+                        "Speed_Head",
+                        "Move",
+                        "Color",
+                        "Gobo",
+                        "Shutter"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "GLP",
+            "name": "Mighty Scan 250 ELC",
+            "shortName": "M250ELC",
+            "physical": {
+                "dimensions": [200, 200, 360]
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Speed": {
+                    "type": "Speed",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Color": {
+                    "type": "MultiColor",
+                    "defaultValue": 167,
+                    "highlightValue": 167,
+                    "capabilities": [
+                        {
+                            "range": [0, 3],
+                            "name": "5600k",
+                            "center": true
+                        },
+                        {
+                            "range": [4, 7],
+                            "name": "halfcolor1",
+                            "center": true
+                        },
+                        {
+                            "range": [8, 11],
+                            "name": "blue107",
+                            "center": true
+                        },
+                        {
+                            "range": [12, 15],
+                            "name": "halfcolor2",
+                            "center": true
+                        },
+                        {
+                            "range": [16, 19],
+                            "name": "blue110",
+                            "center": true
+                        },
+                        {
+                            "range": [20, 23],
+                            "name": "halfcolor3",
+                            "center": true
+                        },
+                        {
+                            "range": [24, 27],
+                            "name": "blue101",
+                            "center": true
+                        },
+                        {
+                            "range": [28, 31],
+                            "name": "halfcolor4",
+                            "center": true
+                        },
+                        {
+                            "range": [32, 35],
+                            "name": "cyan401",
+                            "center": true
+                        },
+                        {
+                            "range": [36, 39],
+                            "name": "halfcolor5",
+                            "center": true
+                        },
+                        {
+                            "range": [48, 51],
+                            "name": "green201",
+                            "center": true
+                        },
+                        {
+                            "range": [44, 47],
+                            "name": "halfcolor6",
+                            "center": true
+                        },
+                        {
+                            "range": [48, 51],
+                            "name": "green204",
+                            "center": true
+                        },
+                        {
+                            "range": [52, 55],
+                            "name": "halfcolor7",
+                            "center": true
+                        },
+                        {
+                            "range": [56, 59],
+                            "name": "yellow601",
+                            "center": true
+                        },
+                        {
+                            "range": [60, 63],
+                            "name": "halfcolor8",
+                            "center": true
+                        },
+                        {
+                            "range": [64, 67],
+                            "name": "orange306",
+                            "center": true
+                        },
+                        {
+                            "range": [68, 71],
+                            "name": "halfcolor9",
+                            "center": true
+                        },
+                        {
+                            "range": [72, 75],
+                            "name": "red304",
+                            "center": true
+                        },
+                        {
+                            "range": [76, 79],
+                            "name": "halfcolor10",
+                            "center": true
+                        },
+                        {
+                            "range": [80, 83],
+                            "name": "pink303",
+                            "center": true
+                        },
+                        {
+                            "range": [84, 87],
+                            "name": "halfcolor11",
+                            "center": true
+                        },
+                        {
+                            "range": [88, 91],
+                            "name": "magenta501",
+                            "center": true
+                        },
+                        {
+                            "range": [92, 95],
+                            "name": "halfcolor12",
+                            "center": true
+                        },
+                        {
+                            "range": [96, 99],
+                            "name": "magenta507",
+                            "center": true
+                        },
+                        {
+                            "range": [100, 103],
+                            "name": "halfcolor13",
+                            "center": true
+                        },
+                        {
+                            "range": [104, 107],
+                            "name": "cyan104",
+                            "center": true
+                        },
+                        {
+                            "range": [108, 111],
+                            "name": "halfcolor14",
+                            "center": true
+                        },
+                        {
+                            "range": [112, 115],
+                            "name": "orange302",
+                            "center": true
+                        },
+                        {
+                            "range": [116, 119],
+                            "name": "halfcolor15",
+                            "center": true
+                        },
+                        {
+                            "range": [120, 123],
+                            "name": "t"
+                        },
+                        {
+                            "range": [124, 127],
+                            "name": "halfcolor16",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 131],
+                            "name": "pink310",
+                            "center": true
+                        },
+                        {
+                            "range": [132, 135],
+                            "name": "halfcolor17",
+                            "center": true
+                        },
+                        {
+                            "range": [136, 139],
+                            "name": "yellow603",
+                            "center": true
+                        },
+                        {
+                            "range": [140, 143],
+                            "name": "halfcolor18",
+                            "center": true
+                        },
+                        {
+                            "range": [144, 147],
+                            "name": "UVblue108",
+                            "center": true
+                        },
+                        {
+                            "range": [148, 151],
+                            "name": "halfcolor19",
+                            "center": true
+                        },
+                        {
+                            "range": [152, 155],
+                            "name": "red301",
+                            "center": true
+                        },
+                        {
+                            "range": [156, 159],
+                            "name": "halfcolor20",
+                            "center": true
+                        },
+                        {
+                            "range": [160, 175],
+                            "name": "open",
+                            "center": true
+                        },
+                        {
+                            "range": [176, 255],
+                            "name": "rotation"
+                        }
+                    ]
+                },
+                "Gobo": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 7],
+                            "name": "gobo1",
+                            "center": true
+                        },
+                        {
+                            "range": [8, 15],
+                            "name": "gobo2",
+                            "center": true
+                        },
+                        {
+                            "range": [16, 23],
+                            "name": "gobo3",
+                            "center": true
+                        },
+                        {
+                            "range": [24, 31],
+                            "name": "gobo4",
+                            "center": true
+                        },
+                        {
+                            "range": [32, 39],
+                            "name": "gobo5",
+                            "center": true
+                        },
+                        {
+                            "range": [40, 47],
+                            "name": "gobo6",
+                            "center": true
+                        },
+                        {
+                            "range": [48, 55],
+                            "name": "gobo7",
+                            "center": true
+                        },
+                        {
+                            "range": [56, 63],
+                            "name": "gobo8",
+                            "center": true
+                        },
+                        {
+                            "range": [64, 71],
+                            "name": "gobo9",
+                            "center": true
+                        },
+                        {
+                            "range": [72, 79],
+                            "name": "gobo10",
+                            "center": true
+                        },
+                        {
+                            "range": [80, 87],
+                            "name": "gobo11",
+                            "center": true
+                        },
+                        {
+                            "range": [88, 95],
+                            "name": "gobo12",
+                            "center": true
+                        },
+                        {
+                            "range": [96, 103],
+                            "name": "gobo13",
+                            "center": true
+                        },
+                        {
+                            "range": [104, 111],
+                            "name": "gobo14",
+                            "center": true
+                        },
+                        {
+                            "range": [112, 119],
+                            "name": "gobo15",
+                            "center": true
+                        },
+                        {
+                            "range": [120, 127],
+                            "name": "gobo16",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 135],
+                            "name": "gobo17",
+                            "center": true
+                        },
+                        {
+                            "range": [136, 143],
+                            "name": "gobo18",
+                            "center": true
+                        },
+                        {
+                            "range": [144, 151],
+                            "name": "gobo19",
+                            "center": true
+                        },
+                        {
+                            "range": [152, 159],
+                            "name": "gobo20",
+                            "center": true
+                        },
+                        {
+                            "range": [160, 175],
+                            "name": "gobo21",
+                            "center": true
+                        },
+                        {
+                            "range": [176, 208],
+                            "name": "rotation"
+                        },
+                        {
+                            "range": [209, 255],
+                            "name": "rot_stop",
+                            "center": true
+                        }
+                    ]
+                },
+                "Shutter": {
+                    "type": "Shutter",
+                    "defaultValue": 11,
+                    "highlightValue": 11,
+                    "capabilities": [
+                        {
+                            "range": [0, 7],
+                            "name": "closed1"
+                        },
+                        {
+                            "range": [8, 15],
+                            "name": "open",
+                            "center": true
+                        },
+                        {
+                            "range": [16, 23],
+                            "name": "closed2",
+                            "center": true
+                        },
+                        {
+                            "range": [24, 127],
+                            "name": "frequency"
+                        },
+                        {
+                            "range": [128, 255],
+                            "name": "color_gobo_spee"
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "6-channel Mode",
+                    "shortName": "6ch",
+                    "channels": [
+                        "Pan",
+                        "Tilt",
+                        "Speed",
+                        "Color",
+                        "Gobo",
+                        "Shutter"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "GLP",
+            "name": "Patend Light 1200",
+            "shortName": "GLP_1200",
+            "physical": {
+                "dimensions": [600, 500, 400],
+                "weight": 42,
+                "power": 1500
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Speed_H": {
+                    "type": "Speed",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Speed_M": {
+                    "type": "Speed",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Special": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "relative"
+                        },
+                        {
+                            "range": [1, 19],
+                            "name": "H<360"
+                        },
+                        {
+                            "range": [20, 29],
+                            "name": "H>360"
+                        },
+                        {
+                            "range": [30, 39],
+                            "name": "H<360"
+                        },
+                        {
+                            "range": [40, 49],
+                            "name": "H>360"
+                        },
+                        {
+                            "range": [50, 59],
+                            "name": "H_rot_l:M<360"
+                        },
+                        {
+                            "range": [60, 69],
+                            "name": "H_rot_l:M>360"
+                        },
+                        {
+                            "range": [70, 79],
+                            "name": "H_rot_r:M<360"
+                        },
+                        {
+                            "range": [120, 129],
+                            "name": "H_rot_r:M>360"
+                        },
+                        {
+                            "range": [90, 99],
+                            "name": "H<360"
+                        },
+                        {
+                            "range": [100, 109],
+                            "name": "H>360"
+                        },
+                        {
+                            "range": [110, 119],
+                            "name": "H<360"
+                        },
+                        {
+                            "range": [120, 129],
+                            "name": "H>360"
+                        },
+                        {
+                            "range": [130, 139],
+                            "name": "H_rot_l:M_rot_l",
+                            "center": true
+                        },
+                        {
+                            "range": [140, 149],
+                            "name": "H_rot_r:M_rot_r",
+                            "center": true
+                        },
+                        {
+                            "range": [150, 159],
+                            "name": "H_rot_l:M_rot_r",
+                            "center": true
+                        },
+                        {
+                            "range": [160, 254],
+                            "name": "H_rot_r:M_rot_l",
+                            "center": true
+                        },
+                        {
+                            "range": [254, 254],
+                            "name": "reset"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "reset_all"
+                        }
+                    ]
+                },
+                "Color": {
+                    "type": "MultiColor",
+                    "capabilities": [
+                        {
+                            "range": [0, 4],
+                            "name": "white",
+                            "color": "#ffffff",
+                            "center": true
+                        },
+                        {
+                            "range": [10, 14],
+                            "name": "green",
+                            "color": "#00ff00",
+                            "center": true
+                        },
+                        {
+                            "range": [20, 24],
+                            "name": "red",
+                            "color": "#ff0000",
+                            "center": true
+                        },
+                        {
+                            "range": [30, 34],
+                            "name": "dark_blue",
+                            "center": true
+                        },
+                        {
+                            "range": [40, 44],
+                            "name": "yellow",
+                            "color": "#ffff00",
+                            "center": true
+                        },
+                        {
+                            "range": [50, 54],
+                            "name": "pink",
+                            "color": "#ffc0cb",
+                            "center": true
+                        },
+                        {
+                            "range": [55, 59],
+                            "name": "turquiose",
+                            "center": true
+                        },
+                        {
+                            "range": [70, 74],
+                            "name": "orange",
+                            "color": "#ff7f00",
+                            "center": true
+                        },
+                        {
+                            "range": [80, 84],
+                            "name": "cyan",
+                            "color": "#00ffff",
+                            "center": true
+                        },
+                        {
+                            "range": [90, 94],
+                            "name": "magenta",
+                            "color": "#ca1f7b",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 191],
+                            "name": "rot_sl->ff"
+                        },
+                        {
+                            "range": [192, 192],
+                            "name": "rot_stop"
+                        },
+                        {
+                            "range": [193, 255],
+                            "name": "rot_sl->ff"
+                        }
+                    ]
+                },
+                "Gobo1": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 9],
+                            "name": "open"
+                        },
+                        {
+                            "range": [10, 19],
+                            "name": "gobo2",
+                            "center": true
+                        },
+                        {
+                            "range": [20, 29],
+                            "name": "gobo3",
+                            "center": true
+                        },
+                        {
+                            "range": [30, 39],
+                            "name": "gobo4",
+                            "center": true
+                        },
+                        {
+                            "range": [40, 49],
+                            "name": "gobo5",
+                            "center": true
+                        },
+                        {
+                            "range": [50, 127],
+                            "name": "gobo6",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 191],
+                            "name": "rot_cw"
+                        },
+                        {
+                            "range": [192, 192],
+                            "name": "rot_stop"
+                        },
+                        {
+                            "range": [193, 255],
+                            "name": "rot_ccw"
+                        }
+                    ]
+                },
+                "Shutter": {
+                    "type": "Shutter",
+                    "capabilities": [
+                        {
+                            "range": [0, 9],
+                            "name": "open"
+                        },
+                        {
+                            "range": [10, 19],
+                            "name": "close 1",
+                            "center": true
+                        },
+                        {
+                            "range": [20, 29],
+                            "name": "close 2",
+                            "center": true
+                        },
+                        {
+                            "range": [30, 99],
+                            "name": "slow-fast"
+                        },
+                        {
+                            "range": [100, 250],
+                            "name": "close 1"
+                        },
+                        {
+                            "range": [251, 255],
+                            "name": "open"
+                        }
+                    ]
+                },
+                "Gobo1.rot": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 4],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [5, 24],
+                            "name": "rot_cc"
+                        },
+                        {
+                            "range": [25, 29],
+                            "name": "stop",
+                            "center": true
+                        },
+                        {
+                            "range": [30, 49],
+                            "name": "rot ccw"
+                        },
+                        {
+                            "range": [50, 54],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [55, 255],
+                            "name": "position"
+                        }
+                    ]
+                },
+                "Iris": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Focus": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Gobo2": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 9],
+                            "name": "open"
+                        },
+                        {
+                            "range": [10, 19],
+                            "name": "gobo2",
+                            "center": true
+                        },
+                        {
+                            "range": [20, 29],
+                            "name": "gobo3",
+                            "center": true
+                        },
+                        {
+                            "range": [30, 39],
+                            "name": "gobo4",
+                            "center": true
+                        },
+                        {
+                            "range": [40, 44],
+                            "name": "gobo5",
+                            "center": true
+                        },
+                        {
+                            "range": [45, 123],
+                            "name": "gobo6",
+                            "center": true
+                        },
+                        {
+                            "range": [124, 191],
+                            "name": "rot_cw"
+                        },
+                        {
+                            "range": [192, 192],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [193, 255],
+                            "name": "rot_ccw"
+                        }
+                    ]
+                },
+                "Gobo2.rot": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [16, 143],
+                            "name": "rot_cw"
+                        },
+                        {
+                            "range": [144, 144],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [145, 255],
+                            "name": "rot_ccw"
+                        }
+                    ]
+                },
+                "Prism": {
+                    "type": "Prism",
+                    "capabilities": [
+                        {
+                            "range": [0, 9],
+                            "name": "open"
+                        },
+                        {
+                            "range": [10, 19],
+                            "name": "prism1",
+                            "center": true
+                        },
+                        {
+                            "range": [20, 69],
+                            "name": "rot_cw"
+                        },
+                        {
+                            "range": [70, 70],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [71, 119],
+                            "name": "rot_ccw"
+                        },
+                        {
+                            "range": [120, 120],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [121, 129],
+                            "name": "frost",
+                            "color": "#edf5dd",
+                            "center": true
+                        },
+                        {
+                            "range": [130, 139],
+                            "name": "prism2",
+                            "center": true
+                        },
+                        {
+                            "range": [140, 189],
+                            "name": "rot_cw"
+                        },
+                        {
+                            "range": [190, 190],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [191, 239],
+                            "name": "rot_ccw"
+                        },
+                        {
+                            "range": [240, 255],
+                            "name": "stop"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "17-channel Mode",
+                    "shortName": "17ch",
+                    "channels": [
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "Speed_H",
+                        "Speed_M",
+                        "Special",
+                        "Color",
+                        "Gobo1",
+                        "Shutter",
+                        "Gobo1.rot",
+                        "Iris",
+                        "Focus",
+                        "Gobo2",
+                        "Gobo2.rot",
+                        "Prism",
+                        "Intensity"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "GLP",
+            "name": "Patend Light 1200 Basic",
+            "shortName": "GLP-1200B",
+            "physical": {
+                "dimensions": [600, 500, 400],
+                "weight": 40,
+                "power": 1500
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Speed_H": {
+                    "type": "Speed",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Speed_M": {
+                    "type": "Speed",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Special": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "relative"
+                        },
+                        {
+                            "range": [1, 19],
+                            "name": "H<360"
+                        },
+                        {
+                            "range": [20, 29],
+                            "name": "H>360"
+                        },
+                        {
+                            "range": [30, 39],
+                            "name": "H<360"
+                        },
+                        {
+                            "range": [40, 49],
+                            "name": "H>360"
+                        },
+                        {
+                            "range": [50, 59],
+                            "name": "H_rot_l:M<360"
+                        },
+                        {
+                            "range": [60, 69],
+                            "name": "H_rot_l:M>360"
+                        },
+                        {
+                            "range": [70, 79],
+                            "name": "H_rot_r:M<360"
+                        },
+                        {
+                            "range": [120, 129],
+                            "name": "H_rot_r:M>360"
+                        },
+                        {
+                            "range": [90, 99],
+                            "name": "H<360"
+                        },
+                        {
+                            "range": [100, 109],
+                            "name": "H>360"
+                        },
+                        {
+                            "range": [110, 119],
+                            "name": "H<360"
+                        },
+                        {
+                            "range": [120, 129],
+                            "name": "H>360"
+                        },
+                        {
+                            "range": [130, 139],
+                            "name": "H_rot_l:M_rot_l",
+                            "center": true
+                        },
+                        {
+                            "range": [140, 149],
+                            "name": "H_rot_r:M_rot_r",
+                            "center": true
+                        },
+                        {
+                            "range": [150, 159],
+                            "name": "H_rot_l:M_rot_r",
+                            "center": true
+                        },
+                        {
+                            "range": [160, 254],
+                            "name": "H_rot_r:M_rot_l",
+                            "center": true
+                        },
+                        {
+                            "range": [254, 254],
+                            "name": "reset"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "reset_all"
+                        }
+                    ]
+                },
+                "Color": {
+                    "type": "MultiColor",
+                    "capabilities": [
+                        {
+                            "range": [0, 4],
+                            "name": "white",
+                            "color": "#ffffff",
+                            "center": true
+                        },
+                        {
+                            "range": [10, 14],
+                            "name": "green",
+                            "color": "#00ff00",
+                            "center": true
+                        },
+                        {
+                            "range": [20, 24],
+                            "name": "red",
+                            "color": "#ff0000",
+                            "center": true
+                        },
+                        {
+                            "range": [30, 34],
+                            "name": "dark_blue",
+                            "center": true
+                        },
+                        {
+                            "range": [40, 44],
+                            "name": "yellow",
+                            "color": "#ffff00",
+                            "center": true
+                        },
+                        {
+                            "range": [50, 54],
+                            "name": "pink",
+                            "color": "#ffc0cb",
+                            "center": true
+                        },
+                        {
+                            "range": [55, 59],
+                            "name": "turquiose",
+                            "center": true
+                        },
+                        {
+                            "range": [70, 74],
+                            "name": "orange",
+                            "color": "#ff7f00",
+                            "center": true
+                        },
+                        {
+                            "range": [80, 84],
+                            "name": "cyan",
+                            "color": "#00ffff",
+                            "center": true
+                        },
+                        {
+                            "range": [90, 94],
+                            "name": "magenta",
+                            "color": "#ca1f7b",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 191],
+                            "name": "rot_sl->ff"
+                        },
+                        {
+                            "range": [192, 192],
+                            "name": "rot_stop"
+                        },
+                        {
+                            "range": [193, 255],
+                            "name": "rot_sl->ff"
+                        }
+                    ]
+                },
+                "Color2": {
+                    "type": "MultiColor",
+                    "capabilities": [
+                        {
+                            "range": [0, 63],
+                            "name": "white",
+                            "color": "#ffffff"
+                        },
+                        {
+                            "range": [64, 127],
+                            "name": "cyan",
+                            "color": "#00ffff",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 191],
+                            "name": "white",
+                            "color": "#ffffff",
+                            "center": true
+                        },
+                        {
+                            "range": [192, 255],
+                            "name": "magenta",
+                            "color": "#ca1f7b",
+                            "center": true
+                        }
+                    ]
+                },
+                "Shutter": {
+                    "type": "Shutter",
+                    "capabilities": [
+                        {
+                            "range": [0, 9],
+                            "name": "open"
+                        },
+                        {
+                            "range": [10, 19],
+                            "name": "close 1",
+                            "center": true
+                        },
+                        {
+                            "range": [20, 29],
+                            "name": "close 2",
+                            "center": true
+                        },
+                        {
+                            "range": [30, 99],
+                            "name": "slow-fast"
+                        },
+                        {
+                            "range": [100, 250],
+                            "name": "close 1"
+                        },
+                        {
+                            "range": [251, 255],
+                            "name": "open"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Gobo1": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 9],
+                            "name": "open"
+                        },
+                        {
+                            "range": [10, 19],
+                            "name": "gobo2",
+                            "center": true
+                        },
+                        {
+                            "range": [20, 29],
+                            "name": "gobo3",
+                            "center": true
+                        },
+                        {
+                            "range": [30, 39],
+                            "name": "gobo4",
+                            "center": true
+                        },
+                        {
+                            "range": [40, 49],
+                            "name": "gobo5",
+                            "center": true
+                        },
+                        {
+                            "range": [50, 127],
+                            "name": "gobo6",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 191],
+                            "name": "rot_cw"
+                        },
+                        {
+                            "range": [192, 192],
+                            "name": "rot_stop"
+                        },
+                        {
+                            "range": [193, 255],
+                            "name": "rot_ccw"
+                        }
+                    ]
+                },
+                "Gobo1.rot": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 4],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [5, 24],
+                            "name": "rot_cc"
+                        },
+                        {
+                            "range": [25, 29],
+                            "name": "stop",
+                            "center": true
+                        },
+                        {
+                            "range": [30, 49],
+                            "name": "rot ccw"
+                        },
+                        {
+                            "range": [50, 54],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [55, 255],
+                            "name": "position"
+                        }
+                    ]
+                },
+                "Gobo2": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 9],
+                            "name": "open"
+                        },
+                        {
+                            "range": [10, 19],
+                            "name": "gobo2",
+                            "center": true
+                        },
+                        {
+                            "range": [20, 29],
+                            "name": "gobo3",
+                            "center": true
+                        },
+                        {
+                            "range": [30, 39],
+                            "name": "gobo4",
+                            "center": true
+                        },
+                        {
+                            "range": [40, 44],
+                            "name": "gobo5",
+                            "center": true
+                        },
+                        {
+                            "range": [45, 123],
+                            "name": "gobo6",
+                            "center": true
+                        },
+                        {
+                            "range": [124, 191],
+                            "name": "rot_cw"
+                        },
+                        {
+                            "range": [192, 192],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [193, 255],
+                            "name": "rot_ccw"
+                        }
+                    ]
+                },
+                "Focus": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Iris": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Prism": {
+                    "type": "Prism",
+                    "capabilities": [
+                        {
+                            "range": [0, 9],
+                            "name": "open"
+                        },
+                        {
+                            "range": [10, 120],
+                            "name": "prism1",
+                            "center": true
+                        },
+                        {
+                            "range": [121, 129],
+                            "name": "effect",
+                            "center": true
+                        },
+                        {
+                            "range": [130, 255],
+                            "name": "prism2",
+                            "center": true
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "17-channel Mode",
+                    "shortName": "17ch",
+                    "channels": [
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "Speed_H",
+                        "Speed_M",
+                        "Special",
+                        "Color",
+                        "Color2",
+                        "Shutter",
+                        "Intensity",
+                        "Gobo1",
+                        "Gobo1.rot",
+                        "Gobo2",
+                        "Focus",
+                        "Iris",
+                        "Prism"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "GLP",
+            "name": "Patend Light 575 Basic",
+            "shortName": "GLP-575B",
+            "physical": {
+                "dimensions": [600, 500, 400],
+                "weight": 40,
+                "power": 800
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Speed_H": {
+                    "type": "Speed",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Speed_M": {
+                    "type": "Speed",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Special": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "relative"
+                        },
+                        {
+                            "range": [1, 19],
+                            "name": "H<360"
+                        },
+                        {
+                            "range": [20, 29],
+                            "name": "H>360"
+                        },
+                        {
+                            "range": [30, 39],
+                            "name": "H<360"
+                        },
+                        {
+                            "range": [40, 49],
+                            "name": "H>360"
+                        },
+                        {
+                            "range": [50, 59],
+                            "name": "H_rot_l:M<360"
+                        },
+                        {
+                            "range": [60, 69],
+                            "name": "H_rot_l:M>360"
+                        },
+                        {
+                            "range": [70, 79],
+                            "name": "H_rot_r:M<360"
+                        },
+                        {
+                            "range": [120, 129],
+                            "name": "H_rot_r:M>360"
+                        },
+                        {
+                            "range": [90, 99],
+                            "name": "H<360"
+                        },
+                        {
+                            "range": [100, 109],
+                            "name": "H>360"
+                        },
+                        {
+                            "range": [110, 119],
+                            "name": "H<360"
+                        },
+                        {
+                            "range": [120, 129],
+                            "name": "H>360"
+                        },
+                        {
+                            "range": [130, 139],
+                            "name": "H_rot_l:M_rot_l",
+                            "center": true
+                        },
+                        {
+                            "range": [140, 149],
+                            "name": "H_rot_r:M_rot_r",
+                            "center": true
+                        },
+                        {
+                            "range": [150, 159],
+                            "name": "H_rot_l:M_rot_r",
+                            "center": true
+                        },
+                        {
+                            "range": [160, 254],
+                            "name": "H_rot_r:M_rot_l",
+                            "center": true
+                        },
+                        {
+                            "range": [254, 254],
+                            "name": "reset"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "reset_all"
+                        }
+                    ]
+                },
+                "Color": {
+                    "type": "MultiColor",
+                    "capabilities": [
+                        {
+                            "range": [0, 4],
+                            "name": "white",
+                            "color": "#ffffff",
+                            "center": true
+                        },
+                        {
+                            "range": [10, 14],
+                            "name": "green",
+                            "color": "#00ff00",
+                            "center": true
+                        },
+                        {
+                            "range": [20, 24],
+                            "name": "red",
+                            "color": "#ff0000",
+                            "center": true
+                        },
+                        {
+                            "range": [30, 34],
+                            "name": "dark_blue",
+                            "center": true
+                        },
+                        {
+                            "range": [40, 44],
+                            "name": "yellow",
+                            "color": "#ffff00",
+                            "center": true
+                        },
+                        {
+                            "range": [50, 54],
+                            "name": "pink",
+                            "color": "#ffc0cb",
+                            "center": true
+                        },
+                        {
+                            "range": [55, 59],
+                            "name": "turquiose",
+                            "center": true
+                        },
+                        {
+                            "range": [70, 74],
+                            "name": "orange",
+                            "color": "#ff7f00",
+                            "center": true
+                        },
+                        {
+                            "range": [80, 84],
+                            "name": "cyan",
+                            "color": "#00ffff",
+                            "center": true
+                        },
+                        {
+                            "range": [90, 94],
+                            "name": "magenta",
+                            "color": "#ca1f7b",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 191],
+                            "name": "rot_sl->ff"
+                        },
+                        {
+                            "range": [192, 192],
+                            "name": "rot_stop"
+                        },
+                        {
+                            "range": [193, 255],
+                            "name": "rot_sl->ff"
+                        }
+                    ]
+                },
+                "Color2": {
+                    "type": "MultiColor",
+                    "capabilities": [
+                        {
+                            "range": [0, 63],
+                            "name": "white",
+                            "color": "#ffffff"
+                        },
+                        {
+                            "range": [64, 127],
+                            "name": "cyan",
+                            "color": "#00ffff",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 191],
+                            "name": "white",
+                            "color": "#ffffff",
+                            "center": true
+                        },
+                        {
+                            "range": [192, 255],
+                            "name": "magenta",
+                            "color": "#ca1f7b",
+                            "center": true
+                        }
+                    ]
+                },
+                "Shutter": {
+                    "type": "Shutter",
+                    "capabilities": [
+                        {
+                            "range": [0, 9],
+                            "name": "open"
+                        },
+                        {
+                            "range": [10, 19],
+                            "name": "close 1",
+                            "center": true
+                        },
+                        {
+                            "range": [20, 29],
+                            "name": "close 2",
+                            "center": true
+                        },
+                        {
+                            "range": [30, 99],
+                            "name": "slow-fast"
+                        },
+                        {
+                            "range": [100, 250],
+                            "name": "close 1"
+                        },
+                        {
+                            "range": [251, 255],
+                            "name": "open"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Gobo1": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 9],
+                            "name": "open"
+                        },
+                        {
+                            "range": [10, 19],
+                            "name": "gobo2",
+                            "center": true
+                        },
+                        {
+                            "range": [20, 29],
+                            "name": "gobo3",
+                            "center": true
+                        },
+                        {
+                            "range": [30, 39],
+                            "name": "gobo4",
+                            "center": true
+                        },
+                        {
+                            "range": [40, 49],
+                            "name": "gobo5",
+                            "center": true
+                        },
+                        {
+                            "range": [50, 127],
+                            "name": "gobo6",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 191],
+                            "name": "rot_cw"
+                        },
+                        {
+                            "range": [192, 192],
+                            "name": "rot_stop"
+                        },
+                        {
+                            "range": [193, 255],
+                            "name": "rot_ccw"
+                        }
+                    ]
+                },
+                "Gobo1.rot": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 4],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [5, 24],
+                            "name": "rot_cc"
+                        },
+                        {
+                            "range": [25, 29],
+                            "name": "stop",
+                            "center": true
+                        },
+                        {
+                            "range": [30, 49],
+                            "name": "rot ccw"
+                        },
+                        {
+                            "range": [50, 54],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [55, 255],
+                            "name": "position"
+                        }
+                    ]
+                },
+                "Gobo2": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 9],
+                            "name": "open"
+                        },
+                        {
+                            "range": [10, 19],
+                            "name": "gobo2",
+                            "center": true
+                        },
+                        {
+                            "range": [20, 29],
+                            "name": "gobo3",
+                            "center": true
+                        },
+                        {
+                            "range": [30, 39],
+                            "name": "gobo4",
+                            "center": true
+                        },
+                        {
+                            "range": [40, 44],
+                            "name": "gobo5",
+                            "center": true
+                        },
+                        {
+                            "range": [45, 123],
+                            "name": "gobo6",
+                            "center": true
+                        },
+                        {
+                            "range": [124, 191],
+                            "name": "rot_cw"
+                        },
+                        {
+                            "range": [192, 192],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [193, 255],
+                            "name": "rot_ccw"
+                        }
+                    ]
+                },
+                "Focus": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Iris": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Prism": {
+                    "type": "Prism",
+                    "capabilities": [
+                        {
+                            "range": [0, 9],
+                            "name": "open"
+                        },
+                        {
+                            "range": [10, 120],
+                            "name": "prism1",
+                            "center": true
+                        },
+                        {
+                            "range": [121, 129],
+                            "name": "effect",
+                            "center": true
+                        },
+                        {
+                            "range": [130, 255],
+                            "name": "prism2",
+                            "center": true
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "17-channel Mode",
+                    "shortName": "17ch",
+                    "channels": [
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "Speed_H",
+                        "Speed_M",
+                        "Special",
+                        "Color",
+                        "Color2",
+                        "Shutter",
+                        "Intensity",
+                        "Gobo1",
+                        "Gobo1.rot",
+                        "Gobo2",
+                        "Focus",
+                        "Iris",
+                        "Prism"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "GLP",
+            "name": "Pocket Scan",
+            "shortName": "P_Scan",
+            "physical": {
+                "dimensions": [200, 200, 300],
+                "weight": 4,
+                "power": 150
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Color": {
+                    "type": "MultiColor",
+                    "defaultValue": 122,
+                    "highlightValue": 122,
+                    "capabilities": [
+                        {
+                            "range": [0, 3],
+                            "name": "5600k",
+                            "center": true
+                        },
+                        {
+                            "range": [4, 7],
+                            "name": "halfcolor1",
+                            "center": true
+                        },
+                        {
+                            "range": [8, 11],
+                            "name": "green201",
+                            "center": true
+                        },
+                        {
+                            "range": [12, 15],
+                            "name": "halfcolor2",
+                            "center": true
+                        },
+                        {
+                            "range": [16, 19],
+                            "name": "orange302",
+                            "center": true
+                        },
+                        {
+                            "range": [20, 23],
+                            "name": "halfcolor3",
+                            "center": true
+                        },
+                        {
+                            "range": [24, 27],
+                            "name": "blue101",
+                            "center": true
+                        },
+                        {
+                            "range": [28, 31],
+                            "name": "halfcolor4",
+                            "center": true
+                        },
+                        {
+                            "range": [32, 35],
+                            "name": "yellow603",
+                            "center": true
+                        },
+                        {
+                            "range": [36, 39],
+                            "name": "halfcolor5",
+                            "center": true
+                        },
+                        {
+                            "range": [48, 51],
+                            "name": "pink310",
+                            "center": true
+                        },
+                        {
+                            "range": [44, 47],
+                            "name": "halfcolor6",
+                            "center": true
+                        },
+                        {
+                            "range": [48, 51],
+                            "name": "torques208",
+                            "center": true
+                        },
+                        {
+                            "range": [52, 55],
+                            "name": "halfcolor7",
+                            "center": true
+                        },
+                        {
+                            "range": [56, 59],
+                            "name": "red304",
+                            "center": true
+                        },
+                        {
+                            "range": [60, 63],
+                            "name": "halfcolor8",
+                            "center": true
+                        },
+                        {
+                            "range": [64, 67],
+                            "name": "cyan104",
+                            "center": true
+                        },
+                        {
+                            "range": [68, 71],
+                            "name": "halfcolor9",
+                            "center": true
+                        },
+                        {
+                            "range": [72, 75],
+                            "name": "magenta507",
+                            "center": true
+                        },
+                        {
+                            "range": [76, 79],
+                            "name": "halfcolor10",
+                            "center": true
+                        },
+                        {
+                            "range": [80, 83],
+                            "name": "magenta501",
+                            "center": true
+                        },
+                        {
+                            "range": [84, 87],
+                            "name": "halfcolor11",
+                            "center": true
+                        },
+                        {
+                            "range": [88, 91],
+                            "name": "UBBlue108",
+                            "center": true
+                        },
+                        {
+                            "range": [92, 95],
+                            "name": "halfcolor12",
+                            "center": true
+                        },
+                        {
+                            "range": [96, 99],
+                            "name": "yellow601",
+                            "center": true
+                        },
+                        {
+                            "range": [100, 103],
+                            "name": "halfcolor13",
+                            "center": true
+                        },
+                        {
+                            "range": [104, 107],
+                            "name": "green204",
+                            "center": true
+                        },
+                        {
+                            "range": [108, 111],
+                            "name": "halfcolor14",
+                            "center": true
+                        },
+                        {
+                            "range": [112, 115],
+                            "name": "orange306",
+                            "center": true
+                        },
+                        {
+                            "range": [116, 119],
+                            "name": "halfcolor15",
+                            "center": true
+                        },
+                        {
+                            "range": [120, 123],
+                            "name": "white",
+                            "color": "#ffffff",
+                            "center": true
+                        },
+                        {
+                            "range": [124, 127],
+                            "name": "halfcolor16",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 191],
+                            "name": "rot_cw"
+                        },
+                        {
+                            "range": [192, 253],
+                            "name": "rot_ccw"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "audio_ch"
+                        }
+                    ]
+                },
+                "Gobo": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 7],
+                            "name": "gobo1",
+                            "center": true
+                        },
+                        {
+                            "range": [8, 15],
+                            "name": "gobo2",
+                            "center": true
+                        },
+                        {
+                            "range": [16, 23],
+                            "name": "gobo3",
+                            "center": true
+                        },
+                        {
+                            "range": [24, 31],
+                            "name": "gobo4",
+                            "center": true
+                        },
+                        {
+                            "range": [32, 39],
+                            "name": "gobo5",
+                            "center": true
+                        },
+                        {
+                            "range": [40, 47],
+                            "name": "gobo6",
+                            "center": true
+                        },
+                        {
+                            "range": [48, 55],
+                            "name": "gobo7",
+                            "center": true
+                        },
+                        {
+                            "range": [56, 63],
+                            "name": "gobo8",
+                            "center": true
+                        },
+                        {
+                            "range": [64, 71],
+                            "name": "gobo9",
+                            "center": true
+                        },
+                        {
+                            "range": [72, 79],
+                            "name": "gobo10",
+                            "center": true
+                        },
+                        {
+                            "range": [80, 87],
+                            "name": "gobo11",
+                            "center": true
+                        },
+                        {
+                            "range": [88, 95],
+                            "name": "gobo12",
+                            "center": true
+                        },
+                        {
+                            "range": [96, 103],
+                            "name": "gobo13",
+                            "center": true
+                        },
+                        {
+                            "range": [104, 127],
+                            "name": "gobo14",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 191],
+                            "name": "rot_cw"
+                        },
+                        {
+                            "range": [192, 253],
+                            "name": "rot_ccw"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "audio_ch"
+                        }
+                    ]
+                },
+                "Shutter": {
+                    "type": "Shutter",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [16, 239],
+                            "name": "frequenze"
+                        },
+                        {
+                            "range": [240, 255],
+                            "name": "open"
+                        }
+                    ]
+                },
+                "Speed": {
+                    "type": "Speed",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "relative"
+                        },
+                        {
+                            "range": [16, 254],
+                            "name": "speed"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "audio_ch"
+                        }
+                    ]
+                },
+                "Laser": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "off"
+                        },
+                        {
+                            "range": [16, 127],
+                            "name": "flashing"
+                        },
+                        {
+                            "range": [128, 191],
+                            "name": "on"
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "7-channel Mode",
+                    "shortName": "7ch",
+                    "channels": [
+                        "Pan",
+                        "Tilt",
+                        "Color",
+                        "Gobo",
+                        "Shutter",
+                        "Speed",
+                        "Laser"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "GLP",
+            "name": "Startec-1200",
+            "shortName": "Startec",
+            "physical": {
+                "dimensions": [220, 380, 880],
+                "weight": 35,
+                "power": 2300
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Color": {
+                    "type": "MultiColor",
+                    "capabilities": [
+                        {
+                            "range": [0, 4],
+                            "name": "white",
+                            "color": "#ffffff",
+                            "center": true
+                        },
+                        {
+                            "range": [10, 14],
+                            "name": "green",
+                            "color": "#00ff00",
+                            "center": true
+                        },
+                        {
+                            "range": [20, 24],
+                            "name": "red",
+                            "color": "#ff0000",
+                            "center": true
+                        },
+                        {
+                            "range": [30, 34],
+                            "name": "dark_blue",
+                            "center": true
+                        },
+                        {
+                            "range": [40, 44],
+                            "name": "yellow",
+                            "color": "#ffff00",
+                            "center": true
+                        },
+                        {
+                            "range": [50, 54],
+                            "name": "pink",
+                            "color": "#ffc0cb",
+                            "center": true
+                        },
+                        {
+                            "range": [55, 59],
+                            "name": "turquiose",
+                            "center": true
+                        },
+                        {
+                            "range": [70, 74],
+                            "name": "orange",
+                            "color": "#ff7f00",
+                            "center": true
+                        },
+                        {
+                            "range": [80, 84],
+                            "name": "cyan",
+                            "color": "#00ffff",
+                            "center": true
+                        },
+                        {
+                            "range": [90, 94],
+                            "name": "magenta",
+                            "color": "#ca1f7b",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 191],
+                            "name": "rot_sl->ff"
+                        },
+                        {
+                            "range": [192, 192],
+                            "name": "rot_stop"
+                        },
+                        {
+                            "range": [193, 255],
+                            "name": "rot_sl->ff"
+                        }
+                    ]
+                },
+                "Gobo1": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 9],
+                            "name": "open"
+                        },
+                        {
+                            "range": [10, 19],
+                            "name": "gobo2",
+                            "center": true
+                        },
+                        {
+                            "range": [20, 29],
+                            "name": "gobo3",
+                            "center": true
+                        },
+                        {
+                            "range": [30, 39],
+                            "name": "gobo4",
+                            "center": true
+                        },
+                        {
+                            "range": [40, 49],
+                            "name": "gobo5",
+                            "center": true
+                        },
+                        {
+                            "range": [50, 127],
+                            "name": "gobo6",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 191],
+                            "name": "rot_cw"
+                        },
+                        {
+                            "range": [192, 192],
+                            "name": "rot_stop"
+                        },
+                        {
+                            "range": [193, 255],
+                            "name": "rot_ccw"
+                        }
+                    ]
+                },
+                "Gobo1.rot": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 4],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [5, 24],
+                            "name": "rot_cc"
+                        },
+                        {
+                            "range": [25, 29],
+                            "name": "stop",
+                            "center": true
+                        },
+                        {
+                            "range": [30, 49],
+                            "name": "rot ccw"
+                        },
+                        {
+                            "range": [50, 54],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [55, 255],
+                            "name": "position"
+                        }
+                    ]
+                },
+                "Iris": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Prism": {
+                    "type": "Prism",
+                    "capabilities": [
+                        {
+                            "range": [0, 9],
+                            "name": "open"
+                        },
+                        {
+                            "range": [10, 19],
+                            "name": "prism1",
+                            "center": true
+                        },
+                        {
+                            "range": [20, 69],
+                            "name": "rot_cw"
+                        },
+                        {
+                            "range": [70, 70],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [71, 119],
+                            "name": "rot_ccw"
+                        },
+                        {
+                            "range": [120, 120],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [121, 129],
+                            "name": "frost",
+                            "color": "#edf5dd",
+                            "center": true
+                        },
+                        {
+                            "range": [130, 139],
+                            "name": "prism2",
+                            "center": true
+                        },
+                        {
+                            "range": [140, 189],
+                            "name": "rot_cw"
+                        },
+                        {
+                            "range": [190, 190],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [191, 239],
+                            "name": "rot_ccw"
+                        },
+                        {
+                            "range": [240, 255],
+                            "name": "stop"
+                        }
+                    ]
+                },
+                "Shutter": {
+                    "type": "Shutter",
+                    "capabilities": [
+                        {
+                            "range": [0, 9],
+                            "name": "open"
+                        },
+                        {
+                            "range": [10, 31],
+                            "name": "close 1",
+                            "center": true
+                        },
+                        {
+                            "range": [32, 63],
+                            "name": "close 2",
+                            "center": true
+                        },
+                        {
+                            "range": [64, 239],
+                            "name": "slow-fast"
+                        },
+                        {
+                            "range": [240, 255],
+                            "name": "open"
+                        }
+                    ]
+                },
+                "Focus": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Special": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [250, 255],
+                            "name": "reset"
+                        }
+                    ]
+                },
+                "Speed": {
+                    "type": "Speed",
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "relative"
+                        },
+                        {
+                            "range": [16, 255],
+                            "name": "slow-fast"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "14-channel Mode",
+                    "shortName": "14ch",
+                    "channels": [
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "Color",
+                        "Gobo1",
+                        "Gobo1.rot",
+                        "Iris",
+                        "Prism",
+                        "Shutter",
+                        "Focus",
+                        "Intensity",
+                        "Special",
+                        "Speed"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "GLP",
+            "name": "VolksLicht R-G-B",
+            "shortName": "VolksLicht",
+            "comment": "ab Software 1.50/27",
+            "physical": {
+                "dimensions": [242, 356, 285],
+                "weight": 7.8,
+                "power": 180
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "_Color Preset": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 7],
+                            "name": "open"
+                        },
+                        {
+                            "range": [8, 15],
+                            "name": "red",
+                            "color": "#ff0000"
+                        },
+                        {
+                            "range": [16, 23],
+                            "name": "amber",
+                            "color": "#ffbf00"
+                        },
+                        {
+                            "range": [24, 31],
+                            "name": "yellow warm"
+                        },
+                        {
+                            "range": [32, 39],
+                            "name": "yellow",
+                            "color": "#ffff00"
+                        },
+                        {
+                            "range": [40, 47],
+                            "name": "green",
+                            "color": "#00ff00"
+                        },
+                        {
+                            "range": [48, 55],
+                            "name": "turquoise",
+                            "color": "#40e0d0"
+                        },
+                        {
+                            "range": [56, 63],
+                            "name": "cyan",
+                            "color": "#00ffff"
+                        },
+                        {
+                            "range": [64, 71],
+                            "name": "blue",
+                            "color": "#0000ff"
+                        },
+                        {
+                            "range": [72, 79],
+                            "name": "lavender",
+                            "color": "#b57edc"
+                        },
+                        {
+                            "range": [80, 87],
+                            "name": "mauve",
+                            "color": "#e0b0ff"
+                        },
+                        {
+                            "range": [88, 95],
+                            "name": "magenta",
+                            "color": "#ca1f7b"
+                        },
+                        {
+                            "range": [96, 103],
+                            "name": "pink",
+                            "color": "#ffc0cb"
+                        },
+                        {
+                            "range": [104, 111],
+                            "name": "white 3200K"
+                        },
+                        {
+                            "range": [112, 119],
+                            "name": "white 5600K"
+                        },
+                        {
+                            "range": [120, 127],
+                            "name": "white 7200K"
+                        },
+                        {
+                            "range": [128, 128],
+                            "name": "rainbow stop"
+                        },
+                        {
+                            "range": [129, 223],
+                            "name": "rainbow s-f"
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "rainbow random"
+                        }
+                    ]
+                },
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Shutter": {
+                    "type": "Shutter",
+                    "highlightValue": 80,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [16, 47],
+                            "name": "pulse random"
+                        },
+                        {
+                            "range": [48, 79],
+                            "name": "dim shut"
+                        },
+                        {
+                            "range": [80, 111],
+                            "name": "shut dim"
+                        },
+                        {
+                            "range": [112, 143],
+                            "name": "dim dim"
+                        },
+                        {
+                            "range": [144, 199],
+                            "name": "Strobe 5s-1s"
+                        },
+                        {
+                            "range": [200, 239],
+                            "name": "Strobe 1Hz-10Hz"
+                        },
+                        {
+                            "range": [240, 240],
+                            "name": "Strobe 25Hz"
+                        },
+                        {
+                            "range": [241, 241],
+                            "name": "Strobe 50Hz"
+                        },
+                        {
+                            "range": [242, 255],
+                            "name": "open"
+                        }
+                    ]
+                },
+                "Dimmer": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Special": {
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [250, 255],
+                            "name": "reset"
+                        }
+                    ]
+                },
+                "Movement": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "no movement"
+                        },
+                        {
+                            "range": [1, 1],
+                            "name": "pan 1-0"
+                        },
+                        {
+                            "range": [2, 3],
+                            "name": "pan 1-90"
+                        },
+                        {
+                            "range": [4, 5],
+                            "name": "pan 1-180"
+                        },
+                        {
+                            "range": [6, 7],
+                            "name": "pan 1-270"
+                        },
+                        {
+                            "range": [8, 9],
+                            "name": "pan 2-0"
+                        },
+                        {
+                            "range": [10, 11],
+                            "name": "pan 2-90"
+                        },
+                        {
+                            "range": [12, 13],
+                            "name": "pan 2-180"
+                        },
+                        {
+                            "range": [14, 15],
+                            "name": "pan 2-270"
+                        },
+                        {
+                            "range": [16, 17],
+                            "name": "pan 3-0"
+                        },
+                        {
+                            "range": [18, 19],
+                            "name": "pan 3-90"
+                        },
+                        {
+                            "range": [20, 21],
+                            "name": "pan 3-180"
+                        },
+                        {
+                            "range": [22, 23],
+                            "name": "pan 3-270"
+                        },
+                        {
+                            "range": [24, 25],
+                            "name": "pan 4-0"
+                        },
+                        {
+                            "range": [26, 27],
+                            "name": "pan 4-90"
+                        },
+                        {
+                            "range": [28, 29],
+                            "name": "pan 4-180"
+                        },
+                        {
+                            "range": [30, 31],
+                            "name": "pan 4-270"
+                        },
+                        {
+                            "range": [32, 32],
+                            "name": "tilt 1-0"
+                        },
+                        {
+                            "range": [33, 34],
+                            "name": "tilt 1-90"
+                        },
+                        {
+                            "range": [35, 36],
+                            "name": "tilt 1-180"
+                        },
+                        {
+                            "range": [37, 38],
+                            "name": "tilt 1-270"
+                        },
+                        {
+                            "range": [39, 40],
+                            "name": "tilt 2-0"
+                        },
+                        {
+                            "range": [41, 42],
+                            "name": "tilt 2-90"
+                        },
+                        {
+                            "range": [43, 44],
+                            "name": "tilt 2-180"
+                        },
+                        {
+                            "range": [45, 46],
+                            "name": "tilt 2-270"
+                        },
+                        {
+                            "range": [47, 48],
+                            "name": "tilt 3-0"
+                        },
+                        {
+                            "range": [49, 50],
+                            "name": "tilt 3-90"
+                        },
+                        {
+                            "range": [51, 52],
+                            "name": "tilt 3-180"
+                        },
+                        {
+                            "range": [53, 54],
+                            "name": "tilt 3-270"
+                        },
+                        {
+                            "range": [55, 56],
+                            "name": "tilt 4-0"
+                        },
+                        {
+                            "range": [57, 58],
+                            "name": "tilt 4-90"
+                        },
+                        {
+                            "range": [59, 60],
+                            "name": "tilt 4-180"
+                        },
+                        {
+                            "range": [61, 63],
+                            "name": "tilt 4-270"
+                        },
+                        {
+                            "range": [64, 95],
+                            "name": "Pan Tilt"
+                        },
+                        {
+                            "range": [96, 127],
+                            "name": "Pan Tilt invers"
+                        },
+                        {
+                            "range": [128, 159],
+                            "name": "circle"
+                        },
+                        {
+                            "range": [160, 191],
+                            "name": "circle (invers)"
+                        },
+                        {
+                            "range": [192, 223],
+                            "name": "horizontal8"
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "random"
+                        }
+                    ]
+                },
+                "P/T speed": {
+                    "type": "Speed",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "speed "
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "13-channel Mode",
+                    "shortName": "13ch",
+                    "channels": [
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "_Color Preset",
+                        "Red",
+                        "Green",
+                        "Blue",
+                        "Shutter",
+                        "Dimmer",
+                        "Special",
+                        "Movement",
+                        "P/T speed"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "GLP",
+            "name": "YPOC 250 Basic Laser",
+            "shortName": "Ypoc250BL",
+            "comment": "cd",
+            "physical": {
+                "dimensions": [450, 450, 450],
+                "weight": 20,
+                "power": 400
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Color": {
+                    "type": "MultiColor",
+                    "capabilities": [
+                        {
+                            "range": [0, 3],
+                            "name": "open fast"
+                        },
+                        {
+                            "range": [4, 7],
+                            "name": "Brilliant Blue"
+                        },
+                        {
+                            "range": [8, 11],
+                            "name": "Blue",
+                            "color": "#0000ff"
+                        },
+                        {
+                            "range": [12, 15],
+                            "name": "Blue Purple"
+                        },
+                        {
+                            "range": [16, 19],
+                            "name": "Pink",
+                            "color": "#ffc0cb"
+                        },
+                        {
+                            "range": [20, 23],
+                            "name": "Orange",
+                            "color": "#ff7f00"
+                        },
+                        {
+                            "range": [24, 27],
+                            "name": "Italian Blue"
+                        },
+                        {
+                            "range": [28, 31],
+                            "name": "Turquoise",
+                            "color": "#40e0d0"
+                        },
+                        {
+                            "range": [32, 35],
+                            "name": "Jade",
+                            "color": "#00a86b"
+                        },
+                        {
+                            "range": [36, 39],
+                            "name": "CTB 001"
+                        },
+                        {
+                            "range": [40, 43],
+                            "name": "CTO 02"
+                        },
+                        {
+                            "range": [44, 47],
+                            "name": "Red",
+                            "color": "#ff0000"
+                        },
+                        {
+                            "range": [48, 63],
+                            "name": "open fast"
+                        },
+                        {
+                            "range": [64, 67],
+                            "name": "open slow"
+                        },
+                        {
+                            "range": [67, 71],
+                            "name": "Color 1"
+                        },
+                        {
+                            "range": [72, 75],
+                            "name": "Brilliant Blue"
+                        },
+                        {
+                            "range": [76, 79],
+                            "name": "Blue",
+                            "color": "#0000ff"
+                        },
+                        {
+                            "range": [80, 83],
+                            "name": "Blue Purple"
+                        },
+                        {
+                            "range": [84, 87],
+                            "name": "Pink",
+                            "color": "#ffc0cb"
+                        },
+                        {
+                            "range": [88, 91],
+                            "name": "Orange",
+                            "color": "#ff7f00"
+                        },
+                        {
+                            "range": [92, 95],
+                            "name": "Italian Blue"
+                        },
+                        {
+                            "range": [96, 99],
+                            "name": "Turquoise",
+                            "color": "#40e0d0"
+                        },
+                        {
+                            "range": [100, 103],
+                            "name": "Jade",
+                            "color": "#00a86b"
+                        },
+                        {
+                            "range": [104, 107],
+                            "name": "CTB 001"
+                        },
+                        {
+                            "range": [108, 111],
+                            "name": "CTO 02"
+                        },
+                        {
+                            "range": [112, 127],
+                            "name": "open slow"
+                        },
+                        {
+                            "range": [128, 191],
+                            "name": "Rotation cw"
+                        },
+                        {
+                            "range": [192, 253],
+                            "name": "Rotation ccw"
+                        },
+                        {
+                            "range": [254, 254],
+                            "name": "audio slow"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "audio fast"
+                        }
+                    ]
+                },
+                "Gobo": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [7, 0],
+                            "name": "Gobo 1 (f)",
+                            "center": true
+                        },
+                        {
+                            "range": [8, 15],
+                            "name": "Gobo 2 (f)",
+                            "center": true
+                        },
+                        {
+                            "range": [16, 23],
+                            "name": "Gobo 3 (f)",
+                            "center": true
+                        },
+                        {
+                            "range": [24, 31],
+                            "name": "Gobo 4 (f)",
+                            "center": true
+                        },
+                        {
+                            "range": [32, 39],
+                            "name": "Gobo 5 (f)",
+                            "center": true
+                        },
+                        {
+                            "range": [40, 47],
+                            "name": "Gobo 6 (f)",
+                            "center": true
+                        },
+                        {
+                            "range": [48, 55],
+                            "name": "Gobo 7 (f)",
+                            "center": true
+                        },
+                        {
+                            "range": [63, 0],
+                            "name": "Gobo 1 (f)",
+                            "center": true
+                        },
+                        {
+                            "range": [71, 0],
+                            "name": "Gobo 1 (s)",
+                            "center": true
+                        },
+                        {
+                            "range": [72, 79],
+                            "name": "Gobo 2 (s)",
+                            "center": true
+                        },
+                        {
+                            "range": [80, 87],
+                            "name": "Gobo 3 (s)",
+                            "center": true
+                        },
+                        {
+                            "range": [88, 95],
+                            "name": "Gobo 4 (s)",
+                            "center": true
+                        },
+                        {
+                            "range": [96, 103],
+                            "name": "Gobo 5 (s)",
+                            "center": true
+                        },
+                        {
+                            "range": [104, 111],
+                            "name": "Gobo 6 (s)",
+                            "center": true
+                        },
+                        {
+                            "range": [112, 119],
+                            "name": "Gobo 7 (s)",
+                            "center": true
+                        },
+                        {
+                            "range": [127, 0],
+                            "name": "Gobo 1 (s)",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 191],
+                            "name": "Rot s-->f cw"
+                        },
+                        {
+                            "range": [192, 253],
+                            "name": "Rot f-->s ccw"
+                        },
+                        {
+                            "range": [254, 254],
+                            "name": "Audio slow"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "Audio fast"
+                        }
+                    ]
+                },
+                "Shutter": {
+                    "type": "Shutter",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [16, 31],
+                            "name": "random strobe"
+                        },
+                        {
+                            "range": [32, 47],
+                            "name": "pulse s-f"
+                        },
+                        {
+                            "range": [48, 63],
+                            "name": "Audio Shutter"
+                        },
+                        {
+                            "range": [64, 239],
+                            "name": "strobe s-f"
+                        },
+                        {
+                            "range": [240, 255],
+                            "name": "lamp on",
+                            "center": true
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Special": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "no function"
+                        },
+                        {
+                            "range": [16, 31],
+                            "name": "gobo +/- 10 s-f"
+                        },
+                        {
+                            "range": [32, 47],
+                            "name": "gobo +/- 20 s-f"
+                        },
+                        {
+                            "range": [48, 63],
+                            "name": "gobo +/- 30 s-f"
+                        },
+                        {
+                            "range": [64, 79],
+                            "name": "color chase 1"
+                        },
+                        {
+                            "range": [80, 95],
+                            "name": "color chase 2"
+                        },
+                        {
+                            "range": [96, 111],
+                            "name": "Pan/Tilt chase"
+                        },
+                        {
+                            "range": [112, 127],
+                            "name": "Pan/Tilt chase"
+                        },
+                        {
+                            "range": [230, 249],
+                            "name": "lamp off"
+                        },
+                        {
+                            "range": [250, 255],
+                            "name": "reset"
+                        }
+                    ]
+                },
+                "Movement": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "no function"
+                        },
+                        {
+                            "range": [1, 1],
+                            "name": "PAN 1 0"
+                        },
+                        {
+                            "range": [2, 3],
+                            "name": "PAN 1 90"
+                        },
+                        {
+                            "range": [4, 5],
+                            "name": "PAN 1 180"
+                        },
+                        {
+                            "range": [6, 7],
+                            "name": "PAN 1 270"
+                        },
+                        {
+                            "range": [8, 9],
+                            "name": "PAN 2 0"
+                        },
+                        {
+                            "range": [10, 11],
+                            "name": "PAN 2 90"
+                        },
+                        {
+                            "range": [12, 13],
+                            "name": "PAN 2 180"
+                        },
+                        {
+                            "range": [14, 15],
+                            "name": "PAN 2 270"
+                        },
+                        {
+                            "range": [16, 17],
+                            "name": "PAN 3 0"
+                        },
+                        {
+                            "range": [18, 19],
+                            "name": "PAN 3 90"
+                        },
+                        {
+                            "range": [20, 21],
+                            "name": "PAN 3 180"
+                        },
+                        {
+                            "range": [22, 23],
+                            "name": "PAN 3 270"
+                        },
+                        {
+                            "range": [24, 25],
+                            "name": "PAN 4 0"
+                        },
+                        {
+                            "range": [26, 27],
+                            "name": "PAN 4 90"
+                        },
+                        {
+                            "range": [28, 29],
+                            "name": "PAN 4 180"
+                        },
+                        {
+                            "range": [30, 31],
+                            "name": "PAN 4 270"
+                        },
+                        {
+                            "range": [32, 63],
+                            "name": "Tilt"
+                        },
+                        {
+                            "range": [64, 95],
+                            "name": "PAN TILT"
+                        },
+                        {
+                            "range": [96, 127],
+                            "name": "PAN TILT I"
+                        },
+                        {
+                            "range": [128, 159],
+                            "name": "Circle"
+                        },
+                        {
+                            "range": [160, 191],
+                            "name": "Circle I"
+                        },
+                        {
+                            "range": [192, 223],
+                            "name": "Eight"
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "random"
+                        }
+                    ]
+                },
+                "Speed": {
+                    "type": "Speed",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "relative"
+                        },
+                        {
+                            "range": [16, 255],
+                            "name": "index"
+                        }
+                    ]
+                },
+                "Laser": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "Laser OFF"
+                        },
+                        {
+                            "range": [16, 31],
+                            "name": "random strobe",
+                            "center": true
+                        },
+                        {
+                            "range": [32, 47],
+                            "name": "audio laser",
+                            "center": true
+                        },
+                        {
+                            "range": [48, 127],
+                            "name": "blink s-->f"
+                        },
+                        {
+                            "range": [128, 239],
+                            "name": "strobe s-->f"
+                        },
+                        {
+                            "range": [240, 255],
+                            "name": "Laser ON",
+                            "center": true
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "12-channel Mode",
+                    "shortName": "12ch",
+                    "channels": [
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "Color",
+                        "Gobo",
+                        "Shutter",
+                        "Intensity",
+                        "Special",
+                        "Movement",
+                        "Speed",
+                        "Laser"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "GLP",
+            "name": "YPOC 250 Colour",
+            "shortName": "Ypoc250",
+            "physical": {
+                "dimensions": [450, 450, 450],
+                "weight": 21,
+                "power": 400
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Color": {
+                    "type": "MultiColor",
+                    "capabilities": [
+                        {
+                            "range": [0, 3],
+                            "name": "open fast"
+                        },
+                        {
+                            "range": [4, 7],
+                            "name": "Brilliant Blue"
+                        },
+                        {
+                            "range": [8, 11],
+                            "name": "Blue",
+                            "color": "#0000ff"
+                        },
+                        {
+                            "range": [12, 15],
+                            "name": "Blue Purple"
+                        },
+                        {
+                            "range": [16, 19],
+                            "name": "Pink",
+                            "color": "#ffc0cb"
+                        },
+                        {
+                            "range": [20, 23],
+                            "name": "Orange",
+                            "color": "#ff7f00"
+                        },
+                        {
+                            "range": [24, 27],
+                            "name": "Italian Blue"
+                        },
+                        {
+                            "range": [28, 31],
+                            "name": "Turquoise",
+                            "color": "#40e0d0"
+                        },
+                        {
+                            "range": [32, 35],
+                            "name": "Jade",
+                            "color": "#00a86b"
+                        },
+                        {
+                            "range": [36, 39],
+                            "name": "CTB 001"
+                        },
+                        {
+                            "range": [40, 43],
+                            "name": "CTO 02"
+                        },
+                        {
+                            "range": [44, 47],
+                            "name": "Red",
+                            "color": "#ff0000"
+                        },
+                        {
+                            "range": [48, 63],
+                            "name": "open fast"
+                        },
+                        {
+                            "range": [64, 67],
+                            "name": "open slow"
+                        },
+                        {
+                            "range": [67, 71],
+                            "name": "Color 1"
+                        },
+                        {
+                            "range": [72, 75],
+                            "name": "Brilliant Blue"
+                        },
+                        {
+                            "range": [76, 79],
+                            "name": "Blue",
+                            "color": "#0000ff"
+                        },
+                        {
+                            "range": [80, 83],
+                            "name": "Blue Purple"
+                        },
+                        {
+                            "range": [84, 87],
+                            "name": "Pink",
+                            "color": "#ffc0cb"
+                        },
+                        {
+                            "range": [88, 91],
+                            "name": "Orange",
+                            "color": "#ff7f00"
+                        },
+                        {
+                            "range": [92, 95],
+                            "name": "Italian Blue"
+                        },
+                        {
+                            "range": [96, 99],
+                            "name": "Turquoise",
+                            "color": "#40e0d0"
+                        },
+                        {
+                            "range": [100, 103],
+                            "name": "Jade",
+                            "color": "#00a86b"
+                        },
+                        {
+                            "range": [104, 107],
+                            "name": "CTB 001"
+                        },
+                        {
+                            "range": [108, 111],
+                            "name": "CTO 02"
+                        },
+                        {
+                            "range": [112, 127],
+                            "name": "open slow"
+                        },
+                        {
+                            "range": [128, 191],
+                            "name": "Rotation cw"
+                        },
+                        {
+                            "range": [192, 253],
+                            "name": "Rotation ccw"
+                        },
+                        {
+                            "range": [254, 254],
+                            "name": "audio slow"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "audio fast"
+                        }
+                    ]
+                },
+                "Cyan": {
+                    "type": "SingleColor",
+                    "color": "Cyan",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Magenta": {
+                    "type": "SingleColor",
+                    "color": "Magenta",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Yellow": {
+                    "type": "SingleColor",
+                    "color": "Yellow",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Shutter": {
+                    "type": "Shutter",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [16, 31],
+                            "name": "random strobe"
+                        },
+                        {
+                            "range": [32, 47],
+                            "name": "strobe s-f"
+                        },
+                        {
+                            "range": [48, 239],
+                            "name": "strobe f-s"
+                        },
+                        {
+                            "range": [240, 254],
+                            "name": "open"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "lamp on"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Beam": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "open"
+                        },
+                        {
+                            "range": [16, 239],
+                            "name": "shaper"
+                        },
+                        {
+                            "range": [240, 255],
+                            "name": "frost",
+                            "color": "#edf5dd"
+                        }
+                    ]
+                },
+                "Special": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "no function"
+                        },
+                        {
+                            "range": [16, 23],
+                            "name": "audio slow"
+                        },
+                        {
+                            "range": [24, 31],
+                            "name": "audio fast"
+                        },
+                        {
+                            "range": [32, 63],
+                            "name": "color chase"
+                        },
+                        {
+                            "range": [64, 79],
+                            "name": "color chase 1"
+                        },
+                        {
+                            "range": [80, 95],
+                            "name": "color chase 2"
+                        },
+                        {
+                            "range": [96, 111],
+                            "name": "Pan/Tilt chase"
+                        },
+                        {
+                            "range": [112, 127],
+                            "name": "Pan/Tilt chase"
+                        },
+                        {
+                            "range": [230, 249],
+                            "name": "lamp off"
+                        },
+                        {
+                            "range": [250, 255],
+                            "name": "reset"
+                        }
+                    ]
+                },
+                "Movement": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "no function"
+                        },
+                        {
+                            "range": [1, 1],
+                            "name": "PAN 1 0"
+                        },
+                        {
+                            "range": [2, 3],
+                            "name": "PAN 1 90"
+                        },
+                        {
+                            "range": [4, 5],
+                            "name": "PAN 1 180"
+                        },
+                        {
+                            "range": [6, 7],
+                            "name": "PAN 1 270"
+                        },
+                        {
+                            "range": [8, 9],
+                            "name": "PAN 2 0"
+                        },
+                        {
+                            "range": [10, 11],
+                            "name": "PAN 2 90"
+                        },
+                        {
+                            "range": [12, 13],
+                            "name": "PAN 2 180"
+                        },
+                        {
+                            "range": [14, 15],
+                            "name": "PAN 2 270"
+                        },
+                        {
+                            "range": [16, 17],
+                            "name": "PAN 3 0"
+                        },
+                        {
+                            "range": [18, 19],
+                            "name": "PAN 3 90"
+                        },
+                        {
+                            "range": [20, 21],
+                            "name": "PAN 3 180"
+                        },
+                        {
+                            "range": [22, 23],
+                            "name": "PAN 3 270"
+                        },
+                        {
+                            "range": [24, 25],
+                            "name": "PAN 4 0"
+                        },
+                        {
+                            "range": [26, 27],
+                            "name": "PAN 4 90"
+                        },
+                        {
+                            "range": [28, 29],
+                            "name": "PAN 4 180"
+                        },
+                        {
+                            "range": [30, 31],
+                            "name": "PAN 4 270"
+                        },
+                        {
+                            "range": [32, 63],
+                            "name": "Tilt"
+                        },
+                        {
+                            "range": [64, 95],
+                            "name": "PAN TILT"
+                        },
+                        {
+                            "range": [96, 127],
+                            "name": "PAN TILT I"
+                        },
+                        {
+                            "range": [128, 159],
+                            "name": "Circle"
+                        },
+                        {
+                            "range": [160, 191],
+                            "name": "Circle I"
+                        },
+                        {
+                            "range": [192, 223],
+                            "name": "Eight"
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "random"
+                        }
+                    ]
+                },
+                "Speed": {
+                    "type": "Speed",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 1],
+                            "name": "relative"
+                        },
+                        {
+                            "range": [2, 255],
+                            "name": "index"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "14-channel Mode",
+                    "shortName": "14ch",
+                    "channels": [
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "Color",
+                        "Cyan",
+                        "Magenta",
+                        "Yellow",
+                        "Shutter",
+                        "Intensity",
+                        "Beam",
+                        "Special",
+                        "Movement",
+                        "Speed"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "GLP",
+            "name": "YPOC 250 Laser",
+            "shortName": "Ypoc250L",
+            "physical": {
+                "dimensions": [450, 450, 450],
+                "weight": 20,
+                "power": 400
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Color": {
+                    "type": "MultiColor",
+                    "capabilities": [
+                        {
+                            "range": [0, 3],
+                            "name": "open fast"
+                        },
+                        {
+                            "range": [4, 7],
+                            "name": "Brilliant Blue"
+                        },
+                        {
+                            "range": [8, 11],
+                            "name": "Blue",
+                            "color": "#0000ff"
+                        },
+                        {
+                            "range": [12, 15],
+                            "name": "Blue Purple"
+                        },
+                        {
+                            "range": [16, 19],
+                            "name": "Pink",
+                            "color": "#ffc0cb"
+                        },
+                        {
+                            "range": [20, 23],
+                            "name": "Orange",
+                            "color": "#ff7f00"
+                        },
+                        {
+                            "range": [24, 27],
+                            "name": "Italian Blue"
+                        },
+                        {
+                            "range": [28, 31],
+                            "name": "Turquoise",
+                            "color": "#40e0d0"
+                        },
+                        {
+                            "range": [32, 35],
+                            "name": "Jade",
+                            "color": "#00a86b"
+                        },
+                        {
+                            "range": [36, 39],
+                            "name": "CTB 001"
+                        },
+                        {
+                            "range": [40, 43],
+                            "name": "CTO 02"
+                        },
+                        {
+                            "range": [44, 47],
+                            "name": "Red",
+                            "color": "#ff0000"
+                        },
+                        {
+                            "range": [48, 63],
+                            "name": "open fast"
+                        },
+                        {
+                            "range": [64, 67],
+                            "name": "open slow"
+                        },
+                        {
+                            "range": [67, 71],
+                            "name": "Color 1"
+                        },
+                        {
+                            "range": [72, 75],
+                            "name": "Brilliant Blue"
+                        },
+                        {
+                            "range": [76, 79],
+                            "name": "Blue",
+                            "color": "#0000ff"
+                        },
+                        {
+                            "range": [80, 83],
+                            "name": "Blue Purple"
+                        },
+                        {
+                            "range": [84, 87],
+                            "name": "Pink",
+                            "color": "#ffc0cb"
+                        },
+                        {
+                            "range": [88, 91],
+                            "name": "Orange",
+                            "color": "#ff7f00"
+                        },
+                        {
+                            "range": [92, 95],
+                            "name": "Italian Blue"
+                        },
+                        {
+                            "range": [96, 99],
+                            "name": "Turquoise",
+                            "color": "#40e0d0"
+                        },
+                        {
+                            "range": [100, 103],
+                            "name": "Jade",
+                            "color": "#00a86b"
+                        },
+                        {
+                            "range": [104, 107],
+                            "name": "CTB 001"
+                        },
+                        {
+                            "range": [108, 111],
+                            "name": "CTO 02"
+                        },
+                        {
+                            "range": [112, 127],
+                            "name": "open slow"
+                        },
+                        {
+                            "range": [128, 191],
+                            "name": "Rotation cw"
+                        },
+                        {
+                            "range": [192, 253],
+                            "name": "Rotation ccw"
+                        },
+                        {
+                            "range": [254, 254],
+                            "name": "audio slow"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "audio fast"
+                        }
+                    ]
+                },
+                "Gobo": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [7, 0],
+                            "name": "Gobo 1 (f)",
+                            "center": true
+                        },
+                        {
+                            "range": [8, 15],
+                            "name": "Gobo 2 (f)",
+                            "center": true
+                        },
+                        {
+                            "range": [16, 23],
+                            "name": "Gobo 3 (f)",
+                            "center": true
+                        },
+                        {
+                            "range": [24, 31],
+                            "name": "Gobo 4 (f)",
+                            "center": true
+                        },
+                        {
+                            "range": [32, 39],
+                            "name": "Gobo 5 (f)",
+                            "center": true
+                        },
+                        {
+                            "range": [40, 47],
+                            "name": "Gobo 6 (f)",
+                            "center": true
+                        },
+                        {
+                            "range": [48, 55],
+                            "name": "Gobo 7 (f)",
+                            "center": true
+                        },
+                        {
+                            "range": [63, 0],
+                            "name": "Gobo 1 (f)",
+                            "center": true
+                        },
+                        {
+                            "range": [71, 0],
+                            "name": "Gobo 1 (s)",
+                            "center": true
+                        },
+                        {
+                            "range": [72, 79],
+                            "name": "Gobo 2 (s)",
+                            "center": true
+                        },
+                        {
+                            "range": [80, 87],
+                            "name": "Gobo 3 (s)",
+                            "center": true
+                        },
+                        {
+                            "range": [88, 95],
+                            "name": "Gobo 4 (s)",
+                            "center": true
+                        },
+                        {
+                            "range": [96, 103],
+                            "name": "Gobo 5 (s)",
+                            "center": true
+                        },
+                        {
+                            "range": [104, 111],
+                            "name": "Gobo 6 (s)",
+                            "center": true
+                        },
+                        {
+                            "range": [112, 119],
+                            "name": "Gobo 7 (s)",
+                            "center": true
+                        },
+                        {
+                            "range": [127, 0],
+                            "name": "Gobo 1 (s)",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 191],
+                            "name": "Rot s-->f cw"
+                        },
+                        {
+                            "range": [192, 253],
+                            "name": "Rot f-->s ccw"
+                        },
+                        {
+                            "range": [254, 254],
+                            "name": "Audio slow"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "Audio fast"
+                        }
+                    ]
+                },
+                "Gobo rot": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 131],
+                            "name": "Pos 0...540 deg"
+                        },
+                        {
+                            "range": [132, 191],
+                            "name": "Rot s-->f cw"
+                        },
+                        {
+                            "range": [192, 253],
+                            "name": "Rot f-->s ccw"
+                        },
+                        {
+                            "range": [254, 254],
+                            "name": "Audio rot s"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "Audio rot f"
+                        }
+                    ]
+                },
+                "Prism": {
+                    "type": "Prism",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 5],
+                            "name": "open"
+                        },
+                        {
+                            "range": [6, 129],
+                            "name": "Rot 0...540 deg"
+                        },
+                        {
+                            "range": [130, 191],
+                            "name": "Rot s-->f cw"
+                        },
+                        {
+                            "range": [192, 253],
+                            "name": "Rot f-->s ccw"
+                        },
+                        {
+                            "range": [254, 254],
+                            "name": "Audio rot s"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "Audio rot f"
+                        }
+                    ]
+                },
+                "Shutter": {
+                    "type": "Shutter",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [16, 31],
+                            "name": "random strobe"
+                        },
+                        {
+                            "range": [32, 47],
+                            "name": "pulse s-f"
+                        },
+                        {
+                            "range": [48, 63],
+                            "name": "Audio Shutter"
+                        },
+                        {
+                            "range": [64, 239],
+                            "name": "strobe s-f"
+                        },
+                        {
+                            "range": [240, 255],
+                            "name": "lamp on",
+                            "center": true
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Focus": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Special": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "no function"
+                        },
+                        {
+                            "range": [16, 31],
+                            "name": "gobo +/- 10 s-f"
+                        },
+                        {
+                            "range": [32, 47],
+                            "name": "gobo +/- 20 s-f"
+                        },
+                        {
+                            "range": [48, 63],
+                            "name": "gobo +/- 30 s-f"
+                        },
+                        {
+                            "range": [64, 79],
+                            "name": "color chase 1"
+                        },
+                        {
+                            "range": [80, 95],
+                            "name": "color chase 2"
+                        },
+                        {
+                            "range": [96, 111],
+                            "name": "Pan/Tilt chase"
+                        },
+                        {
+                            "range": [112, 127],
+                            "name": "Pan/Tilt chase"
+                        },
+                        {
+                            "range": [230, 249],
+                            "name": "lamp off"
+                        },
+                        {
+                            "range": [250, 255],
+                            "name": "reset"
+                        }
+                    ]
+                },
+                "Movement": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "no function"
+                        },
+                        {
+                            "range": [1, 1],
+                            "name": "PAN 1 0"
+                        },
+                        {
+                            "range": [2, 3],
+                            "name": "PAN 1 90"
+                        },
+                        {
+                            "range": [4, 5],
+                            "name": "PAN 1 180"
+                        },
+                        {
+                            "range": [6, 7],
+                            "name": "PAN 1 270"
+                        },
+                        {
+                            "range": [8, 9],
+                            "name": "PAN 2 0"
+                        },
+                        {
+                            "range": [10, 11],
+                            "name": "PAN 2 90"
+                        },
+                        {
+                            "range": [12, 13],
+                            "name": "PAN 2 180"
+                        },
+                        {
+                            "range": [14, 15],
+                            "name": "PAN 2 270"
+                        },
+                        {
+                            "range": [16, 17],
+                            "name": "PAN 3 0"
+                        },
+                        {
+                            "range": [18, 19],
+                            "name": "PAN 3 90"
+                        },
+                        {
+                            "range": [20, 21],
+                            "name": "PAN 3 180"
+                        },
+                        {
+                            "range": [22, 23],
+                            "name": "PAN 3 270"
+                        },
+                        {
+                            "range": [24, 25],
+                            "name": "PAN 4 0"
+                        },
+                        {
+                            "range": [26, 27],
+                            "name": "PAN 4 90"
+                        },
+                        {
+                            "range": [28, 29],
+                            "name": "PAN 4 180"
+                        },
+                        {
+                            "range": [30, 31],
+                            "name": "PAN 4 270"
+                        },
+                        {
+                            "range": [32, 63],
+                            "name": "Tilt"
+                        },
+                        {
+                            "range": [64, 95],
+                            "name": "PAN TILT"
+                        },
+                        {
+                            "range": [96, 127],
+                            "name": "PAN TILT I"
+                        },
+                        {
+                            "range": [128, 159],
+                            "name": "Circle"
+                        },
+                        {
+                            "range": [160, 191],
+                            "name": "Circle I"
+                        },
+                        {
+                            "range": [192, 223],
+                            "name": "Eight"
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "random"
+                        }
+                    ]
+                },
+                "Speed": {
+                    "type": "Speed",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "relative"
+                        },
+                        {
+                            "range": [16, 255],
+                            "name": "index"
+                        }
+                    ]
+                },
+                "Laser": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "Laser OFF"
+                        },
+                        {
+                            "range": [16, 31],
+                            "name": "random strobe",
+                            "center": true
+                        },
+                        {
+                            "range": [32, 47],
+                            "name": "audio laser",
+                            "center": true
+                        },
+                        {
+                            "range": [48, 127],
+                            "name": "blink s-->f"
+                        },
+                        {
+                            "range": [128, 239],
+                            "name": "strobe s-->f"
+                        },
+                        {
+                            "range": [240, 255],
+                            "name": "Laser ON",
+                            "center": true
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "15-channel Mode",
+                    "shortName": "15ch",
+                    "channels": [
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "Color",
+                        "Gobo",
+                        "Gobo rot",
+                        "Prism",
+                        "Shutter",
+                        "Intensity",
+                        "Focus",
+                        "Special",
+                        "Movement",
+                        "Speed",
+                        "Laser"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "GLP",
+            "name": "YPOC 575",
+            "shortName": "YPOC575",
+            "comment": "cd",
+            "physical": {
+                "dimensions": [400, 400, 500],
+                "weight": 24,
+                "power": 575
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Color": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 2],
+                            "name": "open",
+                            "center": true
+                        },
+                        {
+                            "range": [3, 6],
+                            "name": "brilliant blue",
+                            "center": true
+                        },
+                        {
+                            "range": [7, 10],
+                            "name": "blue",
+                            "color": "#0000ff",
+                            "center": true
+                        },
+                        {
+                            "range": [11, 14],
+                            "name": "blue purble",
+                            "center": true
+                        },
+                        {
+                            "range": [15, 18],
+                            "name": "magenta",
+                            "color": "#ca1f7b",
+                            "center": true
+                        },
+                        {
+                            "range": [19, 22],
+                            "name": "pink",
+                            "color": "#ffc0cb",
+                            "center": true
+                        },
+                        {
+                            "range": [23, 26],
+                            "name": "orange",
+                            "color": "#ff7f00",
+                            "center": true
+                        },
+                        {
+                            "range": [27, 30],
+                            "name": "canary",
+                            "color": "#f3fb62",
+                            "center": true
+                        },
+                        {
+                            "range": [31, 34],
+                            "name": "italian blue",
+                            "center": true
+                        },
+                        {
+                            "range": [35, 38],
+                            "name": "turquoise",
+                            "color": "#40e0d0",
+                            "center": true
+                        },
+                        {
+                            "range": [39, 42],
+                            "name": "jade",
+                            "color": "#00a86b",
+                            "center": true
+                        },
+                        {
+                            "range": [43, 46],
+                            "name": "red",
+                            "color": "#ff0000",
+                            "center": true
+                        },
+                        {
+                            "range": [47, 66],
+                            "name": "open",
+                            "center": true
+                        },
+                        {
+                            "range": [67, 70],
+                            "name": "brilliant blue",
+                            "center": true
+                        },
+                        {
+                            "range": [71, 74],
+                            "name": "blue",
+                            "color": "#0000ff",
+                            "center": true
+                        },
+                        {
+                            "range": [75, 78],
+                            "name": "blue purble",
+                            "center": true
+                        },
+                        {
+                            "range": [79, 82],
+                            "name": "magenta",
+                            "color": "#ca1f7b",
+                            "center": true
+                        },
+                        {
+                            "range": [83, 86],
+                            "name": "pink",
+                            "color": "#ffc0cb",
+                            "center": true
+                        },
+                        {
+                            "range": [87, 90],
+                            "name": "orange",
+                            "color": "#ff7f00",
+                            "center": true
+                        },
+                        {
+                            "range": [91, 94],
+                            "name": "canary",
+                            "color": "#f3fb62",
+                            "center": true
+                        },
+                        {
+                            "range": [95, 98],
+                            "name": "italian blue",
+                            "center": true
+                        },
+                        {
+                            "range": [99, 102],
+                            "name": "turquoise",
+                            "color": "#40e0d0",
+                            "center": true
+                        },
+                        {
+                            "range": [103, 106],
+                            "name": "jade",
+                            "color": "#00a86b",
+                            "center": true
+                        },
+                        {
+                            "range": [107, 110],
+                            "name": "red",
+                            "color": "#ff0000",
+                            "center": true
+                        },
+                        {
+                            "range": [111, 127],
+                            "name": "open",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 129],
+                            "name": "stop",
+                            "center": true
+                        },
+                        {
+                            "range": [130, 191],
+                            "name": ">>"
+                        },
+                        {
+                            "range": [192, 253],
+                            "name": "<<"
+                        },
+                        {
+                            "range": [254, 254],
+                            "name": "audio random s.",
+                            "center": true
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "audio random f.",
+                            "center": true
+                        }
+                    ]
+                },
+                "Gobo1": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 7],
+                            "name": "open",
+                            "center": true
+                        },
+                        {
+                            "range": [8, 15],
+                            "name": "slot1",
+                            "center": true
+                        },
+                        {
+                            "range": [16, 23],
+                            "name": "slot2",
+                            "center": true
+                        },
+                        {
+                            "range": [24, 31],
+                            "name": "slot3",
+                            "center": true
+                        },
+                        {
+                            "range": [32, 39],
+                            "name": "slot4",
+                            "center": true
+                        },
+                        {
+                            "range": [40, 47],
+                            "name": "slot5",
+                            "center": true
+                        },
+                        {
+                            "range": [48, 55],
+                            "name": "slot6",
+                            "center": true
+                        },
+                        {
+                            "range": [56, 63],
+                            "name": "slot7",
+                            "center": true
+                        },
+                        {
+                            "range": [64, 71],
+                            "name": "open",
+                            "center": true
+                        },
+                        {
+                            "range": [72, 79],
+                            "name": "slot1",
+                            "center": true
+                        },
+                        {
+                            "range": [80, 87],
+                            "name": "slot2",
+                            "center": true
+                        },
+                        {
+                            "range": [88, 95],
+                            "name": "slot3",
+                            "center": true
+                        },
+                        {
+                            "range": [96, 103],
+                            "name": "slot4",
+                            "center": true
+                        },
+                        {
+                            "range": [104, 111],
+                            "name": "slot5",
+                            "center": true
+                        },
+                        {
+                            "range": [112, 119],
+                            "name": "slot6",
+                            "center": true
+                        },
+                        {
+                            "range": [120, 127],
+                            "name": "slot7",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 129],
+                            "name": "stop",
+                            "center": true
+                        },
+                        {
+                            "range": [130, 191],
+                            "name": ">>"
+                        },
+                        {
+                            "range": [192, 253],
+                            "name": "<<"
+                        },
+                        {
+                            "range": [254, 254],
+                            "name": "audio random s.",
+                            "center": true
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "audio random f.",
+                            "center": true
+                        }
+                    ]
+                },
+                "Gobo1 rot.": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "ind."
+                        },
+                        {
+                            "range": [128, 129],
+                            "name": "stop",
+                            "center": true
+                        },
+                        {
+                            "range": [130, 191],
+                            "name": "rot. >>"
+                        },
+                        {
+                            "range": [192, 253],
+                            "name": "rot. <<"
+                        },
+                        {
+                            "range": [254, 254],
+                            "name": "audio rot. s.",
+                            "center": true
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "audio rot. f.",
+                            "center": true
+                        }
+                    ]
+                },
+                "Gobo2": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 3],
+                            "name": "open",
+                            "center": true
+                        },
+                        {
+                            "range": [4, 7],
+                            "name": "slot1",
+                            "center": true
+                        },
+                        {
+                            "range": [8, 11],
+                            "name": "slot2",
+                            "center": true
+                        },
+                        {
+                            "range": [12, 15],
+                            "name": "slot3",
+                            "center": true
+                        },
+                        {
+                            "range": [16, 19],
+                            "name": "slot4",
+                            "center": true
+                        },
+                        {
+                            "range": [20, 23],
+                            "name": "slot5",
+                            "center": true
+                        },
+                        {
+                            "range": [24, 27],
+                            "name": "slot6",
+                            "center": true
+                        },
+                        {
+                            "range": [28, 31],
+                            "name": "slot7",
+                            "center": true
+                        },
+                        {
+                            "range": [32, 35],
+                            "name": "slot8",
+                            "center": true
+                        },
+                        {
+                            "range": [36, 63],
+                            "name": "slot9",
+                            "center": true
+                        },
+                        {
+                            "range": [64, 67],
+                            "name": "open",
+                            "center": true
+                        },
+                        {
+                            "range": [68, 71],
+                            "name": "slot1",
+                            "center": true
+                        },
+                        {
+                            "range": [72, 75],
+                            "name": "slot2",
+                            "center": true
+                        },
+                        {
+                            "range": [76, 79],
+                            "name": "slot3",
+                            "center": true
+                        },
+                        {
+                            "range": [80, 83],
+                            "name": "slot4",
+                            "center": true
+                        },
+                        {
+                            "range": [84, 87],
+                            "name": "slot5",
+                            "center": true
+                        },
+                        {
+                            "range": [88, 91],
+                            "name": "slot6",
+                            "center": true
+                        },
+                        {
+                            "range": [92, 95],
+                            "name": "slot7",
+                            "center": true
+                        },
+                        {
+                            "range": [96, 99],
+                            "name": "slot8",
+                            "center": true
+                        },
+                        {
+                            "range": [100, 127],
+                            "name": "slot9",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 129],
+                            "name": "stop",
+                            "center": true
+                        },
+                        {
+                            "range": [130, 191],
+                            "name": ">>"
+                        },
+                        {
+                            "range": [192, 253],
+                            "name": "<<"
+                        },
+                        {
+                            "range": [254, 254],
+                            "name": "audio random s.",
+                            "center": true
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "audio random f.",
+                            "center": true
+                        }
+                    ]
+                },
+                "Shutter": {
+                    "type": "Shutter",
+                    "highlightValue": 255,
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "closed",
+                            "center": true
+                        },
+                        {
+                            "range": [16, 31],
+                            "name": "random",
+                            "center": true
+                        },
+                        {
+                            "range": [32, 47],
+                            "name": "pulse"
+                        },
+                        {
+                            "range": [48, 63],
+                            "name": "audio"
+                        },
+                        {
+                            "range": [64, 239],
+                            "name": "strobe"
+                        },
+                        {
+                            "range": [240, 255],
+                            "name": "open",
+                            "center": true
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Focus": {
+                    "type": "Beam",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Prisma": {
+                    "type": "Prism",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 5],
+                            "name": "open",
+                            "center": true
+                        },
+                        {
+                            "range": [6, 129],
+                            "name": "ind."
+                        },
+                        {
+                            "range": [130, 191],
+                            "name": "rot. >>"
+                        },
+                        {
+                            "range": [192, 253],
+                            "name": "rot. <<"
+                        },
+                        {
+                            "range": [254, 254],
+                            "name": "audio rot. s.",
+                            "center": true
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "audio rot. f.",
+                            "center": true
+                        }
+                    ]
+                },
+                "Special": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": ""
+                        },
+                        {
+                            "range": [16, 31],
+                            "name": "gobo sh. 10"
+                        },
+                        {
+                            "range": [32, 47],
+                            "name": "gobo sh. 20"
+                        },
+                        {
+                            "range": [48, 63],
+                            "name": "gobo sh. 30"
+                        },
+                        {
+                            "range": [64, 95],
+                            "name": "color chaser"
+                        },
+                        {
+                            "range": [96, 111],
+                            "name": "audio P/T s."
+                        },
+                        {
+                            "range": [112, 127],
+                            "name": "audio P/T f."
+                        },
+                        {
+                            "range": [128, 223],
+                            "name": "not used",
+                            "center": true
+                        },
+                        {
+                            "range": [224, 229],
+                            "name": "fan slow",
+                            "center": true
+                        },
+                        {
+                            "range": [230, 249],
+                            "name": "lamp off",
+                            "center": true
+                        },
+                        {
+                            "range": [250, 255],
+                            "name": "reset",
+                            "center": true
+                        }
+                    ]
+                },
+                "Movement": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "stop",
+                            "center": true
+                        },
+                        {
+                            "range": [1, 1],
+                            "name": "pan 1 0"
+                        },
+                        {
+                            "range": [2, 3],
+                            "name": "pan 1 90"
+                        },
+                        {
+                            "range": [4, 5],
+                            "name": "pan 1 180"
+                        },
+                        {
+                            "range": [6, 7],
+                            "name": "pan 1 270"
+                        },
+                        {
+                            "range": [8, 9],
+                            "name": "pan 2 0"
+                        },
+                        {
+                            "range": [10, 11],
+                            "name": "pan 2 90"
+                        },
+                        {
+                            "range": [12, 13],
+                            "name": "pan 2 180"
+                        },
+                        {
+                            "range": [14, 15],
+                            "name": "pan 2 270"
+                        },
+                        {
+                            "range": [16, 17],
+                            "name": "pan 3 0"
+                        },
+                        {
+                            "range": [18, 19],
+                            "name": "pan 3 90"
+                        },
+                        {
+                            "range": [20, 21],
+                            "name": "pan 3 180"
+                        },
+                        {
+                            "range": [22, 23],
+                            "name": "pan 3 270"
+                        },
+                        {
+                            "range": [24, 25],
+                            "name": "pan 4 0"
+                        },
+                        {
+                            "range": [26, 27],
+                            "name": "pan 4 90"
+                        },
+                        {
+                            "range": [28, 29],
+                            "name": "pan 4 180"
+                        },
+                        {
+                            "range": [30, 31],
+                            "name": "pan 4 270"
+                        },
+                        {
+                            "range": [32, 33],
+                            "name": "tilt 1 0"
+                        },
+                        {
+                            "range": [34, 35],
+                            "name": "tilt 1 90"
+                        },
+                        {
+                            "range": [36, 37],
+                            "name": "tilt 1 180"
+                        },
+                        {
+                            "range": [38, 39],
+                            "name": "tilt 1 270"
+                        },
+                        {
+                            "range": [40, 41],
+                            "name": "tilt 2 0"
+                        },
+                        {
+                            "range": [42, 43],
+                            "name": "tilt 2 90"
+                        },
+                        {
+                            "range": [44, 45],
+                            "name": "tilt 2 180"
+                        },
+                        {
+                            "range": [46, 47],
+                            "name": "tilt 2 270"
+                        },
+                        {
+                            "range": [48, 49],
+                            "name": "tilt 3 0"
+                        },
+                        {
+                            "range": [50, 51],
+                            "name": "tilt 3 90"
+                        },
+                        {
+                            "range": [52, 53],
+                            "name": "tilt 3 180"
+                        },
+                        {
+                            "range": [54, 55],
+                            "name": "tilt 3 270"
+                        },
+                        {
+                            "range": [56, 57],
+                            "name": "tilt 4 0"
+                        },
+                        {
+                            "range": [58, 59],
+                            "name": "tilt 4 90"
+                        },
+                        {
+                            "range": [60, 61],
+                            "name": "tilt 4 180"
+                        },
+                        {
+                            "range": [62, 63],
+                            "name": "tilt 4 270"
+                        },
+                        {
+                            "range": [64, 95],
+                            "name": "p/t"
+                        },
+                        {
+                            "range": [96, 127],
+                            "name": "p/t inv."
+                        },
+                        {
+                            "range": [128, 159],
+                            "name": "circle"
+                        },
+                        {
+                            "range": [160, 191],
+                            "name": "circle inv."
+                        },
+                        {
+                            "range": [192, 223],
+                            "name": "lying axle"
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "random"
+                        }
+                    ]
+                },
+                "P/T speed": {
+                    "type": "Speed",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "track"
+                        },
+                        {
+                            "range": [16, 255],
+                            "name": "speed"
+                        }
+                    ]
+                },
+                "Laser": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "off",
+                            "center": true
+                        },
+                        {
+                            "range": [16, 31],
+                            "name": "random strobe"
+                        },
+                        {
+                            "range": [32, 47],
+                            "name": "audio strobe"
+                        },
+                        {
+                            "range": [48, 127],
+                            "name": "pulse"
+                        },
+                        {
+                            "range": [128, 239],
+                            "name": "strobe"
+                        },
+                        {
+                            "range": [240, 255],
+                            "name": "on",
+                            "center": true
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "16-channel Mode",
+                    "shortName": "16ch",
+                    "channels": [
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "Color",
+                        "Gobo1",
+                        "Gobo1 rot.",
+                        "Gobo2",
+                        "Shutter",
+                        "Intensity",
+                        "Focus",
+                        "Prisma",
+                        "Special",
+                        "Movement",
+                        "P/T speed",
+                        "Laser"
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/fixtures/imports/ecue-MainLibrary/Generic.json
+++ b/fixtures/imports/ecue-MainLibrary/Generic.json
@@ -1,0 +1,1580 @@
+{
+    "manufacturers": {
+        "Generic": {
+            "name": "Generic"
+        }
+    },
+    "fixtures": [
+        {
+            "manufacturer": "Generic",
+            "name": "2-ch Strobe",
+            "shortName": "2-ch Strobe",
+            "comment": "cd",
+            "physical": {
+                "dimensions": [100, 100, 100]
+            },
+            "availableChannels": {
+                "Speed": {
+                    "type": "Speed",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "2-channel Mode",
+                    "shortName": "2ch",
+                    "channels": [
+                        "Speed",
+                        "Intensity"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Generic",
+            "name": "CMY Fader",
+            "shortName": "CMY",
+            "physical": {
+                "dimensions": [100, 100, 100]
+            },
+            "availableChannels": {
+                "Yellow": {
+                    "type": "SingleColor",
+                    "color": "Yellow",
+                    "defaultValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Magenta": {
+                    "type": "SingleColor",
+                    "color": "Magenta",
+                    "defaultValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Cyan": {
+                    "type": "SingleColor",
+                    "color": "Cyan",
+                    "defaultValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "3-channel Mode",
+                    "shortName": "3ch",
+                    "channels": [
+                        "Yellow",
+                        "Magenta",
+                        "Cyan"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Generic",
+            "name": "CMY Fader Dim",
+            "shortName": "CMYfdim",
+            "comment": "CMY Fader and Dimmer as Multipart Fixture",
+            "physical": {
+                "dimensions": [100, 100, 100]
+            },
+            "availableChannels": {
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Yellow": {
+                    "type": "SingleColor",
+                    "color": "Yellow",
+                    "defaultValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Magenta": {
+                    "type": "SingleColor",
+                    "color": "Magenta",
+                    "defaultValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Cyan": {
+                    "type": "SingleColor",
+                    "color": "Cyan",
+                    "defaultValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "4-channel Mode",
+                    "shortName": "4ch",
+                    "channels": [
+                        "Intensity",
+                        "Yellow",
+                        "Magenta",
+                        "Cyan"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Generic",
+            "name": "Desk Channel",
+            "shortName": "Dskch",
+            "comment": "Standard Dimmer Channel ('Par Light' etc.)",
+            "physical": {
+                "dimensions": [100, 100, 100]
+            },
+            "availableChannels": {
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "1-channel Mode",
+                    "shortName": "1ch",
+                    "channels": [
+                        "Intensity"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Generic",
+            "name": "Desk Channel 16 bit",
+            "shortName": "Dskch16",
+            "comment": "Dimmer channel with 16 bit resolution",
+            "physical": {
+                "dimensions": [100, 100, 100]
+            },
+            "availableChannels": {
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 0,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "defaultValue": null
+                },
+                "Intensity fine": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "defaultValue": null
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Intensity",
+                    "Intensity fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "2-channel Mode",
+                    "shortName": "2ch",
+                    "channels": [
+                        "Intensity",
+                        "Intensity fine"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Generic",
+            "name": "Desk Channel 16 bit HL",
+            "shortName": "Dskch16HL",
+            "comment": "Dimmer channel with 16 bit resolution",
+            "physical": {
+                "dimensions": [100, 100, 100]
+            },
+            "availableChannels": {
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "defaultValue": null
+                },
+                "Intensity fine": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "defaultValue": null
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Intensity",
+                    "Intensity fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "2-channel Mode",
+                    "shortName": "2ch",
+                    "channels": [
+                        "Intensity fine",
+                        "Intensity"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Generic",
+            "name": "DimRGB Fader",
+            "shortName": "DimRGBFader",
+            "comment": "RGB Fader and Dimmer as Multipart Fixture",
+            "physical": {
+                "dimensions": [100, 100, 100]
+            },
+            "availableChannels": {
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "4-channel Mode",
+                    "shortName": "4ch",
+                    "channels": [
+                        "Intensity",
+                        "Red",
+                        "Green",
+                        "Blue"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Generic",
+            "name": "DW 2CH",
+            "shortName": "DW 2CH",
+            "physical": {
+                "dimensions": [100, 100, 100]
+            },
+            "availableChannels": {
+                "Warm White": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Cool White": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                }
+            },
+            "modes": [
+                {
+                    "name": "2-channel Mode",
+                    "shortName": "2ch",
+                    "channels": [
+                        "Warm White",
+                        "Cool White"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Generic",
+            "name": "DW 3CH",
+            "shortName": "DW 3CH",
+            "physical": {
+                "dimensions": [100, 100, 100]
+            },
+            "availableChannels": {
+                "Warm White 1": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Cool White": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Warm White 2": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                }
+            },
+            "modes": [
+                {
+                    "name": "3-channel Mode",
+                    "shortName": "3ch",
+                    "channels": [
+                        "Warm White 1",
+                        "Cool White",
+                        "Warm White 2"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Generic",
+            "name": "MountXY",
+            "shortName": "MountXY",
+            "physical": {
+                "dimensions": [100, 100, 100]
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "2-channel Mode",
+                    "shortName": "2ch",
+                    "channels": [
+                        "Pan",
+                        "Tilt"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Generic",
+            "name": "MountXY16 bit",
+            "shortName": "MountXY16",
+            "physical": {
+                "dimensions": [100, 100, 100]
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "4-channel Mode",
+                    "shortName": "4ch",
+                    "channels": [
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Generic",
+            "name": "Non Dimmable",
+            "shortName": "NoDim",
+            "comment": "Switching single channel.",
+            "physical": {
+                "dimensions": [100, 100, 100]
+            },
+            "availableChannels": {
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 254],
+                            "name": "off",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "on",
+                            "showInMenu": false
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "1-channel Mode",
+                    "shortName": "1ch",
+                    "channels": [
+                        "Intensity"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Generic",
+            "name": "RBGWFader",
+            "shortName": "RBGW",
+            "physical": {
+                "dimensions": [100, 100, 100]
+            },
+            "availableChannels": {
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "White": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "4-channel Mode",
+                    "shortName": "4ch",
+                    "channels": [
+                        "Red",
+                        "Blue",
+                        "Green",
+                        "White"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Generic",
+            "name": "RGB Fader",
+            "shortName": "RGBFader",
+            "physical": {
+                "dimensions": [100, 100, 100]
+            },
+            "availableChannels": {
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "3-channel Mode",
+                    "shortName": "3ch",
+                    "channels": [
+                        "Red",
+                        "Green",
+                        "Blue"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Generic",
+            "name": "RGB Par",
+            "shortName": "RGBPar",
+            "comment": "cd",
+            "physical": {
+                "dimensions": [100, 100, 100]
+            },
+            "availableChannels": {
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Macro": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "off"
+                        },
+                        {
+                            "range": [16, 255],
+                            "name": "on"
+                        }
+                    ]
+                },
+                "Strobe/Speed": {
+                    "type": "Speed",
+                    "crossfade": true
+                },
+                "Mode": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 31],
+                            "name": "color"
+                        },
+                        {
+                            "range": [32, 63],
+                            "name": "fade out"
+                        },
+                        {
+                            "range": [64, 95],
+                            "name": "fade in"
+                        },
+                        {
+                            "range": [96, 127],
+                            "name": "fade in/out"
+                        },
+                        {
+                            "range": [128, 159],
+                            "name": "auto"
+                        },
+                        {
+                            "range": [160, 191],
+                            "name": "RGB chase"
+                        },
+                        {
+                            "range": [192, 223],
+                            "name": "7C chase"
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "sound"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                }
+            },
+            "modes": [
+                {
+                    "name": "7-channel Mode",
+                    "shortName": "7ch",
+                    "channels": [
+                        "Red",
+                        "Green",
+                        "Blue",
+                        "Macro",
+                        "Strobe/Speed",
+                        "Mode",
+                        "Intensity"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Generic",
+            "name": "RGB16 bit",
+            "shortName": "RGB16",
+            "comment": "RGB Fader with 16 bit channels",
+            "physical": {
+                "dimensions": [100, 100, 100]
+            },
+            "availableChannels": {
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "defaultValue": null
+                },
+                "Red fine": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "defaultValue": null
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "defaultValue": null
+                },
+                "Green fine": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "defaultValue": null
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "defaultValue": null
+                },
+                "Blue fine": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "defaultValue": null
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Red",
+                    "Red fine"
+                ],
+                [
+                    "Green",
+                    "Green fine"
+                ],
+                [
+                    "Blue",
+                    "Blue fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "6-channel Mode",
+                    "shortName": "6ch",
+                    "channels": [
+                        "Red",
+                        "Red fine",
+                        "Green",
+                        "Green fine",
+                        "Blue",
+                        "Blue fine"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Generic",
+            "name": "RGB16 bit HL",
+            "shortName": "RGB16 HL",
+            "comment": "RGB Fader with 16 bit channels",
+            "physical": {
+                "dimensions": [100, 100, 100]
+            },
+            "availableChannels": {
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "defaultValue": null
+                },
+                "Red fine": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "defaultValue": null
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "defaultValue": null
+                },
+                "Green fine": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "defaultValue": null
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "defaultValue": null
+                },
+                "Blue fine": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "defaultValue": null
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Red",
+                    "Red fine"
+                ],
+                [
+                    "Green",
+                    "Green fine"
+                ],
+                [
+                    "Blue",
+                    "Blue fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "6-channel Mode",
+                    "shortName": "6ch",
+                    "channels": [
+                        "Red fine",
+                        "Red",
+                        "Green fine",
+                        "Green",
+                        "Blue fine",
+                        "Blue"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Generic",
+            "name": "RGBAWFader",
+            "shortName": "RGBAW",
+            "comment": "5 CH",
+            "physical": {
+                "dimensions": [100, 100, 100]
+            },
+            "availableChannels": {
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Amber": {
+                    "type": "SingleColor",
+                    "color": "Amber",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "White": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                }
+            },
+            "modes": [
+                {
+                    "name": "5-channel Mode",
+                    "shortName": "5ch",
+                    "channels": [
+                        "Red",
+                        "Green",
+                        "Blue",
+                        "Amber",
+                        "White"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Generic",
+            "name": "RGBDim Fader",
+            "shortName": "RGBDimFader",
+            "comment": "RGB Fader and Dimmer as Multipart Fixture",
+            "physical": {
+                "dimensions": [100, 100, 100]
+            },
+            "availableChannels": {
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "4-channel Mode",
+                    "shortName": "4ch",
+                    "channels": [
+                        "Red",
+                        "Green",
+                        "Blue",
+                        "Intensity"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Generic",
+            "name": "RGBWAFader",
+            "shortName": "RGBWA",
+            "comment": "5 CH",
+            "physical": {
+                "dimensions": [100, 100, 100]
+            },
+            "availableChannels": {
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "White": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Amber": {
+                    "type": "SingleColor",
+                    "color": "Amber",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                }
+            },
+            "modes": [
+                {
+                    "name": "5-channel Mode",
+                    "shortName": "5ch",
+                    "channels": [
+                        "Red",
+                        "Green",
+                        "Blue",
+                        "White",
+                        "Amber"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Generic",
+            "name": "RGBWFader",
+            "shortName": "RGBW",
+            "physical": {
+                "dimensions": [100, 100, 100]
+            },
+            "availableChannels": {
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "White": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "4-channel Mode",
+                    "shortName": "4ch",
+                    "channels": [
+                        "Red",
+                        "Green",
+                        "Blue",
+                        "White"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Generic",
+            "name": "Scroller",
+            "shortName": "Scroller",
+            "comment": "Single Scroller (Single channel not affected by Grandmaster)",
+            "physical": {
+                "dimensions": [100, 100, 100]
+            },
+            "availableChannels": {
+                "Colour": {
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "1-channel Mode",
+                    "shortName": "1ch",
+                    "channels": [
+                        "Colour"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Generic",
+            "name": "Scroller 16 Bit",
+            "shortName": "Scroller16",
+            "comment": "16 Bit Deskchannel not affected by Grandmaster",
+            "physical": {
+                "dimensions": [100, 100, 100]
+            },
+            "availableChannels": {
+                "Colour": {
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "Colour fine": {
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "defaultValue": null,
+                    "highlightValue": null
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Colour",
+                    "Colour fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "2-channel Mode",
+                    "shortName": "2ch",
+                    "channels": [
+                        "Colour",
+                        "Colour fine"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Generic",
+            "name": "Scroller Dimmer",
+            "shortName": "Scrldim",
+            "comment": "Scroller and Dimmer (Multipart Fixture)",
+            "physical": {
+                "dimensions": [100, 100, 100]
+            },
+            "availableChannels": {
+                "Colour": {
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "2-channel Mode",
+                    "shortName": "2ch",
+                    "channels": [
+                        "Colour",
+                        "Intensity"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Generic",
+            "name": "SWA Fader",
+            "shortName": "SWAFader",
+            "comment": "(Smartwhite + Amber)",
+            "physical": {
+                "dimensions": [100, 100, 100]
+            },
+            "availableChannels": {
+                "Cold": {
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Warm": {
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Amber": {
+                    "type": "SingleColor",
+                    "color": "Amber",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "3-channel Mode",
+                    "shortName": "3ch",
+                    "channels": [
+                        "Cold",
+                        "Warm",
+                        "Amber"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Generic",
+            "name": "Switch",
+            "shortName": "Switch",
+            "comment": "Switching channel. No submaster influence.",
+            "physical": {
+                "dimensions": [100, 100, 100]
+            },
+            "availableChannels": {
+                "Set": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "OFF"
+                        },
+                        {
+                            "range": [1, 254],
+                            "name": "Middle"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "ON"
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "1-channel Mode",
+                    "shortName": "1ch",
+                    "channels": [
+                        "Set"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Generic",
+            "name": "WW Fader",
+            "shortName": "WWFader",
+            "comment": "Dual White Fader",
+            "physical": {
+                "dimensions": [100, 100, 100]
+            },
+            "availableChannels": {
+                "Intensity A": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Intensity B": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "2-channel Mode",
+                    "shortName": "2ch",
+                    "channels": [
+                        "Intensity A",
+                        "Intensity B"
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/fixtures/imports/ecue-MainLibrary/Geni.json
+++ b/fixtures/imports/ecue-MainLibrary/Geni.json
@@ -1,0 +1,202 @@
+{
+    "manufacturers": {
+        "Geni": {
+            "name": "Geni",
+            "comment": "Geni Electronics Co. ",
+            "website": "http://geni.com.hk/"
+        }
+    },
+    "fixtures": [
+        {
+            "manufacturer": "Geni",
+            "name": "Shiva-250R",
+            "shortName": "Shiva-250R",
+            "comment": "http://www.bekafun.net/files/producten/jli-genishiva200r-manual.pdf",
+            "physical": {
+                "dimensions": [300, 180, 670],
+                "weight": 15,
+                "power": 300
+            },
+            "availableChannels": {
+                "Shutter": {
+                    "type": "Shutter",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 159],
+                            "name": "Dimmer"
+                        },
+                        {
+                            "range": [160, 253],
+                            "name": "Strobe 1..7fps"
+                        },
+                        {
+                            "range": [254, 255],
+                            "name": "Open"
+                        }
+                    ]
+                },
+                "Color": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "White",
+                            "color": "#ffffff"
+                        },
+                        {
+                            "range": [16, 31],
+                            "name": "Pink",
+                            "color": "#ffc0cb",
+                            "center": true
+                        },
+                        {
+                            "range": [32, 47],
+                            "name": "Yellow",
+                            "color": "#ffff00",
+                            "center": true
+                        },
+                        {
+                            "range": [48, 63],
+                            "name": "Light Blue",
+                            "color": "#add8e6",
+                            "center": true
+                        },
+                        {
+                            "range": [64, 79],
+                            "name": "Green",
+                            "color": "#00ff00",
+                            "center": true
+                        },
+                        {
+                            "range": [80, 95],
+                            "name": "Orange",
+                            "color": "#ff7f00",
+                            "center": true
+                        },
+                        {
+                            "range": [96, 111],
+                            "name": "Purple",
+                            "color": "#800080",
+                            "center": true
+                        },
+                        {
+                            "range": [112, 127],
+                            "name": "Red",
+                            "color": "#ff0000",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 143],
+                            "name": "Dark Blue",
+                            "color": "#00008b",
+                            "center": true
+                        },
+                        {
+                            "range": [144, 174],
+                            "name": "Indigo",
+                            "color": "#4b0082",
+                            "center": true
+                        },
+                        {
+                            "range": [175, 255],
+                            "name": "ColorRot sl..fs"
+                        }
+                    ]
+                },
+                "Gobo": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 42],
+                            "name": "Gobo1"
+                        },
+                        {
+                            "range": [43, 85],
+                            "name": "Gobo2",
+                            "center": true
+                        },
+                        {
+                            "range": [86, 127],
+                            "name": "Gobo3",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 170],
+                            "name": "Gobo4",
+                            "center": true
+                        },
+                        {
+                            "range": [171, 213],
+                            "name": "Gobo5",
+                            "center": true
+                        },
+                        {
+                            "range": [214, 255],
+                            "name": "Gobo6",
+                            "center": true
+                        }
+                    ]
+                },
+                "Gobo Rotation": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 7],
+                            "name": "No Rotation"
+                        },
+                        {
+                            "range": [8, 131],
+                            "name": "ccw"
+                        },
+                        {
+                            "range": [132, 255],
+                            "name": "cw"
+                        }
+                    ]
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "0..170"
+                        }
+                    ]
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "0..90"
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "6-channel Mode",
+                    "shortName": "6ch",
+                    "channels": [
+                        "Shutter",
+                        "Color",
+                        "Gobo",
+                        "Gobo Rotation",
+                        "Pan",
+                        "Tilt"
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/fixtures/imports/ecue-MainLibrary/Griven.json
+++ b/fixtures/imports/ecue-MainLibrary/Griven.json
@@ -1,0 +1,59 @@
+{
+    "manufacturers": {
+        "Griven": {
+            "name": "Griven",
+            "website": "http://www.griven.com"
+        }
+    },
+    "fixtures": [
+        {
+            "manufacturer": "Griven",
+            "name": "Colorado 1800 MK 2",
+            "shortName": "Colorado 1800",
+            "physical": {
+                "dimensions": [650, 650, 650],
+                "weight": 60
+            },
+            "availableChannels": {
+                "Lamp On": {
+                    "type": "Beam"
+                },
+                "Dimmer": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Yellow": {
+                    "type": "SingleColor",
+                    "color": "Yellow",
+                    "crossfade": true
+                },
+                "Cyan": {
+                    "type": "SingleColor",
+                    "color": "Cyan",
+                    "crossfade": true
+                },
+                "Magenta": {
+                    "type": "SingleColor",
+                    "color": "Magenta",
+                    "crossfade": true
+                }
+            },
+            "modes": [
+                {
+                    "name": "5-channel Mode",
+                    "shortName": "5ch",
+                    "channels": [
+                        "Lamp On",
+                        "Dimmer",
+                        "Yellow",
+                        "Cyan",
+                        "Magenta"
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/fixtures/imports/ecue-MainLibrary/High-End-Systems.json
+++ b/fixtures/imports/ecue-MainLibrary/High-End-Systems.json
@@ -1,0 +1,9814 @@
+{
+    "manufacturers": {
+        "High End Systems": {
+            "name": "High End Systems",
+            "website": "www.highend.com"
+        }
+    },
+    "fixtures": [
+        {
+            "manufacturer": "High End Systems",
+            "name": "Catalyst",
+            "shortName": "Catalyst",
+            "physical": {
+                "dimensions": [100, 100, 100],
+                "weight": 20
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Speed": {
+                    "type": "Speed",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Control": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Library": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "Folder0"
+                        },
+                        {
+                            "range": [1, 1],
+                            "name": "Folder1"
+                        },
+                        {
+                            "range": [2, 2],
+                            "name": "Folder2"
+                        },
+                        {
+                            "range": [3, 3],
+                            "name": "Folder3"
+                        },
+                        {
+                            "range": [4, 4],
+                            "name": "Folder4"
+                        },
+                        {
+                            "range": [5, 5],
+                            "name": "Folder5"
+                        },
+                        {
+                            "range": [6, 6],
+                            "name": "Folder6"
+                        },
+                        {
+                            "range": [7, 7],
+                            "name": "Folder7"
+                        },
+                        {
+                            "range": [8, 8],
+                            "name": "Folder8"
+                        },
+                        {
+                            "range": [9, 9],
+                            "name": "Folder9"
+                        },
+                        {
+                            "range": [10, 10],
+                            "name": "Folder10"
+                        },
+                        {
+                            "range": [11, 11],
+                            "name": "Folder11"
+                        },
+                        {
+                            "range": [12, 12],
+                            "name": "Folder12"
+                        },
+                        {
+                            "range": [13, 13],
+                            "name": "Folder13"
+                        },
+                        {
+                            "range": [14, 14],
+                            "name": "Folder14"
+                        },
+                        {
+                            "range": [15, 15],
+                            "name": "Folder15"
+                        },
+                        {
+                            "range": [16, 16],
+                            "name": "Folder16"
+                        },
+                        {
+                            "range": [17, 17],
+                            "name": "Folder17"
+                        },
+                        {
+                            "range": [18, 18],
+                            "name": "Folder18"
+                        },
+                        {
+                            "range": [19, 19],
+                            "name": "Folder19"
+                        },
+                        {
+                            "range": [20, 20],
+                            "name": "Folder20"
+                        },
+                        {
+                            "range": [21, 254],
+                            "name": "Folderx"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "Firewire"
+                        }
+                    ]
+                },
+                "File": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "File0"
+                        },
+                        {
+                            "range": [1, 1],
+                            "name": "File1"
+                        },
+                        {
+                            "range": [2, 2],
+                            "name": "File2"
+                        },
+                        {
+                            "range": [3, 3],
+                            "name": "File3"
+                        },
+                        {
+                            "range": [4, 4],
+                            "name": "File4"
+                        },
+                        {
+                            "range": [5, 5],
+                            "name": "File5"
+                        },
+                        {
+                            "range": [6, 6],
+                            "name": "File6"
+                        },
+                        {
+                            "range": [7, 7],
+                            "name": "File7"
+                        },
+                        {
+                            "range": [8, 8],
+                            "name": "File8"
+                        },
+                        {
+                            "range": [9, 9],
+                            "name": "File9"
+                        },
+                        {
+                            "range": [10, 10],
+                            "name": "File10"
+                        },
+                        {
+                            "range": [11, 11],
+                            "name": "File11"
+                        },
+                        {
+                            "range": [12, 12],
+                            "name": "File12"
+                        },
+                        {
+                            "range": [13, 13],
+                            "name": "File13"
+                        },
+                        {
+                            "range": [14, 14],
+                            "name": "File14"
+                        },
+                        {
+                            "range": [15, 15],
+                            "name": "File15"
+                        },
+                        {
+                            "range": [16, 16],
+                            "name": "File16"
+                        },
+                        {
+                            "range": [17, 17],
+                            "name": "File17"
+                        },
+                        {
+                            "range": [18, 18],
+                            "name": "File18"
+                        },
+                        {
+                            "range": [19, 19],
+                            "name": "File19"
+                        },
+                        {
+                            "range": [20, 20],
+                            "name": "File20"
+                        },
+                        {
+                            "range": [21, 255],
+                            "name": "Filex"
+                        }
+                    ]
+                },
+                "InFrame": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "InFrame fine": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "OutFrame": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "OutFrame fine": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "PlayMode": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 4],
+                            "name": "InFram",
+                            "center": true
+                        },
+                        {
+                            "range": [5, 9],
+                            "name": "OutFra",
+                            "center": true
+                        },
+                        {
+                            "range": [10, 19],
+                            "name": "Loop_fw",
+                            "center": true
+                        },
+                        {
+                            "range": [20, 29],
+                            "name": "Loop_rv",
+                            "center": true
+                        },
+                        {
+                            "range": [30, 39],
+                            "name": "Once_fw",
+                            "center": true
+                        },
+                        {
+                            "range": [40, 49],
+                            "name": "Once_rv",
+                            "center": true
+                        },
+                        {
+                            "range": [50, 59],
+                            "name": "Stop",
+                            "center": true
+                        },
+                        {
+                            "range": [60, 69],
+                            "name": "Random",
+                            "center": true
+                        },
+                        {
+                            "range": [70, 79],
+                            "name": "PlaySine",
+                            "center": true
+                        },
+                        {
+                            "range": [80, 255],
+                            "name": "TBD",
+                            "center": true
+                        }
+                    ]
+                },
+                "PlaySpeed": {
+                    "type": "Speed",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "Max"
+                        },
+                        {
+                            "range": [2, 255],
+                            "name": "Speed",
+                            "center": true
+                        }
+                    ]
+                },
+                "G_Frame": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "G_Frame fine": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "G_Size": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "G_Size fine": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "G_Rotate": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "G_Rotate fine": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "XAxis_Rot": {
+                    "type": "Beam",
+                    "defaultValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "XAxis_Rot fine": {
+                    "type": "Beam",
+                    "defaultValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "YAxis_Rot": {
+                    "type": "Beam",
+                    "defaultValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "YAxis_Rot fine": {
+                    "type": "Beam",
+                    "defaultValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "ZAxis_Rot": {
+                    "type": "Beam",
+                    "defaultValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "ZAxis_Rot fine": {
+                    "type": "Beam",
+                    "defaultValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Scale": {
+                    "type": "Beam",
+                    "defaultValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Scale fine": {
+                    "type": "Beam",
+                    "defaultValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "XPosition": {
+                    "type": "Beam",
+                    "defaultValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "XPosition fine": {
+                    "type": "Beam",
+                    "defaultValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "YPosition": {
+                    "type": "Beam",
+                    "defaultValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "YPosition fine": {
+                    "type": "Beam",
+                    "defaultValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Mov_Speed": {
+                    "type": "Speed",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Asp_Ratio": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 128],
+                            "name": "%Comp_hor."
+                        },
+                        {
+                            "range": [129, 255],
+                            "name": "%Comp_ver."
+                        }
+                    ]
+                },
+                "Mask": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "NoMask"
+                        },
+                        {
+                            "range": [1, 1],
+                            "name": "Black",
+                            "color": "#000000"
+                        },
+                        {
+                            "range": [2, 2],
+                            "name": "Big_Cir"
+                        },
+                        {
+                            "range": [3, 98],
+                            "name": "Var_Cir"
+                        },
+                        {
+                            "range": [99, 99],
+                            "name": "Small_Cir"
+                        },
+                        {
+                            "range": [100, 100],
+                            "name": "L_Square"
+                        },
+                        {
+                            "range": [101, 125],
+                            "name": "Var_Width"
+                        },
+                        {
+                            "range": [126, 126],
+                            "name": "Narr_rv"
+                        },
+                        {
+                            "range": [127, 127],
+                            "name": "L_Square"
+                        },
+                        {
+                            "range": [128, 150],
+                            "name": "Var_Height"
+                        },
+                        {
+                            "range": [151, 151],
+                            "name": "Narr_rh"
+                        },
+                        {
+                            "range": [152, 152],
+                            "name": "L_Square"
+                        },
+                        {
+                            "range": [153, 199],
+                            "name": "Var_size_sq"
+                        },
+                        {
+                            "range": [200, 200],
+                            "name": "S_Square"
+                        },
+                        {
+                            "range": [201, 255],
+                            "name": "TBD"
+                        }
+                    ]
+                },
+                "Mask_Fine": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "M_Rotate": {
+                    "type": "Beam",
+                    "defaultValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "M_Rotate fine": {
+                    "type": "Beam",
+                    "defaultValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Cyan": {
+                    "type": "SingleColor",
+                    "color": "Cyan",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Magenta": {
+                    "type": "SingleColor",
+                    "color": "Magenta",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Yellow": {
+                    "type": "SingleColor",
+                    "color": "Yellow",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Grad_Rd": {
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Grad_Gn": {
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Grad_Bl": {
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Strobe": {
+                    "type": "Strobe",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Crossfade": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Col_Rot": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Effects": {
+                    "type": "Effect",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 4],
+                            "name": "Gobo"
+                        },
+                        {
+                            "range": [5, 9],
+                            "name": "Wobble"
+                        },
+                        {
+                            "range": [10, 19],
+                            "name": "Tile"
+                        },
+                        {
+                            "range": [20, 29],
+                            "name": "Invert"
+                        },
+                        {
+                            "range": [30, 255],
+                            "name": "TBD"
+                        }
+                    ]
+                },
+                "Visual_1": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Visual_2": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Information": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ],
+                [
+                    "InFrame",
+                    "InFrame fine"
+                ],
+                [
+                    "OutFrame",
+                    "OutFrame fine"
+                ],
+                [
+                    "G_Frame",
+                    "G_Frame fine"
+                ],
+                [
+                    "G_Size",
+                    "G_Size fine"
+                ],
+                [
+                    "G_Rotate",
+                    "G_Rotate fine"
+                ],
+                [
+                    "XAxis_Rot",
+                    "XAxis_Rot fine"
+                ],
+                [
+                    "YAxis_Rot",
+                    "YAxis_Rot fine"
+                ],
+                [
+                    "ZAxis_Rot",
+                    "ZAxis_Rot fine"
+                ],
+                [
+                    "Scale",
+                    "Scale fine"
+                ],
+                [
+                    "XPosition",
+                    "XPosition fine"
+                ],
+                [
+                    "YPosition",
+                    "YPosition fine"
+                ],
+                [
+                    "M_Rotate",
+                    "M_Rotate fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "52-channel Mode",
+                    "shortName": "52ch",
+                    "channels": [
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "Speed",
+                        "Control",
+                        "Library",
+                        "File",
+                        "InFrame",
+                        "InFrame fine",
+                        "OutFrame",
+                        "OutFrame fine",
+                        "PlayMode",
+                        "PlaySpeed",
+                        "G_Frame",
+                        "G_Frame fine",
+                        "G_Size",
+                        "G_Size fine",
+                        "G_Rotate",
+                        "G_Rotate fine",
+                        "XAxis_Rot",
+                        "XAxis_Rot fine",
+                        "YAxis_Rot",
+                        "YAxis_Rot fine",
+                        "ZAxis_Rot",
+                        "ZAxis_Rot fine",
+                        "Scale",
+                        "Scale fine",
+                        "XPosition",
+                        "XPosition fine",
+                        "YPosition",
+                        "YPosition fine",
+                        "Mov_Speed",
+                        "Asp_Ratio",
+                        "Mask",
+                        "Mask_Fine",
+                        "M_Rotate",
+                        "M_Rotate fine",
+                        "Intensity",
+                        "Cyan",
+                        "Magenta",
+                        "Yellow",
+                        "Grad_Rd",
+                        "Grad_Gn",
+                        "Grad_Bl",
+                        "Strobe",
+                        "Crossfade",
+                        "Col_Rot",
+                        "Effects",
+                        "Visual_1",
+                        "Visual_2",
+                        "Information"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "High End Systems",
+            "name": "Catalyst DL1",
+            "shortName": "DL1",
+            "physical": {
+                "dimensions": [100, 100, 100]
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Shutter": {
+                    "type": "Shutter",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Focus": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Zoom": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Speed": {
+                    "type": "Speed",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Macro": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "reserved"
+                        }
+                    ]
+                },
+                "Control": {
+                    "type": "MultiColor",
+                    "capabilities": [
+                        {
+                            "range": [0, 9],
+                            "name": "safe"
+                        },
+                        {
+                            "range": [10, 13],
+                            "name": "speed off"
+                        },
+                        {
+                            "range": [20, 28],
+                            "name": "display off"
+                        },
+                        {
+                            "range": [30, 38],
+                            "name": "display dim"
+                        },
+                        {
+                            "range": [40, 48],
+                            "name": "display bright"
+                        },
+                        {
+                            "range": [60, 68],
+                            "name": "home all"
+                        },
+                        {
+                            "range": [80, 88],
+                            "name": "lamp on"
+                        },
+                        {
+                            "range": [90, 98],
+                            "name": "lamp off"
+                        },
+                        {
+                            "range": [120, 130],
+                            "name": "shutdown"
+                        },
+                        {
+                            "range": [131, 149],
+                            "name": "reserved"
+                        },
+                        {
+                            "range": [160, 168],
+                            "name": "Home Focus"
+                        },
+                        {
+                            "range": [170, 178],
+                            "name": "Home Beam"
+                        },
+                        {
+                            "range": [180, 184],
+                            "name": "Projector Menu"
+                        },
+                        {
+                            "range": [185, 188],
+                            "name": "Projector Up"
+                        },
+                        {
+                            "range": [189, 192],
+                            "name": "Projector Down"
+                        },
+                        {
+                            "range": [193, 196],
+                            "name": "Projector Left"
+                        },
+                        {
+                            "range": [197, 200],
+                            "name": "Projector Right"
+                        },
+                        {
+                            "range": [201, 204],
+                            "name": "Projector Selec"
+                        },
+                        {
+                            "range": [205, 208],
+                            "name": "Projector Floor"
+                        },
+                        {
+                            "range": [209, 212],
+                            "name": "Projector Ceili"
+                        },
+                        {
+                            "range": [213, 216],
+                            "name": "Projector Front"
+                        },
+                        {
+                            "range": [217, 220],
+                            "name": "Projector Rear"
+                        }
+                    ]
+                },
+                "Input": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 31],
+                            "name": "Safe"
+                        },
+                        {
+                            "range": [32, 47],
+                            "name": "RGBHV"
+                        },
+                        {
+                            "range": [48, 63],
+                            "name": "S-Video"
+                        },
+                        {
+                            "range": [64, 79],
+                            "name": "Internal"
+                        },
+                        {
+                            "range": [80, 255],
+                            "name": "reserved"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "11-channel Mode",
+                    "shortName": "11ch",
+                    "channels": [
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "Shutter",
+                        "Focus",
+                        "Zoom",
+                        "Speed",
+                        "Macro",
+                        "Control",
+                        "Input"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "High End Systems",
+            "name": "Catalyst MS",
+            "shortName": "CatMS3_0",
+            "comment": "Catalyst Media Server Version 3.0 DMX Protocol",
+            "physical": {
+                "dimensions": [100, 100, 100]
+            },
+            "availableChannels": {
+                "Library": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 253],
+                            "name": "folder"
+                        },
+                        {
+                            "range": [254, 254],
+                            "name": "reference"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "live video"
+                        }
+                    ]
+                },
+                "File": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "file 0"
+                        },
+                        {
+                            "range": [1, 1],
+                            "name": "file 1"
+                        },
+                        {
+                            "range": [2, 2],
+                            "name": "file 2"
+                        },
+                        {
+                            "range": [3, 3],
+                            "name": "file 3"
+                        },
+                        {
+                            "range": [4, 4],
+                            "name": "file 4"
+                        },
+                        {
+                            "range": [5, 5],
+                            "name": "file 5"
+                        },
+                        {
+                            "range": [6, 6],
+                            "name": "file 6"
+                        },
+                        {
+                            "range": [7, 7],
+                            "name": "file 7"
+                        },
+                        {
+                            "range": [8, 8],
+                            "name": "file 8"
+                        },
+                        {
+                            "range": [9, 9],
+                            "name": "file 9"
+                        },
+                        {
+                            "range": [10, 10],
+                            "name": "file 10"
+                        },
+                        {
+                            "range": [11, 255],
+                            "name": "file"
+                        }
+                    ]
+                },
+                "InFrame": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "InFrame fine": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "OutFrame": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "OutFrame fine": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "PlayMode": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [1, 1],
+                            "name": "InFrame"
+                        },
+                        {
+                            "range": [2, 2],
+                            "name": "OutFrame"
+                        },
+                        {
+                            "range": [3, 3],
+                            "name": "loop_cw"
+                        },
+                        {
+                            "range": [4, 4],
+                            "name": "loop_ccw"
+                        },
+                        {
+                            "range": [5, 5],
+                            "name": "one_cw"
+                        },
+                        {
+                            "range": [6, 6],
+                            "name": "once_ccw"
+                        },
+                        {
+                            "range": [7, 7],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [8, 8],
+                            "name": "random"
+                        },
+                        {
+                            "range": [9, 9],
+                            "name": "playsine"
+                        },
+                        {
+                            "range": [80, 99],
+                            "name": "synchronize"
+                        },
+                        {
+                            "range": [100, 255],
+                            "name": "reserved"
+                        }
+                    ]
+                },
+                "Speed": {
+                    "type": "Speed",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "100%"
+                        },
+                        {
+                            "range": [1, 1],
+                            "name": "pause"
+                        },
+                        {
+                            "range": [2, 255],
+                            "name": "0-200%"
+                        }
+                    ]
+                },
+                "X-Axis Rotate": {
+                    "type": "Beam",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 16382],
+                            "name": "cont_ccw",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [16383, 16383],
+                            "name": "stop",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [16384, 32767],
+                            "name": "index_ccw",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [32768, 32768],
+                            "name": "0",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [32769, 49152],
+                            "name": "index_cw",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [49153, 49153],
+                            "name": "stop",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [49154, 65535],
+                            "name": "var.rotation",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "X-Axis Rotate fine": {
+                    "type": "Beam",
+                    "defaultValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 16382],
+                            "name": "cont_ccw",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [16383, 16383],
+                            "name": "stop",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [16384, 32767],
+                            "name": "index_ccw",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [32768, 32768],
+                            "name": "0",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [32769, 49152],
+                            "name": "index_cw",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [49153, 49153],
+                            "name": "stop",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [49154, 65535],
+                            "name": "var.rotation",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Y-Axis Rotate": {
+                    "type": "Beam",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 16382],
+                            "name": "cont_ccw",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [16383, 16383],
+                            "name": "stop",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [16384, 32767],
+                            "name": "index_ccw",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [32768, 32768],
+                            "name": "0",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [32769, 49152],
+                            "name": "index_cw",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [49153, 49153],
+                            "name": "stop",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [49154, 65535],
+                            "name": "var.rotation",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Y-Axis Rotate fine": {
+                    "type": "Beam",
+                    "defaultValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 16382],
+                            "name": "cont_ccw",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [16383, 16383],
+                            "name": "stop",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [16384, 32767],
+                            "name": "index_ccw",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [32768, 32768],
+                            "name": "0",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [32769, 49152],
+                            "name": "index_cw",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [49153, 49153],
+                            "name": "stop",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [49154, 65535],
+                            "name": "var.rotation",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Z-Axis Rotate": {
+                    "type": "Beam",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 16382],
+                            "name": "cont_ccw",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [16383, 16383],
+                            "name": "stop",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [16384, 32767],
+                            "name": "index_ccw",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [32768, 32768],
+                            "name": "0",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [32769, 49152],
+                            "name": "index_cw",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [49153, 49153],
+                            "name": "stop",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [49154, 65535],
+                            "name": "var.rotation",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Z-Axis Rotate fine": {
+                    "type": "Beam",
+                    "defaultValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 16382],
+                            "name": "cont_ccw",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [16383, 16383],
+                            "name": "stop",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [16384, 32767],
+                            "name": "index_ccw",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [32768, 32768],
+                            "name": "0",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [32769, 49152],
+                            "name": "index_cw",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [49153, 49153],
+                            "name": "stop",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [49154, 65535],
+                            "name": "var.rotation",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Scale": {
+                    "type": "Beam",
+                    "defaultValue": 144,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 32767],
+                            "name": "size_inverted",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [32768, 32768],
+                            "name": "scaled to 0",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [32769, 36863],
+                            "name": "resize from 0",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [36864, 36864],
+                            "name": "actual size",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [32769, 65535],
+                            "name": "image size",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Scale fine": {
+                    "type": "Beam",
+                    "defaultValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 32767],
+                            "name": "size_inverted",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [32768, 32768],
+                            "name": "scaled to 0",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [32769, 36863],
+                            "name": "resize from 0",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [36864, 36864],
+                            "name": "actual size",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [32769, 65535],
+                            "name": "image size",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "X-Position": {
+                    "type": "Intensity",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "highlightValue": null
+                },
+                "X-Position fine": {
+                    "type": "Intensity",
+                    "defaultValue": 0,
+                    "crossfade": true,
+                    "highlightValue": null
+                },
+                "Y-Position": {
+                    "type": "Intensity",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "highlightValue": null
+                },
+                "Y-Position fine": {
+                    "type": "Intensity",
+                    "defaultValue": 0,
+                    "crossfade": true,
+                    "highlightValue": null
+                },
+                "Ratio": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 128],
+                            "name": "compress horiz."
+                        },
+                        {
+                            "range": [129, 255],
+                            "name": "compress vert."
+                        }
+                    ]
+                },
+                "movement": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "defaultValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "defaultValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "defaultValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Strobe": {
+                    "type": "Strobe",
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "no strobe"
+                        },
+                        {
+                            "range": [1, 24],
+                            "name": "pattern 1"
+                        },
+                        {
+                            "range": [25, 49],
+                            "name": "pattern 2"
+                        },
+                        {
+                            "range": [50, 74],
+                            "name": "pattern 3"
+                        },
+                        {
+                            "range": [75, 99],
+                            "name": "pattern 4"
+                        },
+                        {
+                            "range": [100, 124],
+                            "name": "flicker"
+                        },
+                        {
+                            "range": [125, 149],
+                            "name": "random"
+                        },
+                        {
+                            "range": [150, 255],
+                            "name": "no strobe"
+                        }
+                    ]
+                },
+                "Trail": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "incl. duration"
+                        }
+                    ]
+                },
+                "ColorFX": {
+                    "type": "MultiColor",
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "RGB Subtract"
+                        },
+                        {
+                            "range": [1, 1],
+                            "name": "RGB High Contr"
+                        },
+                        {
+                            "range": [2, 2],
+                            "name": "RGB highest Con"
+                        },
+                        {
+                            "range": [3, 3],
+                            "name": "trans black"
+                        },
+                        {
+                            "range": [4, 4],
+                            "name": "trans white"
+                        },
+                        {
+                            "range": [10, 10],
+                            "name": "RGB Subtract In"
+                        },
+                        {
+                            "range": [11, 11],
+                            "name": "RGB Subtract Hi"
+                        },
+                        {
+                            "range": [12, 12],
+                            "name": "RGB Subtract Hi"
+                        },
+                        {
+                            "range": [13, 13],
+                            "name": "invert gray"
+                        },
+                        {
+                            "range": [20, 20],
+                            "name": "black white",
+                            "color": "#fffef6"
+                        },
+                        {
+                            "range": [21, 21],
+                            "name": "black white hig"
+                        },
+                        {
+                            "range": [22, 22],
+                            "name": "black white shi"
+                        },
+                        {
+                            "range": [23, 23],
+                            "name": "black white ssh"
+                        },
+                        {
+                            "range": [24, 24],
+                            "name": "invert black"
+                        },
+                        {
+                            "range": [30, 30],
+                            "name": "mask"
+                        },
+                        {
+                            "range": [31, 31],
+                            "name": "invert mask 1"
+                        },
+                        {
+                            "range": [32, 32],
+                            "name": "invert mask 2"
+                        },
+                        {
+                            "range": [40, 40],
+                            "name": "alpha as red"
+                        },
+                        {
+                            "range": [41, 41],
+                            "name": "alpha as green"
+                        },
+                        {
+                            "range": [42, 42],
+                            "name": "alpha as blue"
+                        },
+                        {
+                            "range": [43, 43],
+                            "name": "alpha as color"
+                        },
+                        {
+                            "range": [50, 50],
+                            "name": "reserved"
+                        },
+                        {
+                            "range": [51, 51],
+                            "name": "lookup 2 color"
+                        },
+                        {
+                            "range": [52, 52],
+                            "name": "lookup BW"
+                        },
+                        {
+                            "range": [60, 60],
+                            "name": "gamma BW"
+                        },
+                        {
+                            "range": [61, 61],
+                            "name": "gamma color"
+                        },
+                        {
+                            "range": [61, 61],
+                            "name": "gamma color sep"
+                        },
+                        {
+                            "range": [70, 70],
+                            "name": "convert YUV"
+                        },
+                        {
+                            "range": [71, 71],
+                            "name": "saturation"
+                        },
+                        {
+                            "range": [72, 72],
+                            "name": "high saturation"
+                        },
+                        {
+                            "range": [73, 73],
+                            "name": "solarize"
+                        },
+                        {
+                            "range": [74, 74],
+                            "name": "invert solarize"
+                        },
+                        {
+                            "range": [80, 80],
+                            "name": "RGB Blend 1"
+                        },
+                        {
+                            "range": [81, 81],
+                            "name": "RGB Blend 2"
+                        },
+                        {
+                            "range": [82, 82],
+                            "name": "RGB Blend 3"
+                        },
+                        {
+                            "range": [83, 83],
+                            "name": "RGB Blend 4"
+                        },
+                        {
+                            "range": [84, 84],
+                            "name": "RGB Blend 5"
+                        },
+                        {
+                            "range": [85, 85],
+                            "name": "RGB Blend 6 add"
+                        },
+                        {
+                            "range": [86, 86],
+                            "name": "RGB Blend 7 Sub"
+                        },
+                        {
+                            "range": [89, 89],
+                            "name": "RGB Blend 10 ma"
+                        },
+                        {
+                            "range": [90, 90],
+                            "name": "RGB Blend 11 ad"
+                        },
+                        {
+                            "range": [91, 91],
+                            "name": "RGB Blend 12 in"
+                        },
+                        {
+                            "range": [100, 100],
+                            "name": "Tint"
+                        },
+                        {
+                            "range": [101, 101],
+                            "name": "tint inv"
+                        },
+                        {
+                            "range": [102, 102],
+                            "name": "fade to hue"
+                        },
+                        {
+                            "range": [103, 103],
+                            "name": "RGB>GBR"
+                        },
+                        {
+                            "range": [104, 104],
+                            "name": "RGB>BGR"
+                        },
+                        {
+                            "range": [105, 105],
+                            "name": "RGB>GRB"
+                        }
+                    ]
+                },
+                "Visual FX": {
+                    "type": "MultiColor",
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "plane"
+                        },
+                        {
+                            "range": [1, 1],
+                            "name": "inf plane black"
+                        },
+                        {
+                            "range": [5, 5],
+                            "name": "TM1 Stretching"
+                        },
+                        {
+                            "range": [10, 10],
+                            "name": "sphere filled"
+                        },
+                        {
+                            "range": [11, 11],
+                            "name": "sphere wirefram"
+                        },
+                        {
+                            "range": [12, 12],
+                            "name": "sphere points"
+                        },
+                        {
+                            "range": [13, 13],
+                            "name": "sphere lit"
+                        },
+                        {
+                            "range": [14, 14],
+                            "name": "disc"
+                        },
+                        {
+                            "range": [15, 15],
+                            "name": "disc wireframe"
+                        },
+                        {
+                            "range": [16, 16],
+                            "name": "disc points"
+                        },
+                        {
+                            "range": [17, 17],
+                            "name": "disc silhouette"
+                        },
+                        {
+                            "range": [20, 20],
+                            "name": "kaleidoscope"
+                        },
+                        {
+                            "range": [21, 21],
+                            "name": "magic lantern"
+                        },
+                        {
+                            "range": [22, 22],
+                            "name": "stretched"
+                        },
+                        {
+                            "range": [23, 23],
+                            "name": "panorama"
+                        },
+                        {
+                            "range": [30, 30],
+                            "name": "cube four"
+                        },
+                        {
+                            "range": [31, 31],
+                            "name": "cube six"
+                        },
+                        {
+                            "range": [32, 32],
+                            "name": "colored cube"
+                        },
+                        {
+                            "range": [33, 33],
+                            "name": "cube first four"
+                        },
+                        {
+                            "range": [40, 40],
+                            "name": "NxN simultaneos"
+                        },
+                        {
+                            "range": [41, 41],
+                            "name": "NxN rnd color"
+                        },
+                        {
+                            "range": [42, 42],
+                            "name": "NxN consecutive"
+                        },
+                        {
+                            "range": [43, 43],
+                            "name": "NxN rnd color"
+                        },
+                        {
+                            "range": [44, 44],
+                            "name": "NxN rnd frame"
+                        },
+                        {
+                            "range": [45, 45],
+                            "name": "rnd flicker"
+                        },
+                        {
+                            "range": [46, 46],
+                            "name": "rnd color flick"
+                        },
+                        {
+                            "range": [60, 60],
+                            "name": "rect shuttered"
+                        },
+                        {
+                            "range": [61, 61],
+                            "name": "rect grad shutt"
+                        },
+                        {
+                            "range": [62, 62],
+                            "name": "N-Side shuttere"
+                        },
+                        {
+                            "range": [70, 70],
+                            "name": "shutter black"
+                        },
+                        {
+                            "range": [71, 71],
+                            "name": "shutter color"
+                        },
+                        {
+                            "range": [72, 72],
+                            "name": "iris shuttered"
+                        },
+                        {
+                            "range": [90, 90],
+                            "name": "movie chaotic"
+                        },
+                        {
+                            "range": [100, 100],
+                            "name": "movie teapot"
+                        },
+                        {
+                            "range": [120, 120],
+                            "name": "colored sphere"
+                        },
+                        {
+                            "range": [121, 121],
+                            "name": "movie square fl"
+                        },
+                        {
+                            "range": [122, 122],
+                            "name": "shuttered crop"
+                        }
+                    ]
+                },
+                "Parameter 1": {
+                    "type": "Beam"
+                },
+                "Parameter 2": {
+                    "type": "Beam"
+                },
+                "Keystone x1": {
+                    "type": "Beam",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Keystone y1": {
+                    "type": "Beam",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Keystone x2": {
+                    "type": "Beam",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Keystone y2": {
+                    "type": "Beam",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Keystone x3": {
+                    "type": "Beam",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Keystone y3": {
+                    "type": "Beam",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Keystone x4": {
+                    "type": "Beam",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Keystone y4": {
+                    "type": "Beam",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "InFrame",
+                    "InFrame fine"
+                ],
+                [
+                    "OutFrame",
+                    "OutFrame fine"
+                ],
+                [
+                    "X-Axis Rotate",
+                    "X-Axis Rotate fine"
+                ],
+                [
+                    "Y-Axis Rotate",
+                    "Y-Axis Rotate fine"
+                ],
+                [
+                    "Z-Axis Rotate",
+                    "Z-Axis Rotate fine"
+                ],
+                [
+                    "Scale",
+                    "Scale fine"
+                ],
+                [
+                    "X-Position",
+                    "X-Position fine"
+                ],
+                [
+                    "Y-Position",
+                    "Y-Position fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "40-channel Mode",
+                    "shortName": "40ch",
+                    "channels": [
+                        "Library",
+                        "File",
+                        "InFrame",
+                        "InFrame fine",
+                        "OutFrame",
+                        "OutFrame fine",
+                        "PlayMode",
+                        "Speed",
+                        "X-Axis Rotate",
+                        "X-Axis Rotate fine",
+                        "Y-Axis Rotate",
+                        "Y-Axis Rotate fine",
+                        "Z-Axis Rotate",
+                        "Z-Axis Rotate fine",
+                        "Scale",
+                        "Scale fine",
+                        "X-Position",
+                        "X-Position fine",
+                        "Y-Position",
+                        "Y-Position fine",
+                        "Ratio",
+                        "movement",
+                        "Intensity",
+                        "Red",
+                        "Green",
+                        "Blue",
+                        "Strobe",
+                        "Trail",
+                        "ColorFX",
+                        "Visual FX",
+                        "Parameter 1",
+                        "Parameter 2",
+                        "Keystone x1",
+                        "Keystone y1",
+                        "Keystone x2",
+                        "Keystone y2",
+                        "Keystone x3",
+                        "Keystone y3",
+                        "Keystone x4",
+                        "Keystone y4"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "High End Systems",
+            "name": "Cyberlight",
+            "shortName": "Cyberlight",
+            "comment": "http://www.highend.com/pub/products/automated_luminaires/CyberLightTurbo/cyberturbotech.PDF",
+            "physical": {
+                "dimensions": [413, 366, 1067],
+                "weight": 46,
+                "power": 1300
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Colour": {
+                    "type": "MultiColor",
+                    "capabilities": [
+                        {
+                            "range": [0, 1],
+                            "name": "Col 1(Open)"
+                        },
+                        {
+                            "range": [2, 64],
+                            "name": "Rev Spin",
+                            "center": true
+                        },
+                        {
+                            "range": [66, 127],
+                            "name": "Fwrd Spin",
+                            "center": true
+                        },
+                        {
+                            "range": [130, 132],
+                            "name": "*Col 8 & 1"
+                        },
+                        {
+                            "range": [133, 137],
+                            "name": "*Colour 8"
+                        },
+                        {
+                            "range": [138, 142],
+                            "name": "*Col 7 + 8"
+                        },
+                        {
+                            "range": [143, 144],
+                            "name": "*Colour 7"
+                        },
+                        {
+                            "range": [145, 149],
+                            "name": "*Col 6 + 7"
+                        },
+                        {
+                            "range": [150, 155],
+                            "name": "*Colour 6"
+                        },
+                        {
+                            "range": [156, 157],
+                            "name": "*Col 5 + 6"
+                        },
+                        {
+                            "range": [158, 160],
+                            "name": "*Colour 5"
+                        },
+                        {
+                            "range": [161, 165],
+                            "name": "*Col 4 + 5"
+                        },
+                        {
+                            "range": [166, 168],
+                            "name": "*Colour 4"
+                        },
+                        {
+                            "range": [169, 172],
+                            "name": "*Col 3 + 4"
+                        },
+                        {
+                            "range": [173, 178],
+                            "name": "*Colour 3"
+                        },
+                        {
+                            "range": [179, 180],
+                            "name": "*Col 2 + 3"
+                        },
+                        {
+                            "range": [181, 185],
+                            "name": "*Colour 2"
+                        },
+                        {
+                            "range": [186, 188],
+                            "name": "*Col 1 + 2"
+                        },
+                        {
+                            "range": [189, 193],
+                            "name": "*Col 1(Open)"
+                        },
+                        {
+                            "range": [194, 195],
+                            "name": "Col 8 + 1"
+                        },
+                        {
+                            "range": [196, 200],
+                            "name": "Colour 8"
+                        },
+                        {
+                            "range": [201, 203],
+                            "name": "Col 7 + 8"
+                        },
+                        {
+                            "range": [204, 208],
+                            "name": "Colour 7"
+                        },
+                        {
+                            "range": [209, 211],
+                            "name": "Col 6 + 7"
+                        },
+                        {
+                            "range": [212, 216],
+                            "name": "Colour 6"
+                        },
+                        {
+                            "range": [217, 221],
+                            "name": "Col 5 + 6"
+                        },
+                        {
+                            "range": [222, 223],
+                            "name": "Colour 5"
+                        },
+                        {
+                            "range": [224, 229],
+                            "name": "Col 4 + 5"
+                        },
+                        {
+                            "range": [230, 231],
+                            "name": "Colour 4"
+                        },
+                        {
+                            "range": [232, 236],
+                            "name": "Col 3 + 4"
+                        },
+                        {
+                            "range": [237, 239],
+                            "name": "Colour 3"
+                        },
+                        {
+                            "range": [240, 244],
+                            "name": "Colour 2 + 3"
+                        },
+                        {
+                            "range": [245, 249],
+                            "name": "Colour 2"
+                        },
+                        {
+                            "range": [250, 254],
+                            "name": "Col 1 + 2"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "Col 1(Open)"
+                        }
+                    ]
+                },
+                "Cyan": {
+                    "type": "SingleColor",
+                    "color": "Cyan",
+                    "invert": true,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Magenta": {
+                    "type": "SingleColor",
+                    "color": "Magenta",
+                    "invert": true,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Yellow": {
+                    "type": "SingleColor",
+                    "color": "Yellow",
+                    "invert": true,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Static Litho": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 1],
+                            "name": "L1 (Open)"
+                        },
+                        {
+                            "range": [2, 64],
+                            "name": "Rev Spin",
+                            "center": true
+                        },
+                        {
+                            "range": [66, 127],
+                            "name": "Fward Spin",
+                            "center": true
+                        },
+                        {
+                            "range": [130, 132],
+                            "name": "*8 shake nar"
+                        },
+                        {
+                            "range": [133, 137],
+                            "name": "*Litho 8"
+                        },
+                        {
+                            "range": [138, 142],
+                            "name": "*7 shake nar"
+                        },
+                        {
+                            "range": [143, 144],
+                            "name": "*Litho 7"
+                        },
+                        {
+                            "range": [145, 149],
+                            "name": "*6 shake nar"
+                        },
+                        {
+                            "range": [150, 155],
+                            "name": "*Litho 6"
+                        },
+                        {
+                            "range": [156, 157],
+                            "name": "*5 shake nar"
+                        },
+                        {
+                            "range": [158, 160],
+                            "name": "*Litho 5"
+                        },
+                        {
+                            "range": [161, 165],
+                            "name": "*4 shake nar"
+                        },
+                        {
+                            "range": [166, 168],
+                            "name": "*Litho 4"
+                        },
+                        {
+                            "range": [169, 172],
+                            "name": "*3 shake nar"
+                        },
+                        {
+                            "range": [173, 178],
+                            "name": "*Litho 3"
+                        },
+                        {
+                            "range": [179, 180],
+                            "name": "*2 shake nar"
+                        },
+                        {
+                            "range": [181, 185],
+                            "name": "*Litho 2"
+                        },
+                        {
+                            "range": [186, 188],
+                            "name": "*1 shake nar"
+                        },
+                        {
+                            "range": [189, 193],
+                            "name": "*Litho 1"
+                        },
+                        {
+                            "range": [194, 195],
+                            "name": "8 shake wide"
+                        },
+                        {
+                            "range": [196, 200],
+                            "name": "Litho 8"
+                        },
+                        {
+                            "range": [201, 203],
+                            "name": "7 shake wide"
+                        },
+                        {
+                            "range": [204, 208],
+                            "name": "Litho 7"
+                        },
+                        {
+                            "range": [209, 210],
+                            "name": "6 shake wide"
+                        },
+                        {
+                            "range": [211, 216],
+                            "name": "Litho 6"
+                        },
+                        {
+                            "range": [217, 221],
+                            "name": "5 shake wide"
+                        },
+                        {
+                            "range": [222, 223],
+                            "name": "Litho 5"
+                        },
+                        {
+                            "range": [224, 229],
+                            "name": "4 shake wide"
+                        },
+                        {
+                            "range": [230, 231],
+                            "name": "Litho 4"
+                        },
+                        {
+                            "range": [232, 236],
+                            "name": "3 shake wide"
+                        },
+                        {
+                            "range": [237, 239],
+                            "name": "Litho 3"
+                        },
+                        {
+                            "range": [240, 244],
+                            "name": "2 shake wide"
+                        },
+                        {
+                            "range": [245, 249],
+                            "name": "Litho 2"
+                        },
+                        {
+                            "range": [250, 254],
+                            "name": "1 shake wide"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "L1(Open)"
+                        }
+                    ]
+                },
+                "Litho": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 12],
+                            "name": "*P 3 Open"
+                        },
+                        {
+                            "range": [13, 25],
+                            "name": "*Position 1"
+                        },
+                        {
+                            "range": [26, 32],
+                            "name": "*Position 2"
+                        },
+                        {
+                            "range": [33, 42],
+                            "name": "*P 3 Open"
+                        },
+                        {
+                            "range": [43, 50],
+                            "name": "*Position 4"
+                        },
+                        {
+                            "range": [51, 60],
+                            "name": "*Position 5"
+                        },
+                        {
+                            "range": [61, 70],
+                            "name": "*Fwrd rot 1"
+                        },
+                        {
+                            "range": [71, 81],
+                            "name": "*Fwrd rot 2"
+                        },
+                        {
+                            "range": [82, 91],
+                            "name": "*Fwrd rot 4"
+                        },
+                        {
+                            "range": [92, 98],
+                            "name": "*Fwrd rot 5"
+                        },
+                        {
+                            "range": [99, 106],
+                            "name": "*Rev rot 1"
+                        },
+                        {
+                            "range": [107, 116],
+                            "name": "*Rev rot 2"
+                        },
+                        {
+                            "range": [117, 126],
+                            "name": "*Rev rot 4"
+                        },
+                        {
+                            "range": [127, 137],
+                            "name": "*Rev rot 5"
+                        },
+                        {
+                            "range": [138, 149],
+                            "name": "Position 1"
+                        },
+                        {
+                            "range": [150, 155],
+                            "name": "Position 2"
+                        },
+                        {
+                            "range": [156, 162],
+                            "name": "P 3 Open"
+                        },
+                        {
+                            "range": [163, 172],
+                            "name": "Position 4"
+                        },
+                        {
+                            "range": [173, 183],
+                            "name": "Position 5"
+                        },
+                        {
+                            "range": [184, 193],
+                            "name": "Fwrd rot 1"
+                        },
+                        {
+                            "range": [194, 203],
+                            "name": "Fwrd rot 2"
+                        },
+                        {
+                            "range": [204, 211],
+                            "name": "Fwrd rot 4"
+                        },
+                        {
+                            "range": [212, 221],
+                            "name": "Fwrd rot 5"
+                        },
+                        {
+                            "range": [222, 231],
+                            "name": "Rev rot 1"
+                        },
+                        {
+                            "range": [232, 241],
+                            "name": "Rev rot 2"
+                        },
+                        {
+                            "range": [242, 249],
+                            "name": "Rev rot 4"
+                        },
+                        {
+                            "range": [250, 254],
+                            "name": "Rev rot 5"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "P 3 Open"
+                        }
+                    ]
+                },
+                "Litho Rot.": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "Speed"
+                        }
+                    ]
+                },
+                "Zoom": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "Beam"
+                        }
+                    ]
+                },
+                "Focus": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "Distance"
+                        }
+                    ]
+                },
+                "Iris": {
+                    "type": "Beam",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "Iris",
+                            "color": "#5a4fcf"
+                        }
+                    ]
+                },
+                "FX": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 19],
+                            "name": "*4 Open"
+                        },
+                        {
+                            "range": [20, 35],
+                            "name": "*1 Prism"
+                        },
+                        {
+                            "range": [36, 53],
+                            "name": "*2 Mosaic"
+                        },
+                        {
+                            "range": [54, 68],
+                            "name": "*3 Yellow cor"
+                        },
+                        {
+                            "range": [69, 83],
+                            "name": "*4 Open"
+                        },
+                        {
+                            "range": [84, 93],
+                            "name": "*5 Magenta"
+                        },
+                        {
+                            "range": [94, 111],
+                            "name": "*6 Wide angle"
+                        },
+                        {
+                            "range": [112, 126],
+                            "name": "*7 Diffusion"
+                        },
+                        {
+                            "range": [127, 142],
+                            "name": "*8 Cyan cor"
+                        },
+                        {
+                            "range": [143, 157],
+                            "name": "1 Prism"
+                        },
+                        {
+                            "range": [158, 170],
+                            "name": "2 Mosaic"
+                        },
+                        {
+                            "range": [171, 185],
+                            "name": "3 Yellow cor"
+                        },
+                        {
+                            "range": [186, 203],
+                            "name": "4 Open"
+                        },
+                        {
+                            "range": [204, 216],
+                            "name": "5 Magenta"
+                        },
+                        {
+                            "range": [217, 231],
+                            "name": "6 Wide angle"
+                        },
+                        {
+                            "range": [232, 244],
+                            "name": "7 Diffusion"
+                        },
+                        {
+                            "range": [245, 254],
+                            "name": "8 Cyan cor"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "4 Open"
+                        }
+                    ]
+                },
+                "Frost": {
+                    "type": "Beam",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 1],
+                            "name": "Frost free"
+                        },
+                        {
+                            "range": [2, 126],
+                            "name": "Frost strobe"
+                        },
+                        {
+                            "range": [129, 254],
+                            "name": "Frost %"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "Frost free"
+                        }
+                    ]
+                },
+                "Strobe": {
+                    "type": "Strobe",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "Closed"
+                        },
+                        {
+                            "range": [1, 254],
+                            "name": "Speed"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "Open"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "MSpeed (*)": {
+                    "type": "Speed",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 20],
+                            "name": "Speed 95"
+                        },
+                        {
+                            "range": [21, 255],
+                            "name": "Speed"
+                        }
+                    ]
+                },
+                "Control": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "20-channel Mode",
+                    "shortName": "20ch",
+                    "channels": [
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "Colour",
+                        "Cyan",
+                        "Magenta",
+                        "Yellow",
+                        "Static Litho",
+                        "Litho",
+                        "Litho Rot.",
+                        "Zoom",
+                        "Focus",
+                        "Iris",
+                        "FX",
+                        "Frost",
+                        "Strobe",
+                        "Intensity",
+                        "MSpeed (*)",
+                        "Control"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "High End Systems",
+            "name": "Dataflash AF-1000",
+            "shortName": "Dataflash",
+            "comment": "cd http://www.highend.com/pub/products/effects/AF1000/af1000.pdf",
+            "physical": {
+                "dimensions": [220, 220, 101],
+                "weight": 2,
+                "power": 1650
+            },
+            "availableChannels": {
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Duration": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Rate": {
+                    "type": "Beam",
+                    "defaultValue": 128,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "3-channel Mode",
+                    "shortName": "3ch",
+                    "channels": [
+                        "Intensity",
+                        "Duration",
+                        "Rate"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "High End Systems",
+            "name": "ES-1",
+            "shortName": "ES-1",
+            "physical": {
+                "dimensions": [650, 500, 200],
+                "weight": 60,
+                "power": 700
+            },
+            "availableChannels": {
+                "Color 1": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 31],
+                            "name": "indexed"
+                        },
+                        {
+                            "range": [32, 47],
+                            "name": "spin cw"
+                        },
+                        {
+                            "range": [48, 63],
+                            "name": "spin ccw"
+                        },
+                        {
+                            "range": [64, 79],
+                            "name": "continous"
+                        },
+                        {
+                            "range": [80, 95],
+                            "name": "scan"
+                        },
+                        {
+                            "range": [96, 111],
+                            "name": "random"
+                        },
+                        {
+                            "range": [112, 127],
+                            "name": "blink"
+                        },
+                        {
+                            "range": [128, 159],
+                            "name": "indexed"
+                        },
+                        {
+                            "range": [160, 175],
+                            "name": "spin cw"
+                        },
+                        {
+                            "range": [176, 191],
+                            "name": "spin ccw"
+                        },
+                        {
+                            "range": [192, 207],
+                            "name": "continous"
+                        },
+                        {
+                            "range": [208, 223],
+                            "name": "scan"
+                        },
+                        {
+                            "range": [224, 239],
+                            "name": "random"
+                        },
+                        {
+                            "range": [240, 255],
+                            "name": "blink"
+                        }
+                    ]
+                },
+                "C1Position": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Color 2": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 31],
+                            "name": "indexed"
+                        },
+                        {
+                            "range": [32, 47],
+                            "name": "spin cw"
+                        },
+                        {
+                            "range": [48, 63],
+                            "name": "spin ccw"
+                        },
+                        {
+                            "range": [64, 79],
+                            "name": "continous"
+                        },
+                        {
+                            "range": [80, 95],
+                            "name": "scan"
+                        },
+                        {
+                            "range": [96, 111],
+                            "name": "random"
+                        },
+                        {
+                            "range": [112, 127],
+                            "name": "blink"
+                        },
+                        {
+                            "range": [128, 159],
+                            "name": "indexed"
+                        },
+                        {
+                            "range": [160, 175],
+                            "name": "spin cw"
+                        },
+                        {
+                            "range": [176, 191],
+                            "name": "spin ccw"
+                        },
+                        {
+                            "range": [192, 207],
+                            "name": "continous"
+                        },
+                        {
+                            "range": [208, 223],
+                            "name": "scan"
+                        },
+                        {
+                            "range": [224, 239],
+                            "name": "random"
+                        },
+                        {
+                            "range": [240, 255],
+                            "name": "blink"
+                        }
+                    ]
+                },
+                "C2Position": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "LW1Funct": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "index"
+                        },
+                        {
+                            "range": [16, 31],
+                            "name": "rotation cw"
+                        },
+                        {
+                            "range": [32, 47],
+                            "name": "rotation ccw"
+                        },
+                        {
+                            "range": [48, 63],
+                            "name": "spin"
+                        },
+                        {
+                            "range": [64, 79],
+                            "name": "scan"
+                        },
+                        {
+                            "range": [80, 95],
+                            "name": "random"
+                        },
+                        {
+                            "range": [96, 111],
+                            "name": "blink"
+                        },
+                        {
+                            "range": [96, 111],
+                            "name": "blink"
+                        },
+                        {
+                            "range": [112, 127],
+                            "name": "blink aperture"
+                        },
+                        {
+                            "range": [128, 143],
+                            "name": "index"
+                        },
+                        {
+                            "range": [144, 159],
+                            "name": "rotation cw"
+                        },
+                        {
+                            "range": [160, 175],
+                            "name": "rotation ccw"
+                        },
+                        {
+                            "range": [176, 191],
+                            "name": "spin"
+                        },
+                        {
+                            "range": [192, 207],
+                            "name": "scan"
+                        },
+                        {
+                            "range": [208, 223],
+                            "name": "random"
+                        },
+                        {
+                            "range": [224, 239],
+                            "name": "blink"
+                        },
+                        {
+                            "range": [240, 255],
+                            "name": "blink aperture"
+                        }
+                    ]
+                },
+                "LW1Pos": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "LW1Rot": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "LW1Rot fine": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "LW2Funct": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "index"
+                        },
+                        {
+                            "range": [16, 31],
+                            "name": "rotation cw"
+                        },
+                        {
+                            "range": [32, 47],
+                            "name": "rotation ccw"
+                        },
+                        {
+                            "range": [48, 63],
+                            "name": "spin"
+                        },
+                        {
+                            "range": [64, 79],
+                            "name": "scan"
+                        },
+                        {
+                            "range": [80, 95],
+                            "name": "random"
+                        },
+                        {
+                            "range": [96, 111],
+                            "name": "blink"
+                        },
+                        {
+                            "range": [96, 111],
+                            "name": "blink"
+                        },
+                        {
+                            "range": [112, 127],
+                            "name": "blink aperture"
+                        },
+                        {
+                            "range": [128, 143],
+                            "name": "index"
+                        },
+                        {
+                            "range": [144, 159],
+                            "name": "rotation cw"
+                        },
+                        {
+                            "range": [160, 175],
+                            "name": "rotation ccw"
+                        },
+                        {
+                            "range": [176, 191],
+                            "name": "spin"
+                        },
+                        {
+                            "range": [192, 207],
+                            "name": "scan"
+                        },
+                        {
+                            "range": [208, 223],
+                            "name": "random"
+                        },
+                        {
+                            "range": [224, 239],
+                            "name": "blink"
+                        },
+                        {
+                            "range": [240, 255],
+                            "name": "blink aperture"
+                        }
+                    ]
+                },
+                "LW2Pos": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "LW2Rot": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "LW2Rot fine": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "Frost": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Fokus": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Iris": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Shutter": {
+                    "type": "Shutter",
+                    "defaultValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 31],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [32, 63],
+                            "name": "strobe"
+                        },
+                        {
+                            "range": [64, 95],
+                            "name": "random"
+                        },
+                        {
+                            "range": [96, 127],
+                            "name": "ramp/snap"
+                        },
+                        {
+                            "range": [128, 159],
+                            "name": "snap/ramp"
+                        },
+                        {
+                            "range": [160, 223],
+                            "name": "random"
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "open"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "MSpeed": {
+                    "type": "Speed",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Macro": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Control": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 9],
+                            "name": "safe"
+                        },
+                        {
+                            "range": [10, 19],
+                            "name": "disable mspeed"
+                        },
+                        {
+                            "range": [20, 28],
+                            "name": "display off"
+                        },
+                        {
+                            "range": [30, 38],
+                            "name": "display dim"
+                        },
+                        {
+                            "range": [40, 48],
+                            "name": "display bright"
+                        },
+                        {
+                            "range": [60, 68],
+                            "name": "home"
+                        },
+                        {
+                            "range": [80, 88],
+                            "name": "lamp on"
+                        },
+                        {
+                            "range": [90, 98],
+                            "name": "lamp off"
+                        },
+                        {
+                            "range": [120, 130],
+                            "name": "shutdown"
+                        },
+                        {
+                            "range": [131, 255],
+                            "name": "reserved"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "LW1Rot",
+                    "LW1Rot fine"
+                ],
+                [
+                    "LW2Rot",
+                    "LW2Rot fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "20-channel Mode",
+                    "shortName": "20ch",
+                    "channels": [
+                        "Color 1",
+                        "C1Position",
+                        "Color 2",
+                        "C2Position",
+                        "LW1Funct",
+                        "LW1Pos",
+                        "LW1Rot",
+                        "LW1Rot fine",
+                        "LW2Funct",
+                        "LW2Pos",
+                        "LW2Rot",
+                        "LW2Rot fine",
+                        "Frost",
+                        "Fokus",
+                        "Iris",
+                        "Shutter",
+                        "Intensity",
+                        "MSpeed",
+                        "Macro",
+                        "Control"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "High End Systems",
+            "name": "Studio Beam",
+            "shortName": "StdBeam",
+            "comment": "cd",
+            "physical": {
+                "dimensions": [500, 500, 616],
+                "weight": 22.4,
+                "power": 800
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Color func.": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "cont"
+                        },
+                        {
+                            "range": [16, 31],
+                            "name": "index"
+                        },
+                        {
+                            "range": [32, 47],
+                            "name": "pure"
+                        },
+                        {
+                            "range": [48, 63],
+                            "name": "spin"
+                        },
+                        {
+                            "range": [64, 79],
+                            "name": "cycle"
+                        },
+                        {
+                            "range": [80, 95],
+                            "name": "media"
+                        },
+                        {
+                            "range": [96, 111],
+                            "name": "random"
+                        },
+                        {
+                            "range": [112, 127],
+                            "name": "blink"
+                        },
+                        {
+                            "range": [128, 143],
+                            "name": "cont"
+                        },
+                        {
+                            "range": [144, 159],
+                            "name": "index"
+                        },
+                        {
+                            "range": [160, 175],
+                            "name": "pure"
+                        },
+                        {
+                            "range": [176, 191],
+                            "name": "spin"
+                        },
+                        {
+                            "range": [192, 207],
+                            "name": "cycle"
+                        },
+                        {
+                            "range": [208, 223],
+                            "name": "media"
+                        },
+                        {
+                            "range": [224, 239],
+                            "name": "random"
+                        },
+                        {
+                            "range": [240, 255],
+                            "name": "blink"
+                        }
+                    ]
+                },
+                "Cyan": {
+                    "type": "SingleColor",
+                    "color": "Cyan",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Magenta": {
+                    "type": "SingleColor",
+                    "color": "Magenta",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Yellow": {
+                    "type": "SingleColor",
+                    "color": "Yellow",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Beam": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "cont"
+                        },
+                        {
+                            "range": [128, 187],
+                            "name": "<<"
+                        },
+                        {
+                            "range": [188, 195],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [196, 255],
+                            "name": ">>"
+                        }
+                    ]
+                },
+                "Zoom": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Frost": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Shutter": {
+                    "type": "Shutter",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 23],
+                            "name": "close"
+                        },
+                        {
+                            "range": [24, 49],
+                            "name": "strobe"
+                        },
+                        {
+                            "range": [50, 101],
+                            "name": "random"
+                        },
+                        {
+                            "range": [102, 127],
+                            "name": "pulse close"
+                        },
+                        {
+                            "range": [128, 153],
+                            "name": "pulse open"
+                        },
+                        {
+                            "range": [154, 179],
+                            "name": "pulse close"
+                        },
+                        {
+                            "range": [180, 231],
+                            "name": "pulse random"
+                        },
+                        {
+                            "range": [232, 255],
+                            "name": "open"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Speed": {
+                    "type": "Speed",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 3],
+                            "name": "idle"
+                        },
+                        {
+                            "range": [4, 255],
+                            "name": "fade"
+                        }
+                    ]
+                },
+                "Macro": {
+                    "type": "MultiColor",
+                    "capabilities": [
+                        {
+                            "range": [0, 7],
+                            "name": "off"
+                        },
+                        {
+                            "range": [8, 11],
+                            "name": "macro1"
+                        },
+                        {
+                            "range": [12, 15],
+                            "name": "macro2"
+                        },
+                        {
+                            "range": [16, 19],
+                            "name": "macro3"
+                        },
+                        {
+                            "range": [20, 23],
+                            "name": "macro4"
+                        },
+                        {
+                            "range": [24, 27],
+                            "name": "macro5"
+                        },
+                        {
+                            "range": [28, 31],
+                            "name": "macro6"
+                        },
+                        {
+                            "range": [32, 35],
+                            "name": "macro7"
+                        },
+                        {
+                            "range": [36, 39],
+                            "name": "macro8"
+                        },
+                        {
+                            "range": [40, 43],
+                            "name": "macro9"
+                        },
+                        {
+                            "range": [44, 47],
+                            "name": "macro10"
+                        },
+                        {
+                            "range": [48, 51],
+                            "name": "macro11"
+                        },
+                        {
+                            "range": [52, 55],
+                            "name": "macro12"
+                        },
+                        {
+                            "range": [56, 59],
+                            "name": "macro13"
+                        },
+                        {
+                            "range": [60, 63],
+                            "name": "macro14"
+                        },
+                        {
+                            "range": [64, 67],
+                            "name": "macro15"
+                        },
+                        {
+                            "range": [68, 71],
+                            "name": "macro16"
+                        },
+                        {
+                            "range": [72, 75],
+                            "name": "macro17"
+                        },
+                        {
+                            "range": [76, 79],
+                            "name": "macro18"
+                        },
+                        {
+                            "range": [80, 83],
+                            "name": "macro19"
+                        },
+                        {
+                            "range": [84, 87],
+                            "name": "macro20"
+                        },
+                        {
+                            "range": [88, 91],
+                            "name": "macro21"
+                        },
+                        {
+                            "range": [92, 95],
+                            "name": "macro22"
+                        },
+                        {
+                            "range": [96, 99],
+                            "name": "macro23"
+                        },
+                        {
+                            "range": [100, 103],
+                            "name": "macro24"
+                        },
+                        {
+                            "range": [104, 107],
+                            "name": "macro25"
+                        },
+                        {
+                            "range": [108, 111],
+                            "name": "macro26"
+                        },
+                        {
+                            "range": [112, 115],
+                            "name": "macro27"
+                        },
+                        {
+                            "range": [116, 119],
+                            "name": "macro28"
+                        },
+                        {
+                            "range": [120, 123],
+                            "name": "macro29"
+                        },
+                        {
+                            "range": [124, 127],
+                            "name": "macro30"
+                        },
+                        {
+                            "range": [128, 131],
+                            "name": "macro31"
+                        },
+                        {
+                            "range": [132, 135],
+                            "name": "macro32"
+                        },
+                        {
+                            "range": [136, 167],
+                            "name": "random"
+                        },
+                        {
+                            "range": [168, 255],
+                            "name": "reserved"
+                        }
+                    ]
+                },
+                "Control": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 9],
+                            "name": "normal"
+                        },
+                        {
+                            "range": [10, 19],
+                            "name": "disable speed"
+                        },
+                        {
+                            "range": [20, 28],
+                            "name": "display off"
+                        },
+                        {
+                            "range": [30, 38],
+                            "name": "display dim"
+                        },
+                        {
+                            "range": [40, 48],
+                            "name": "display bright"
+                        },
+                        {
+                            "range": [60, 68],
+                            "name": "home"
+                        },
+                        {
+                            "range": [80, 88],
+                            "name": "lamp on"
+                        },
+                        {
+                            "range": [90, 98],
+                            "name": "lamp off"
+                        },
+                        {
+                            "range": [110, 118],
+                            "name": "lock"
+                        },
+                        {
+                            "range": [120, 130],
+                            "name": "shutdown"
+                        },
+                        {
+                            "range": [131, 133],
+                            "name": "reserved"
+                        },
+                        {
+                            "range": [134, 137],
+                            "name": "assist strobe"
+                        },
+                        {
+                            "range": [138, 141],
+                            "name": "assist function"
+                        },
+                        {
+                            "range": [142, 145],
+                            "name": "assist dim"
+                        },
+                        {
+                            "range": [146, 149],
+                            "name": "only dimming"
+                        },
+                        {
+                            "range": [150, 255],
+                            "name": "reserved"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "16-channel Mode",
+                    "shortName": "16ch",
+                    "channels": [
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "Color func.",
+                        "Cyan",
+                        "Magenta",
+                        "Yellow",
+                        "Beam",
+                        "Zoom",
+                        "Frost",
+                        "Shutter",
+                        "Intensity",
+                        "Speed",
+                        "Macro",
+                        "Control"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "High End Systems",
+            "name": "Studio Color 250",
+            "shortName": "StdCol250",
+            "physical": {
+                "dimensions": [500, 500, 538],
+                "weight": 21.5,
+                "power": 375
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Colour": {
+                    "type": "MultiColor",
+                    "defaultValue": 32,
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "Continuous"
+                        },
+                        {
+                            "range": [16, 31],
+                            "name": "Indexed"
+                        },
+                        {
+                            "range": [32, 47],
+                            "name": "Pure Mix"
+                        },
+                        {
+                            "range": [48, 63],
+                            "name": "Spin"
+                        },
+                        {
+                            "range": [64, 79],
+                            "name": "Cycle"
+                        },
+                        {
+                            "range": [96, 111],
+                            "name": "Random"
+                        },
+                        {
+                            "range": [112, 127],
+                            "name": "Blink-Ind*"
+                        },
+                        {
+                            "range": [128, 143],
+                            "name": "Continuous*"
+                        },
+                        {
+                            "range": [144, 159],
+                            "name": "Indexed*"
+                        },
+                        {
+                            "range": [160, 175],
+                            "name": "Pure Mix*"
+                        },
+                        {
+                            "range": [176, 191],
+                            "name": "Spin*"
+                        },
+                        {
+                            "range": [192, 207],
+                            "name": "Cycle*"
+                        },
+                        {
+                            "range": [224, 239],
+                            "name": "Random*"
+                        },
+                        {
+                            "range": [240, 255],
+                            "name": "Blink-Ind*"
+                        }
+                    ]
+                },
+                "Cyan": {
+                    "type": "SingleColor",
+                    "color": "Cyan",
+                    "invert": true,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Magenta": {
+                    "type": "SingleColor",
+                    "color": "Magenta",
+                    "invert": true,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Yellow": {
+                    "type": "SingleColor",
+                    "color": "Yellow",
+                    "invert": true,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Beam": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "Continous"
+                        },
+                        {
+                            "range": [128, 187],
+                            "name": "Spin Reverse"
+                        },
+                        {
+                            "range": [188, 195],
+                            "name": "Spin Stop"
+                        },
+                        {
+                            "range": [196, 255],
+                            "name": "Spin Forward"
+                        }
+                    ]
+                },
+                "Focus": {
+                    "type": "Beam",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "Distance"
+                        }
+                    ]
+                },
+                "Strobe": {
+                    "type": "Strobe",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "capabilities": [
+                        {
+                            "range": [0, 23],
+                            "name": "Close"
+                        },
+                        {
+                            "range": [24, 49],
+                            "name": "Periodic"
+                        },
+                        {
+                            "range": [50, 75],
+                            "name": "Random"
+                        },
+                        {
+                            "range": [76, 101],
+                            "name": "Rand/Sync"
+                        },
+                        {
+                            "range": [102, 127],
+                            "name": "Ramp open"
+                        },
+                        {
+                            "range": [128, 153],
+                            "name": "Snap open"
+                        },
+                        {
+                            "range": [154, 179],
+                            "name": "Ramp Open/Shut"
+                        },
+                        {
+                            "range": [180, 205],
+                            "name": "Rand Ramp/Snap"
+                        },
+                        {
+                            "range": [206, 231],
+                            "name": "Rand Snap/Ramp"
+                        },
+                        {
+                            "range": [232, 255],
+                            "name": "Open"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "MSpeed (*)": {
+                    "type": "Speed",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "Velocity"
+                        }
+                    ]
+                },
+                "Macro/LAD": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 7],
+                            "name": "Off"
+                        },
+                        {
+                            "range": [8, 11],
+                            "name": "Macro 1"
+                        },
+                        {
+                            "range": [12, 15],
+                            "name": "Macro 2"
+                        },
+                        {
+                            "range": [16, 19],
+                            "name": "Macro 3"
+                        },
+                        {
+                            "range": [20, 23],
+                            "name": "Macro 4"
+                        },
+                        {
+                            "range": [24, 27],
+                            "name": "Macro 5"
+                        },
+                        {
+                            "range": [28, 31],
+                            "name": "Macro 6"
+                        },
+                        {
+                            "range": [32, 35],
+                            "name": "Macro 7"
+                        },
+                        {
+                            "range": [36, 39],
+                            "name": "Macro 8"
+                        },
+                        {
+                            "range": [40, 43],
+                            "name": "Macro 9"
+                        },
+                        {
+                            "range": [44, 47],
+                            "name": "Macro 10"
+                        },
+                        {
+                            "range": [48, 51],
+                            "name": "Macro 11"
+                        },
+                        {
+                            "range": [52, 55],
+                            "name": "Macro 12"
+                        },
+                        {
+                            "range": [56, 59],
+                            "name": "Macro 13"
+                        },
+                        {
+                            "range": [60, 63],
+                            "name": "Macro 14"
+                        },
+                        {
+                            "range": [64, 67],
+                            "name": "Macro 15"
+                        },
+                        {
+                            "range": [68, 71],
+                            "name": "Macro 16"
+                        },
+                        {
+                            "range": [72, 75],
+                            "name": "Macro 17"
+                        },
+                        {
+                            "range": [76, 79],
+                            "name": "Macro 18"
+                        },
+                        {
+                            "range": [80, 83],
+                            "name": "Macro 19"
+                        },
+                        {
+                            "range": [84, 87],
+                            "name": "Macro 20"
+                        },
+                        {
+                            "range": [88, 91],
+                            "name": "Macro 21"
+                        },
+                        {
+                            "range": [92, 95],
+                            "name": "Macro 22"
+                        },
+                        {
+                            "range": [96, 99],
+                            "name": "Macro 23"
+                        },
+                        {
+                            "range": [100, 103],
+                            "name": "Macro 24"
+                        },
+                        {
+                            "range": [104, 107],
+                            "name": "Macro 25"
+                        },
+                        {
+                            "range": [108, 111],
+                            "name": "Macro 26"
+                        },
+                        {
+                            "range": [112, 125],
+                            "name": "Macro 27"
+                        },
+                        {
+                            "range": [126, 119],
+                            "name": "Macro 28"
+                        },
+                        {
+                            "range": [120, 123],
+                            "name": "Macro 29"
+                        },
+                        {
+                            "range": [124, 127],
+                            "name": "Macro 30"
+                        },
+                        {
+                            "range": [128, 131],
+                            "name": "Macro 31"
+                        },
+                        {
+                            "range": [132, 135],
+                            "name": "Macro 32"
+                        },
+                        {
+                            "range": [136, 167],
+                            "name": "Random Macro"
+                        },
+                        {
+                            "range": [168, 199],
+                            "name": "Macro + LAD off"
+                        },
+                        {
+                            "range": [200, 231],
+                            "name": "LAD Modulate"
+                        },
+                        {
+                            "range": [232, 255],
+                            "name": "LAD On"
+                        }
+                    ]
+                },
+                "Control": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 9],
+                            "name": "Safe"
+                        },
+                        {
+                            "range": [10, 19],
+                            "name": "Pan+Tilt* Off"
+                        },
+                        {
+                            "range": [20, 28],
+                            "name": "Display Off"
+                        },
+                        {
+                            "range": [30, 38],
+                            "name": "Display Dim"
+                        },
+                        {
+                            "range": [40, 48],
+                            "name": "Display Bright"
+                        },
+                        {
+                            "range": [60, 68],
+                            "name": "Home"
+                        },
+                        {
+                            "range": [80, 88],
+                            "name": "Lamp On"
+                        },
+                        {
+                            "range": [90, 98],
+                            "name": "Lamp Off"
+                        },
+                        {
+                            "range": [120, 130],
+                            "name": "Shutdown"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "15-channel Mode",
+                    "shortName": "15ch",
+                    "channels": [
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "Colour",
+                        "Cyan",
+                        "Magenta",
+                        "Yellow",
+                        "Beam",
+                        "Focus",
+                        "Strobe",
+                        "Intensity",
+                        "MSpeed (*)",
+                        "Macro/LAD",
+                        "Control"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "High End Systems",
+            "name": "Studio Color 575",
+            "shortName": "StCol575",
+            "comment": "cd",
+            "physical": {
+                "dimensions": [500, 500, 653],
+                "weight": 26,
+                "power": 700
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Colour Fnc": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "default"
+                        },
+                        {
+                            "range": [16, 31],
+                            "name": "F3"
+                        },
+                        {
+                            "range": [32, 47],
+                            "name": "F4"
+                        },
+                        {
+                            "range": [48, 63],
+                            "name": "F5"
+                        },
+                        {
+                            "range": [64, 79],
+                            "name": "F1"
+                        },
+                        {
+                            "range": [80, 95],
+                            "name": "F1 + F3"
+                        },
+                        {
+                            "range": [96, 111],
+                            "name": "F1 + F4"
+                        },
+                        {
+                            "range": [112, 127],
+                            "name": "F1 + F5"
+                        },
+                        {
+                            "range": [128, 143],
+                            "name": "F2"
+                        },
+                        {
+                            "range": [144, 159],
+                            "name": "F2 + F3"
+                        },
+                        {
+                            "range": [160, 175],
+                            "name": "F2 + F4"
+                        },
+                        {
+                            "range": [176, 191],
+                            "name": "F2 + F5"
+                        },
+                        {
+                            "range": [192, 207],
+                            "name": "F1 + F2"
+                        },
+                        {
+                            "range": [208, 223],
+                            "name": "F1+F2+F3"
+                        },
+                        {
+                            "range": [224, 239],
+                            "name": "F1+F2+F4"
+                        },
+                        {
+                            "range": [240, 255],
+                            "name": "F1+F2+F5"
+                        }
+                    ]
+                },
+                "Colour": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 43],
+                            "name": "open"
+                        },
+                        {
+                            "range": [44, 85],
+                            "name": "CTO"
+                        },
+                        {
+                            "range": [86, 127],
+                            "name": "pink",
+                            "color": "#ffc0cb"
+                        },
+                        {
+                            "range": [128, 169],
+                            "name": "magenta",
+                            "color": "#ca1f7b"
+                        },
+                        {
+                            "range": [170, 212],
+                            "name": "red",
+                            "color": "#ff0000"
+                        },
+                        {
+                            "range": [213, 254],
+                            "name": "aqua"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "open"
+                        }
+                    ]
+                },
+                "Cyan": {
+                    "type": "SingleColor",
+                    "color": "Cyan",
+                    "invert": true,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Magenta": {
+                    "type": "SingleColor",
+                    "color": "Magenta",
+                    "invert": true,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Yellow": {
+                    "type": "SingleColor",
+                    "color": "Yellow",
+                    "invert": true,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Lens": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 63],
+                            "name": "open"
+                        },
+                        {
+                            "range": [64, 127],
+                            "name": "wide"
+                        },
+                        {
+                            "range": [128, 191],
+                            "name": "narrow shap"
+                        },
+                        {
+                            "range": [192, 254],
+                            "name": "wide shap"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "open"
+                        }
+                    ]
+                },
+                "Frost": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 63],
+                            "name": "open"
+                        },
+                        {
+                            "range": [64, 127],
+                            "name": "frost",
+                            "color": "#edf5dd"
+                        },
+                        {
+                            "range": [128, 191],
+                            "name": "narrow shap"
+                        },
+                        {
+                            "range": [192, 254],
+                            "name": "wide shap"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "open"
+                        }
+                    ]
+                },
+                "Strobe": {
+                    "type": "Strobe",
+                    "defaultValue": 255,
+                    "capabilities": [
+                        {
+                            "range": [0, 7],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [8, 127],
+                            "name": "strobe"
+                        },
+                        {
+                            "range": [128, 247],
+                            "name": "random"
+                        },
+                        {
+                            "range": [248, 255],
+                            "name": "open"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "MSpeed": {
+                    "type": "Speed",
+                    "defaultValue": 255,
+                    "capabilities": [
+                        {
+                            "range": [0, 3],
+                            "name": "idle"
+                        },
+                        {
+                            "range": [4, 255],
+                            "name": "speed"
+                        }
+                    ]
+                },
+                "Control": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 63],
+                            "name": "safe"
+                        },
+                        {
+                            "range": [64, 127],
+                            "name": "reset"
+                        },
+                        {
+                            "range": [128, 255],
+                            "name": "shutdown"
+                        }
+                    ]
+                },
+                "Checksum": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "default"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "16-channel Mode",
+                    "shortName": "16ch",
+                    "channels": [
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "Colour Fnc",
+                        "Colour",
+                        "Cyan",
+                        "Magenta",
+                        "Yellow",
+                        "Lens",
+                        "Frost",
+                        "Strobe",
+                        "Intensity",
+                        "MSpeed",
+                        "Control",
+                        "Checksum"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "High End Systems",
+            "name": "Studio Spot 250",
+            "shortName": "StdSp250",
+            "physical": {
+                "dimensions": [500, 500, 600],
+                "weight": 22.4,
+                "power": 375
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Colour": {
+                    "type": "MultiColor",
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "Indexed"
+                        },
+                        {
+                            "range": [16, 31],
+                            "name": "Fwrd Spin"
+                        },
+                        {
+                            "range": [32, 47],
+                            "name": "Rev Spin"
+                        },
+                        {
+                            "range": [48, 63],
+                            "name": "Continuous"
+                        },
+                        {
+                            "range": [64, 79],
+                            "name": "Slow Scan"
+                        },
+                        {
+                            "range": [80, 95],
+                            "name": "Fast Scan"
+                        },
+                        {
+                            "range": [96, 111],
+                            "name": "Random"
+                        },
+                        {
+                            "range": [112, 127],
+                            "name": "Blink"
+                        },
+                        {
+                            "range": [128, 143],
+                            "name": "Indexed*"
+                        },
+                        {
+                            "range": [144, 159],
+                            "name": "Forward Spin*"
+                        },
+                        {
+                            "range": [160, 175],
+                            "name": "Reverse Spin*"
+                        },
+                        {
+                            "range": [176, 191],
+                            "name": "Continuous*"
+                        },
+                        {
+                            "range": [192, 207],
+                            "name": "Slow Scan*"
+                        },
+                        {
+                            "range": [208, 223],
+                            "name": "Fast Scan*"
+                        },
+                        {
+                            "range": [224, 239],
+                            "name": "Random*"
+                        },
+                        {
+                            "range": [240, 255],
+                            "name": "Blink*"
+                        }
+                    ]
+                },
+                "Colour Pos": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 23],
+                            "name": "Colour 1",
+                            "center": true
+                        },
+                        {
+                            "range": [24, 31],
+                            "name": "Colour 2",
+                            "center": true
+                        },
+                        {
+                            "range": [32, 39],
+                            "name": "Colour 3",
+                            "center": true
+                        },
+                        {
+                            "range": [40, 47],
+                            "name": "Colour 4",
+                            "center": true
+                        },
+                        {
+                            "range": [48, 55],
+                            "name": "Colour 5",
+                            "center": true
+                        },
+                        {
+                            "range": [56, 63],
+                            "name": "Colour 6",
+                            "center": true
+                        },
+                        {
+                            "range": [64, 71],
+                            "name": "Colour 7",
+                            "center": true
+                        },
+                        {
+                            "range": [72, 79],
+                            "name": "Colour 8",
+                            "center": true
+                        },
+                        {
+                            "range": [80, 87],
+                            "name": "Colour 9",
+                            "center": true
+                        },
+                        {
+                            "range": [88, 95],
+                            "name": "Colour 10",
+                            "center": true
+                        },
+                        {
+                            "range": [96, 103],
+                            "name": "Colour 11",
+                            "center": true
+                        },
+                        {
+                            "range": [104, 111],
+                            "name": "Colour 12",
+                            "center": true
+                        },
+                        {
+                            "range": [112, 127],
+                            "name": "Colour 13",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 143],
+                            "name": "Colour 1/2",
+                            "center": true
+                        },
+                        {
+                            "range": [144, 151],
+                            "name": "Colour 2/3",
+                            "center": true
+                        },
+                        {
+                            "range": [152, 159],
+                            "name": "Colour 3/4",
+                            "center": true
+                        },
+                        {
+                            "range": [160, 167],
+                            "name": "Colour 4/5",
+                            "center": true
+                        },
+                        {
+                            "range": [168, 175],
+                            "name": "Colour 5/6",
+                            "center": true
+                        },
+                        {
+                            "range": [176, 183],
+                            "name": "Colour 6/7",
+                            "center": true
+                        },
+                        {
+                            "range": [184, 191],
+                            "name": "Colour 7/8",
+                            "center": true
+                        },
+                        {
+                            "range": [192, 199],
+                            "name": "Colour 8/9",
+                            "center": true
+                        },
+                        {
+                            "range": [200, 207],
+                            "name": "Colour 9/10",
+                            "center": true
+                        },
+                        {
+                            "range": [208, 215],
+                            "name": "Colour 10/11",
+                            "center": true
+                        },
+                        {
+                            "range": [216, 223],
+                            "name": "Colour 11/12",
+                            "center": true
+                        },
+                        {
+                            "range": [224, 231],
+                            "name": "Colour 12/13",
+                            "center": true
+                        },
+                        {
+                            "range": [232, 247],
+                            "name": "Colour 13/1",
+                            "center": true
+                        },
+                        {
+                            "range": [248, 255],
+                            "name": "Colour 1",
+                            "center": true
+                        }
+                    ]
+                },
+                "Litho": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "Indexed"
+                        },
+                        {
+                            "range": [16, 31],
+                            "name": "Forward Spin",
+                            "center": true
+                        },
+                        {
+                            "range": [32, 47],
+                            "name": "Reverse Spin",
+                            "center": true
+                        },
+                        {
+                            "range": [48, 63],
+                            "name": "Scan"
+                        },
+                        {
+                            "range": [64, 79],
+                            "name": "Blink"
+                        },
+                        {
+                            "range": [80, 95],
+                            "name": "Random"
+                        },
+                        {
+                            "range": [96, 111],
+                            "name": "Blink Wheel"
+                        },
+                        {
+                            "range": [112, 127],
+                            "name": "Blink Aperture"
+                        },
+                        {
+                            "range": [128, 143],
+                            "name": "Indexed*"
+                        },
+                        {
+                            "range": [144, 159],
+                            "name": "Forward Spin*"
+                        },
+                        {
+                            "range": [160, 175],
+                            "name": "Reverse Spin*"
+                        },
+                        {
+                            "range": [176, 191],
+                            "name": "Scan*"
+                        },
+                        {
+                            "range": [192, 207],
+                            "name": "Blink*"
+                        },
+                        {
+                            "range": [208, 223],
+                            "name": "Random*"
+                        },
+                        {
+                            "range": [224, 239],
+                            "name": "Blink Wheel*"
+                        },
+                        {
+                            "range": [240, 255],
+                            "name": "Blink Aperture*"
+                        }
+                    ]
+                },
+                "Litho Pos": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "Position 0"
+                        },
+                        {
+                            "range": [16, 47],
+                            "name": "Position 1"
+                        },
+                        {
+                            "range": [48, 79],
+                            "name": "Position 2"
+                        },
+                        {
+                            "range": [80, 111],
+                            "name": "Position 3"
+                        },
+                        {
+                            "range": [112, 143],
+                            "name": "Position 4"
+                        },
+                        {
+                            "range": [144, 175],
+                            "name": "Position 5"
+                        },
+                        {
+                            "range": [176, 207],
+                            "name": "Position 6"
+                        },
+                        {
+                            "range": [208, 239],
+                            "name": "Position 7"
+                        },
+                        {
+                            "range": [240, 255],
+                            "name": "Position 0"
+                        }
+                    ]
+                },
+                "Litho Rot": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "Pos"
+                        }
+                    ]
+                },
+                "FX Pos": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 25],
+                            "name": "Position 0"
+                        },
+                        {
+                            "range": [26, 51],
+                            "name": "Position 1"
+                        },
+                        {
+                            "range": [52, 76],
+                            "name": "Position 2"
+                        },
+                        {
+                            "range": [77, 102],
+                            "name": "Position 3"
+                        },
+                        {
+                            "range": [103, 127],
+                            "name": "Position 4"
+                        },
+                        {
+                            "range": [128, 153],
+                            "name": "Position 0*"
+                        },
+                        {
+                            "range": [154, 178],
+                            "name": "Position 1*"
+                        },
+                        {
+                            "range": [179, 204],
+                            "name": "Position 2*"
+                        },
+                        {
+                            "range": [205, 229],
+                            "name": "Position 3*"
+                        },
+                        {
+                            "range": [230, 255],
+                            "name": "Position 4*"
+                        }
+                    ]
+                },
+                "FX Spin": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 120],
+                            "name": "Forward",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [121, 134],
+                            "name": "No Spin",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [135, 255],
+                            "name": "Reverse",
+                            "showInMenu": false,
+                            "center": true
+                        }
+                    ]
+                },
+                "Focus": {
+                    "type": "Beam",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "Distance"
+                        }
+                    ]
+                },
+                "Iris": {
+                    "type": "Beam",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "Close"
+                        },
+                        {
+                            "range": [1, 127],
+                            "name": "Variable Iris"
+                        },
+                        {
+                            "range": [128, 135],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [136, 151],
+                            "name": "Periodic Strobe"
+                        },
+                        {
+                            "range": [152, 167],
+                            "name": "Random Strobe"
+                        },
+                        {
+                            "range": [168, 183],
+                            "name": "Ramp open"
+                        },
+                        {
+                            "range": [184, 199],
+                            "name": "Snap open"
+                        },
+                        {
+                            "range": [200, 215],
+                            "name": "Ramp Open/Shut"
+                        },
+                        {
+                            "range": [216, 231],
+                            "name": "Rand Ramp/Snap"
+                        },
+                        {
+                            "range": [232, 247],
+                            "name": "Rand Snap/Ramp"
+                        },
+                        {
+                            "range": [248, 255],
+                            "name": "Open"
+                        }
+                    ]
+                },
+                "Strobe": {
+                    "type": "Strobe",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "capabilities": [
+                        {
+                            "range": [0, 23],
+                            "name": "Close"
+                        },
+                        {
+                            "range": [24, 49],
+                            "name": "Periodic"
+                        },
+                        {
+                            "range": [50, 75],
+                            "name": "Random"
+                        },
+                        {
+                            "range": [76, 101],
+                            "name": "Rand/Sync"
+                        },
+                        {
+                            "range": [102, 127],
+                            "name": "Ramp open"
+                        },
+                        {
+                            "range": [128, 153],
+                            "name": "Snap open"
+                        },
+                        {
+                            "range": [154, 179],
+                            "name": "Ramp Open/Shut"
+                        },
+                        {
+                            "range": [180, 205],
+                            "name": "Rand Ramp/Snap"
+                        },
+                        {
+                            "range": [206, 231],
+                            "name": "Rand Snap/Ramp"
+                        },
+                        {
+                            "range": [232, 255],
+                            "name": "Open"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "MSpeed (*)": {
+                    "type": "Speed",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "Velocity"
+                        }
+                    ]
+                },
+                "Macro/LAD": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 7],
+                            "name": "Off"
+                        },
+                        {
+                            "range": [8, 11],
+                            "name": "Macro 1"
+                        },
+                        {
+                            "range": [12, 15],
+                            "name": "Macro 2"
+                        },
+                        {
+                            "range": [16, 19],
+                            "name": "Macro 3"
+                        },
+                        {
+                            "range": [20, 23],
+                            "name": "Macro 4"
+                        },
+                        {
+                            "range": [24, 27],
+                            "name": "Macro 5"
+                        },
+                        {
+                            "range": [28, 31],
+                            "name": "Macro 6"
+                        },
+                        {
+                            "range": [32, 35],
+                            "name": "Macro 7"
+                        },
+                        {
+                            "range": [36, 39],
+                            "name": "Macro 8"
+                        },
+                        {
+                            "range": [40, 43],
+                            "name": "Macro 9"
+                        },
+                        {
+                            "range": [44, 47],
+                            "name": "Macro 10"
+                        },
+                        {
+                            "range": [48, 51],
+                            "name": "Macro 11"
+                        },
+                        {
+                            "range": [52, 55],
+                            "name": "Macro 12"
+                        },
+                        {
+                            "range": [56, 59],
+                            "name": "Macro 13"
+                        },
+                        {
+                            "range": [60, 63],
+                            "name": "Macro 14"
+                        },
+                        {
+                            "range": [64, 67],
+                            "name": "Macro 15"
+                        },
+                        {
+                            "range": [68, 71],
+                            "name": "Macro 16"
+                        },
+                        {
+                            "range": [72, 75],
+                            "name": "Macro 17"
+                        },
+                        {
+                            "range": [76, 79],
+                            "name": "Macro 18"
+                        },
+                        {
+                            "range": [80, 83],
+                            "name": "Macro 19"
+                        },
+                        {
+                            "range": [84, 87],
+                            "name": "Macro 20"
+                        },
+                        {
+                            "range": [88, 91],
+                            "name": "Macro 21"
+                        },
+                        {
+                            "range": [92, 95],
+                            "name": "Macro 22"
+                        },
+                        {
+                            "range": [96, 99],
+                            "name": "Macro 23"
+                        },
+                        {
+                            "range": [100, 103],
+                            "name": "Macro 24"
+                        },
+                        {
+                            "range": [104, 107],
+                            "name": "Macro 25"
+                        },
+                        {
+                            "range": [108, 111],
+                            "name": "Macro 26"
+                        },
+                        {
+                            "range": [112, 125],
+                            "name": "Macro 27"
+                        },
+                        {
+                            "range": [126, 119],
+                            "name": "Macro 28"
+                        },
+                        {
+                            "range": [120, 123],
+                            "name": "Macro 29"
+                        },
+                        {
+                            "range": [124, 127],
+                            "name": "Macro 30"
+                        },
+                        {
+                            "range": [128, 131],
+                            "name": "Macro 31"
+                        },
+                        {
+                            "range": [132, 135],
+                            "name": "Macro 32"
+                        },
+                        {
+                            "range": [136, 167],
+                            "name": "Random Macro"
+                        },
+                        {
+                            "range": [168, 199],
+                            "name": "Macro + LAD off"
+                        },
+                        {
+                            "range": [200, 231],
+                            "name": "LAD Modulate"
+                        },
+                        {
+                            "range": [232, 255],
+                            "name": "LAD On"
+                        }
+                    ]
+                },
+                "Control": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 9],
+                            "name": "Safe"
+                        },
+                        {
+                            "range": [10, 19],
+                            "name": "Pan+Tilt* Off"
+                        },
+                        {
+                            "range": [20, 28],
+                            "name": "Display Off"
+                        },
+                        {
+                            "range": [30, 38],
+                            "name": "Display Dim"
+                        },
+                        {
+                            "range": [40, 48],
+                            "name": "Display Bright"
+                        },
+                        {
+                            "range": [60, 68],
+                            "name": "Home"
+                        },
+                        {
+                            "range": [80, 88],
+                            "name": "Lamp On"
+                        },
+                        {
+                            "range": [90, 98],
+                            "name": "Lamp Off"
+                        },
+                        {
+                            "range": [120, 130],
+                            "name": "Shutdown"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "18-channel Mode",
+                    "shortName": "18ch",
+                    "channels": [
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "Colour",
+                        "Colour Pos",
+                        "Litho",
+                        "Litho Pos",
+                        "Litho Rot",
+                        "FX Pos",
+                        "FX Spin",
+                        "Focus",
+                        "Iris",
+                        "Strobe",
+                        "Intensity",
+                        "MSpeed (*)",
+                        "Macro/LAD",
+                        "Control"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "High End Systems",
+            "name": "Studio Spot 575",
+            "shortName": "Stdspt575",
+            "physical": {
+                "dimensions": [552, 552, 714],
+                "weight": 26.8,
+                "power": 700
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Colour <>": {
+                    "type": "MultiColor",
+                    "defaultValue": 71,
+                    "highlightValue": 71,
+                    "capabilities": [
+                        {
+                            "range": [0, 22],
+                            "name": "index",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [23, 39],
+                            "name": ">>",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [40, 54],
+                            "name": "<<",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [55, 71],
+                            "name": "contin",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [72, 87],
+                            "name": "fastscan",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [88, 103],
+                            "name": "slowscan",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [104, 119],
+                            "name": "random",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [120, 137],
+                            "name": "blink",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [138, 151],
+                            "name": "*index",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [152, 167],
+                            "name": "*>>",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [168, 183],
+                            "name": "*<<",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [184, 199],
+                            "name": "*contin",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [200, 215],
+                            "name": "*fastscan",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [216, 231],
+                            "name": "*slowscan",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [232, 254],
+                            "name": "*random",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "*blink",
+                            "showInMenu": false
+                        }
+                    ]
+                },
+                "Colour": {
+                    "type": "MultiColor",
+                    "capabilities": [
+                        {
+                            "range": [0, 38],
+                            "name": "open"
+                        },
+                        {
+                            "range": [39, 87],
+                            "name": "yellow",
+                            "color": "#ffff00"
+                        },
+                        {
+                            "range": [88, 133],
+                            "name": "cto"
+                        },
+                        {
+                            "range": [134, 168],
+                            "name": "aqua"
+                        },
+                        {
+                            "range": [169, 212],
+                            "name": "pink",
+                            "color": "#ffc0cb"
+                        },
+                        {
+                            "range": [213, 254],
+                            "name": "magenta",
+                            "color": "#ca1f7b"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "open"
+                        }
+                    ]
+                },
+                "Colour2<>": {
+                    "type": "MultiColor",
+                    "defaultValue": 71,
+                    "highlightValue": 71,
+                    "capabilities": [
+                        {
+                            "range": [0, 22],
+                            "name": "Combined",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [23, 38],
+                            "name": "index",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [39, 54],
+                            "name": ">>",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [55, 70],
+                            "name": "<<",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [71, 83],
+                            "name": "contin",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [84, 91],
+                            "name": "fastscan",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [92, 103],
+                            "name": "slowscan",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [104, 119],
+                            "name": "random",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [120, 137],
+                            "name": "blink",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [138, 166],
+                            "name": "*index",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [167, 182],
+                            "name": "*>>",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [183, 198],
+                            "name": "*<<",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [199, 211],
+                            "name": "*contin",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [212, 219],
+                            "name": "*fastscan",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [220, 230],
+                            "name": "*slowscan",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [231, 254],
+                            "name": "*random",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "*blink",
+                            "showInMenu": false
+                        }
+                    ]
+                },
+                "Colour 2": {
+                    "type": "MultiColor",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        },
+                        {
+                            "range": [0, 38],
+                            "name": "open"
+                        },
+                        {
+                            "range": [39, 87],
+                            "name": "cyan",
+                            "color": "#00ffff"
+                        },
+                        {
+                            "range": [88, 133],
+                            "name": "l cyan"
+                        },
+                        {
+                            "range": [134, 168],
+                            "name": "indigo",
+                            "color": "#4b0082"
+                        },
+                        {
+                            "range": [169, 212],
+                            "name": "pink2"
+                        },
+                        {
+                            "range": [213, 254],
+                            "name": "magenta2"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "open"
+                        }
+                    ]
+                },
+                "Gobo <>": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 22],
+                            "name": "index",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [23, 39],
+                            "name": ">>",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [40, 54],
+                            "name": "<<",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [55, 71],
+                            "name": "spin",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [72, 87],
+                            "name": "scan",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [88, 103],
+                            "name": "random",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [104, 119],
+                            "name": "blinkw",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [120, 135],
+                            "name": "blinka",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [136, 151],
+                            "name": "*index",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [152, 167],
+                            "name": "*>>",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [168, 183],
+                            "name": "*<<",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [184, 199],
+                            "name": "*spin",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [200, 215],
+                            "name": "*scan",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [216, 231],
+                            "name": "*random",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [232, 254],
+                            "name": "*blinkw",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "*blinka",
+                            "showInMenu": false
+                        }
+                    ]
+                },
+                "Gobo": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 54],
+                            "name": "open"
+                        },
+                        {
+                            "range": [55, 90],
+                            "name": "triwing"
+                        },
+                        {
+                            "range": [91, 127],
+                            "name": "lava",
+                            "color": "#cf1020"
+                        },
+                        {
+                            "range": [128, 163],
+                            "name": "stars"
+                        },
+                        {
+                            "range": [164, 200],
+                            "name": "wavycone"
+                        },
+                        {
+                            "range": [201, 236],
+                            "name": "shatters"
+                        },
+                        {
+                            "range": [237, 255],
+                            "name": "open"
+                        }
+                    ]
+                },
+                "Gobo rot": {
+                    "type": "Gobo",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Gobo rot fine": {
+                    "type": "Gobo",
+                    "defaultValue": 0,
+                    "highlightValue": 0,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Gobo 2 <>": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 22],
+                            "name": "index",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [23, 39],
+                            "name": ">>",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [40, 54],
+                            "name": "<<",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [55, 71],
+                            "name": "spin",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [72, 87],
+                            "name": "scan",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [88, 103],
+                            "name": "random",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [104, 119],
+                            "name": "blinkw",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [120, 135],
+                            "name": "blinka",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [136, 151],
+                            "name": "*index",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [152, 167],
+                            "name": "*>>",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [168, 183],
+                            "name": "*<<",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [184, 199],
+                            "name": "*spin",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [200, 215],
+                            "name": "*scan",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [216, 231],
+                            "name": "*random",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [232, 254],
+                            "name": "*blinkw",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "*blinka",
+                            "showInMenu": false
+                        }
+                    ]
+                },
+                "Gobo 2": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 54],
+                            "name": "open"
+                        },
+                        {
+                            "range": [55, 90],
+                            "name": "lentic"
+                        },
+                        {
+                            "range": [91, 127],
+                            "name": "slo"
+                        },
+                        {
+                            "range": [128, 163],
+                            "name": "blocks"
+                        },
+                        {
+                            "range": [164, 200],
+                            "name": "jax"
+                        },
+                        {
+                            "range": [201, 236],
+                            "name": "gatlin"
+                        },
+                        {
+                            "range": [237, 255],
+                            "name": "open"
+                        }
+                    ]
+                },
+                "Gobo 2 rot": {
+                    "type": "Gobo",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Gobo 2 rot fine": {
+                    "type": "Gobo",
+                    "defaultValue": 0,
+                    "highlightValue": 0,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Frost": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "open"
+                        },
+                        {
+                            "range": [1, 127],
+                            "name": "%"
+                        },
+                        {
+                            "range": [128, 143],
+                            "name": "full",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [144, 159],
+                            "name": "strobe",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [160, 175],
+                            "name": "random",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [176, 191],
+                            "name": "rampsnap",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [192, 207],
+                            "name": "snapramp",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [208, 223],
+                            "name": "rand rs",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [224, 239],
+                            "name": "rand sr",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "open",
+                            "showInMenu": false
+                        }
+                    ]
+                },
+                "Focus": {
+                    "type": "Beam",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Iris": {
+                    "type": "Beam",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [1, 127],
+                            "name": "%"
+                        },
+                        {
+                            "range": [128, 143],
+                            "name": "open",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [144, 159],
+                            "name": "periodic",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [160, 175],
+                            "name": "random",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [176, 191],
+                            "name": "rampsnap",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [192, 207],
+                            "name": "snapramp",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [208, 223],
+                            "name": "rand rs",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [24, 239],
+                            "name": "rand sr",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "open"
+                        }
+                    ]
+                },
+                "Strobe": {
+                    "type": "Strobe",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "capabilities": [
+                        {
+                            "range": [0, 30],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [31, 63],
+                            "name": "strobe",
+                            "center": true
+                        },
+                        {
+                            "range": [64, 95],
+                            "name": "random",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [96, 127],
+                            "name": "rampsnap",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [128, 159],
+                            "name": "snapramp",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [160, 191],
+                            "name": "rand rs",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [192, 223],
+                            "name": "rand sr",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "open"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Speed": {
+                    "type": "Speed",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "capabilities": [
+                        {
+                            "range": [0, 3],
+                            "name": "0.19s",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [4, 31],
+                            "name": "200+s",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [32, 97],
+                            "name": "100+s",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [98, 105],
+                            "name": "90+s",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [106, 113],
+                            "name": "80+s",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [114, 122],
+                            "name": "70+s",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [123, 132],
+                            "name": "60+s",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [133, 143],
+                            "name": "50+s",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [144, 155],
+                            "name": "40+s",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [156, 168],
+                            "name": "30+s",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [169, 184],
+                            "name": "20+s",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [185, 185],
+                            "name": "19.79s",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [186, 186],
+                            "name": "19.23s",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [187, 187],
+                            "name": "18.68s",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [188, 188],
+                            "name": "18.14s",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [189, 189],
+                            "name": "17.61s",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [190, 190],
+                            "name": "17.09s",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [191, 191],
+                            "name": "16.57s",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [192, 192],
+                            "name": "16.06s",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [193, 193],
+                            "name": "15.56s",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [194, 194],
+                            "name": "15.07s",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [195, 195],
+                            "name": "14.58s",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [196, 196],
+                            "name": "14.10s",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [197, 197],
+                            "name": "13.63s",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [198, 198],
+                            "name": "13.17s",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [199, 199],
+                            "name": "12.72s",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [200, 200],
+                            "name": "12.28s",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [201, 201],
+                            "name": "11.84s",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [202, 202],
+                            "name": "11.41s",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [203, 203],
+                            "name": "10.99s",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [204, 204],
+                            "name": "10.58s",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [205, 205],
+                            "name": "10.17s",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [206, 206],
+                            "name": "9.77s",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [207, 207],
+                            "name": "9.39s",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [208, 208],
+                            "name": "9.00s",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [209, 209],
+                            "name": "8.63s",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [210, 210],
+                            "name": "8.27s",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [211, 211],
+                            "name": "7.91s",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [212, 212],
+                            "name": "7.56s",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [213, 213],
+                            "name": "7.22s",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [214, 214],
+                            "name": "6.89s",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [215, 215],
+                            "name": "6.56s",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [216, 216],
+                            "name": "6.25s",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [217, 217],
+                            "name": "5.94s",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [218, 218],
+                            "name": "5.64s",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [219, 219],
+                            "name": "5.34s",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [220, 220],
+                            "name": "5.06s",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [221, 221],
+                            "name": "4.78s",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [222, 222],
+                            "name": "4.52s",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [223, 223],
+                            "name": "4.25s",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [224, 224],
+                            "name": "4.00s",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [225, 225],
+                            "name": "3.76s",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [226, 226],
+                            "name": "3.52s",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [227, 227],
+                            "name": "3.29s",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [228, 228],
+                            "name": "3.07s",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [229, 229],
+                            "name": "2.86s",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [230, 230],
+                            "name": "2.66s",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [231, 231],
+                            "name": "2.46s",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [232, 232],
+                            "name": "2.27s",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [233, 233],
+                            "name": "2.09s",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [234, 234],
+                            "name": "1.92s",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [235, 235],
+                            "name": "1.75s",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [236, 236],
+                            "name": "1.60s",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [237, 237],
+                            "name": "1.45s",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [238, 238],
+                            "name": "1.31s",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [239, 239],
+                            "name": "1.18s",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [240, 240],
+                            "name": "1.05s",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [241, 241],
+                            "name": "0.94s",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [242, 242],
+                            "name": "0.83s",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [243, 243],
+                            "name": "0.73s",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [244, 244],
+                            "name": "0.63s",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [245, 245],
+                            "name": "0.55s",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [246, 246],
+                            "name": "0.47s",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [247, 247],
+                            "name": "0.41s",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [248, 248],
+                            "name": "0.35s",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [249, 249],
+                            "name": "0.29s",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [250, 250],
+                            "name": "0.25s",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [251, 251],
+                            "name": "0.21s",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [252, 252],
+                            "name": "0.19s",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [253, 254],
+                            "name": "0.17s",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "0.15s",
+                            "showInMenu": false
+                        }
+                    ]
+                },
+                "Macro": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 11],
+                            "name": "off",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [12, 19],
+                            "name": "macro1",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [20, 27],
+                            "name": "macro2",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [28, 35],
+                            "name": "macro3",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [36, 43],
+                            "name": "macro4",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [44, 51],
+                            "name": "macro5",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [52, 59],
+                            "name": "macro6",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [60, 67],
+                            "name": "macro7",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [68, 75],
+                            "name": "macro8",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [76, 83],
+                            "name": "macro9",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [84, 91],
+                            "name": "macro10",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [92, 99],
+                            "name": "macro11",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [100, 107],
+                            "name": "macro12",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [108, 115],
+                            "name": "macro13",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [116, 123],
+                            "name": "macro14",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [124, 131],
+                            "name": "macro15",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [132, 139],
+                            "name": "macro16",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [140, 147],
+                            "name": "macro17",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [148, 155],
+                            "name": "macro18",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [156, 163],
+                            "name": "macro19",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [164, 171],
+                            "name": "macro20",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [172, 179],
+                            "name": "macro21",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [180, 187],
+                            "name": "macro22",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [188, 195],
+                            "name": "macro23",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [196, 203],
+                            "name": "macro24",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [204, 211],
+                            "name": "macro25",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [212, 215],
+                            "name": "macro26",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [216, 247],
+                            "name": "random",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "off",
+                            "showInMenu": false
+                        }
+                    ]
+                },
+                "Control": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 14],
+                            "name": "safe",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [15, 24],
+                            "name": "speedoff",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [25, 32],
+                            "name": "disoff",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [33, 40],
+                            "name": "disdim",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [41, 64],
+                            "name": "disbrit",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [65, 80],
+                            "name": "home",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [81, 93],
+                            "name": "lampon",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [94, 124],
+                            "name": "lampoff",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [125, 255],
+                            "name": "shutdown",
+                            "showInMenu": false
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ],
+                [
+                    "Gobo rot",
+                    "Gobo rot fine"
+                ],
+                [
+                    "Gobo 2 rot",
+                    "Gobo 2 rot fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "24-channel Mode",
+                    "shortName": "24ch",
+                    "channels": [
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "Colour <>",
+                        "Colour",
+                        "Colour2<>",
+                        "Colour 2",
+                        "Gobo <>",
+                        "Gobo",
+                        "Gobo rot",
+                        "Gobo rot fine",
+                        "Gobo 2 <>",
+                        "Gobo 2",
+                        "Gobo 2 rot",
+                        "Gobo 2 rot fine",
+                        "Frost",
+                        "Focus",
+                        "Iris",
+                        "Strobe",
+                        "Intensity",
+                        "Speed",
+                        "Macro",
+                        "Control"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "High End Systems",
+            "name": "Technobeam",
+            "shortName": "TechB",
+            "physical": {
+                "dimensions": [323, 242, 826],
+                "weight": 16,
+                "power": 375
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Colour": {
+                    "type": "MultiColor",
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "Indexed"
+                        },
+                        {
+                            "range": [16, 31],
+                            "name": "Forward Spin"
+                        },
+                        {
+                            "range": [32, 47],
+                            "name": "Reverse Spin"
+                        },
+                        {
+                            "range": [48, 63],
+                            "name": "Continuous"
+                        },
+                        {
+                            "range": [64, 79],
+                            "name": "Slow Scan"
+                        },
+                        {
+                            "range": [80, 95],
+                            "name": "Fast Scan"
+                        },
+                        {
+                            "range": [96, 111],
+                            "name": "Random"
+                        },
+                        {
+                            "range": [112, 127],
+                            "name": "Blink"
+                        },
+                        {
+                            "range": [128, 143],
+                            "name": "Indexed*"
+                        },
+                        {
+                            "range": [144, 159],
+                            "name": "Forward Spin*"
+                        },
+                        {
+                            "range": [160, 175],
+                            "name": "Reverse Spin*"
+                        },
+                        {
+                            "range": [176, 191],
+                            "name": "Continuous*"
+                        },
+                        {
+                            "range": [192, 207],
+                            "name": "Slow Scan*"
+                        },
+                        {
+                            "range": [208, 223],
+                            "name": "Fast Scan*"
+                        },
+                        {
+                            "range": [224, 239],
+                            "name": "Random*"
+                        },
+                        {
+                            "range": [240, 255],
+                            "name": "Blink*"
+                        }
+                    ]
+                },
+                "Colour Pos": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 23],
+                            "name": "Pos 1 Open",
+                            "center": true
+                        },
+                        {
+                            "range": [24, 31],
+                            "name": "Position 2",
+                            "center": true
+                        },
+                        {
+                            "range": [32, 39],
+                            "name": "Position 3",
+                            "center": true
+                        },
+                        {
+                            "range": [40, 47],
+                            "name": "Position 4",
+                            "center": true
+                        },
+                        {
+                            "range": [48, 55],
+                            "name": "Position 5",
+                            "center": true
+                        },
+                        {
+                            "range": [56, 63],
+                            "name": "Position 6",
+                            "center": true
+                        },
+                        {
+                            "range": [64, 71],
+                            "name": "Position 7",
+                            "center": true
+                        },
+                        {
+                            "range": [72, 79],
+                            "name": "Position 8",
+                            "center": true
+                        },
+                        {
+                            "range": [80, 87],
+                            "name": "Position 9",
+                            "center": true
+                        },
+                        {
+                            "range": [88, 95],
+                            "name": "Position 10",
+                            "center": true
+                        },
+                        {
+                            "range": [96, 103],
+                            "name": "Position 11",
+                            "center": true
+                        },
+                        {
+                            "range": [104, 111],
+                            "name": "Position 12",
+                            "center": true
+                        },
+                        {
+                            "range": [112, 127],
+                            "name": "Position 13",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 143],
+                            "name": "Colour 1/2",
+                            "center": true
+                        },
+                        {
+                            "range": [144, 151],
+                            "name": "Colour 2/3",
+                            "center": true
+                        },
+                        {
+                            "range": [152, 159],
+                            "name": "Colour 3/4",
+                            "center": true
+                        },
+                        {
+                            "range": [160, 167],
+                            "name": "Colour 4/5",
+                            "center": true
+                        },
+                        {
+                            "range": [168, 175],
+                            "name": "Colour 5/6",
+                            "center": true
+                        },
+                        {
+                            "range": [176, 183],
+                            "name": "Colour 6/7",
+                            "center": true
+                        },
+                        {
+                            "range": [184, 191],
+                            "name": "Colour 7/8",
+                            "center": true
+                        },
+                        {
+                            "range": [192, 199],
+                            "name": "Colour 8/9",
+                            "center": true
+                        },
+                        {
+                            "range": [200, 207],
+                            "name": "Colour 9/10",
+                            "center": true
+                        },
+                        {
+                            "range": [208, 215],
+                            "name": "Colour 10/11",
+                            "center": true
+                        },
+                        {
+                            "range": [216, 223],
+                            "name": "Colour 11/12",
+                            "center": true
+                        },
+                        {
+                            "range": [224, 231],
+                            "name": "Colour 12/13",
+                            "center": true
+                        },
+                        {
+                            "range": [232, 247],
+                            "name": "Colour 13/1",
+                            "center": true
+                        },
+                        {
+                            "range": [248, 255],
+                            "name": "Pos 1 Open",
+                            "center": true
+                        }
+                    ]
+                },
+                "Litho": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "Indexed"
+                        },
+                        {
+                            "range": [16, 31],
+                            "name": "Forward Spin"
+                        },
+                        {
+                            "range": [32, 47],
+                            "name": "Reverse Spin"
+                        },
+                        {
+                            "range": [48, 63],
+                            "name": "Scan"
+                        },
+                        {
+                            "range": [64, 79],
+                            "name": "Blink"
+                        },
+                        {
+                            "range": [80, 95],
+                            "name": "Random"
+                        },
+                        {
+                            "range": [112, 127],
+                            "name": "Wheel Spin"
+                        },
+                        {
+                            "range": [128, 143],
+                            "name": "Indexed*"
+                        },
+                        {
+                            "range": [144, 159],
+                            "name": "Forward Spin*"
+                        },
+                        {
+                            "range": [160, 175],
+                            "name": "Reverse Spin*"
+                        },
+                        {
+                            "range": [176, 191],
+                            "name": "Scan*"
+                        },
+                        {
+                            "range": [192, 207],
+                            "name": "Blink*"
+                        },
+                        {
+                            "range": [208, 223],
+                            "name": "Random*"
+                        },
+                        {
+                            "range": [240, 255],
+                            "name": "Wheel Spin*"
+                        }
+                    ]
+                },
+                "Litho Pos": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "Pos 1 Open"
+                        },
+                        {
+                            "range": [16, 47],
+                            "name": "Position 2"
+                        },
+                        {
+                            "range": [48, 79],
+                            "name": "Position 3"
+                        },
+                        {
+                            "range": [80, 111],
+                            "name": "Position 4"
+                        },
+                        {
+                            "range": [112, 143],
+                            "name": "Position 5"
+                        },
+                        {
+                            "range": [144, 175],
+                            "name": "Position 6"
+                        },
+                        {
+                            "range": [176, 207],
+                            "name": "Position 7"
+                        },
+                        {
+                            "range": [208, 239],
+                            "name": "Position 8"
+                        },
+                        {
+                            "range": [240, 255],
+                            "name": "Pos 1 Open"
+                        }
+                    ]
+                },
+                "Litho Rot": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "Pos"
+                        }
+                    ],
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "Litho Rot fine": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "Pos"
+                        }
+                    ],
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "FX Position": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 25],
+                            "name": "Position 1"
+                        },
+                        {
+                            "range": [26, 51],
+                            "name": "Position 2"
+                        },
+                        {
+                            "range": [52, 76],
+                            "name": "Position 3"
+                        },
+                        {
+                            "range": [77, 102],
+                            "name": "Position 4"
+                        },
+                        {
+                            "range": [103, 127],
+                            "name": "Position 5"
+                        },
+                        {
+                            "range": [128, 153],
+                            "name": "Position 1*"
+                        },
+                        {
+                            "range": [154, 178],
+                            "name": "Position 2*"
+                        },
+                        {
+                            "range": [179, 204],
+                            "name": "Position 3*"
+                        },
+                        {
+                            "range": [205, 229],
+                            "name": "Position 4*"
+                        },
+                        {
+                            "range": [230, 255],
+                            "name": "Position 5*"
+                        }
+                    ]
+                },
+                "FX Spin": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 120],
+                            "name": "Forward",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [121, 134],
+                            "name": "No Spin",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [135, 255],
+                            "name": "Reverse",
+                            "showInMenu": false
+                        }
+                    ]
+                },
+                "Focus": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "Distance"
+                        }
+                    ]
+                },
+                "Iris": {
+                    "type": "Beam",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "capabilities": [
+                        {
+                            "range": [0, 7],
+                            "name": "Close"
+                        },
+                        {
+                            "range": [8, 67],
+                            "name": "Periodic Strobe"
+                        },
+                        {
+                            "range": [68, 127],
+                            "name": "Random Strobe"
+                        },
+                        {
+                            "range": [128, 187],
+                            "name": "Ramp open"
+                        },
+                        {
+                            "range": [188, 247],
+                            "name": "Snap open"
+                        },
+                        {
+                            "range": [248, 255],
+                            "name": "Open"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "MSpeed (*)": {
+                    "type": "Speed",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "Velocity"
+                        }
+                    ]
+                },
+                "Laser Aim": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "Off"
+                        },
+                        {
+                            "range": [128, 247],
+                            "name": "Mod Speed"
+                        },
+                        {
+                            "range": [248, 255],
+                            "name": "On"
+                        }
+                    ]
+                },
+                "Control": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 7],
+                            "name": "Safe"
+                        },
+                        {
+                            "range": [24, 26],
+                            "name": "Display Off"
+                        },
+                        {
+                            "range": [32, 34],
+                            "name": "Display Dim"
+                        },
+                        {
+                            "range": [40, 42],
+                            "name": "Display Bright"
+                        },
+                        {
+                            "range": [64, 66],
+                            "name": "Home"
+                        },
+                        {
+                            "range": [80, 82],
+                            "name": "Lamp On"
+                        },
+                        {
+                            "range": [96, 98],
+                            "name": "Lamp Off"
+                        },
+                        {
+                            "range": [128, 130],
+                            "name": "Shutdown"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ],
+                [
+                    "Litho Rot",
+                    "Litho Rot fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "18-channel Mode",
+                    "shortName": "18ch",
+                    "channels": [
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "Colour",
+                        "Colour Pos",
+                        "Litho",
+                        "Litho Pos",
+                        "Litho Rot",
+                        "Litho Rot fine",
+                        "FX Position",
+                        "FX Spin",
+                        "Focus",
+                        "Iris",
+                        "Intensity",
+                        "MSpeed (*)",
+                        "Laser Aim",
+                        "Control"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "High End Systems",
+            "name": "Trackspot High Res",
+            "shortName": "TrkSpoth",
+            "physical": {
+                "dimensions": [221, 178, 650],
+                "weight": 10.4,
+                "power": 350
+            },
+            "availableChannels": {
+                "Pan (*)": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Tilt (*)": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Colour": {
+                    "type": "MultiColor",
+                    "capabilities": [
+                        {
+                            "range": [0, 7],
+                            "name": "Colour 1"
+                        },
+                        {
+                            "range": [8, 63],
+                            "name": "Forward Spin",
+                            "center": true
+                        },
+                        {
+                            "range": [64, 119],
+                            "name": "Reverse Spin",
+                            "center": true
+                        },
+                        {
+                            "range": [120, 127],
+                            "name": "Half Col 2"
+                        },
+                        {
+                            "range": [128, 132],
+                            "name": "Colour 2"
+                        },
+                        {
+                            "range": [133, 139],
+                            "name": "Half Col 3"
+                        },
+                        {
+                            "range": [140, 147],
+                            "name": "Colour 3"
+                        },
+                        {
+                            "range": [148, 155],
+                            "name": "Half Col 4"
+                        },
+                        {
+                            "range": [156, 162],
+                            "name": "Colour 4"
+                        },
+                        {
+                            "range": [163, 167],
+                            "name": "Half Col 5"
+                        },
+                        {
+                            "range": [168, 175],
+                            "name": "Colour 5"
+                        },
+                        {
+                            "range": [176, 183],
+                            "name": "Half Col 6"
+                        },
+                        {
+                            "range": [184, 190],
+                            "name": "Colour 6"
+                        },
+                        {
+                            "range": [191, 195],
+                            "name": "Half Col 7"
+                        },
+                        {
+                            "range": [196, 203],
+                            "name": "Colour 7"
+                        },
+                        {
+                            "range": [204, 211],
+                            "name": "Half Col 8"
+                        },
+                        {
+                            "range": [212, 218],
+                            "name": "Colour 8"
+                        },
+                        {
+                            "range": [219, 223],
+                            "name": "Half Col 9"
+                        },
+                        {
+                            "range": [224, 231],
+                            "name": "Colour 9"
+                        },
+                        {
+                            "range": [232, 239],
+                            "name": "Half Col 10"
+                        },
+                        {
+                            "range": [240, 246],
+                            "name": "Colour 10"
+                        },
+                        {
+                            "range": [247, 251],
+                            "name": "Half Col 1"
+                        },
+                        {
+                            "range": [252, 255],
+                            "name": "Colour 1"
+                        }
+                    ]
+                },
+                "Gobo": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 9],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [10, 81],
+                            "name": "Forward Spin",
+                            "center": true
+                        },
+                        {
+                            "range": [82, 154],
+                            "name": "Reverse Spin",
+                            "center": true
+                        },
+                        {
+                            "range": [155, 178],
+                            "name": "Gobo 2",
+                            "center": true
+                        },
+                        {
+                            "range": [179, 190],
+                            "name": "Gobo 3",
+                            "center": true
+                        },
+                        {
+                            "range": [191, 200],
+                            "name": "Gobo 4",
+                            "center": true
+                        },
+                        {
+                            "range": [201, 208],
+                            "name": "Gobo 5",
+                            "center": true
+                        },
+                        {
+                            "range": [209, 216],
+                            "name": "Gobo 6",
+                            "center": true
+                        },
+                        {
+                            "range": [217, 226],
+                            "name": "Gobo 7",
+                            "center": true
+                        },
+                        {
+                            "range": [227, 234],
+                            "name": "Gobo 8",
+                            "center": true
+                        },
+                        {
+                            "range": [235, 244],
+                            "name": "Gobo 9",
+                            "center": true
+                        },
+                        {
+                            "range": [245, 251],
+                            "name": "Gobo 10",
+                            "center": true
+                        },
+                        {
+                            "range": [252, 255],
+                            "name": "Open"
+                        }
+                    ]
+                },
+                "Strobe": {
+                    "type": "Strobe",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "capabilities": [
+                        {
+                            "range": [0, 25],
+                            "name": "Closed"
+                        },
+                        {
+                            "range": [26, 50],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [51, 229],
+                            "name": "Speed"
+                        },
+                        {
+                            "range": [230, 241],
+                            "name": "Closed"
+                        },
+                        {
+                            "range": [242, 255],
+                            "name": "Open"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "P/T-Speed(*)": {
+                    "type": "Speed",
+                    "defaultValue": 255,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "Velocity"
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "7-channel Mode",
+                    "shortName": "7ch",
+                    "channels": [
+                        "Pan (*)",
+                        "Tilt (*)",
+                        "Colour",
+                        "Gobo",
+                        "Strobe",
+                        "Intensity",
+                        "P/T-Speed(*)"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "High End Systems",
+            "name": "Trackspot Low Res",
+            "shortName": "TrkSpotl",
+            "physical": {
+                "dimensions": [221, 178, 650],
+                "weight": 10.4,
+                "power": 350
+            },
+            "availableChannels": {
+                "Pan (*)": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Tilt (*)": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Colour": {
+                    "type": "MultiColor",
+                    "capabilities": [
+                        {
+                            "range": [0, 31],
+                            "name": "Colour 1"
+                        },
+                        {
+                            "range": [32, 53],
+                            "name": "Colour 2"
+                        },
+                        {
+                            "range": [54, 78],
+                            "name": "Colour 3"
+                        },
+                        {
+                            "range": [79, 109],
+                            "name": "Colour 4"
+                        },
+                        {
+                            "range": [110, 137],
+                            "name": "Colour 5"
+                        },
+                        {
+                            "range": [138, 159],
+                            "name": "Colour 6"
+                        },
+                        {
+                            "range": [160, 199],
+                            "name": "Colour 7"
+                        },
+                        {
+                            "range": [200, 209],
+                            "name": "Colour 8"
+                        },
+                        {
+                            "range": [210, 239],
+                            "name": "Colour 9"
+                        },
+                        {
+                            "range": [240, 255],
+                            "name": "Colour 10"
+                        }
+                    ]
+                },
+                "Gobo": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 31],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [32, 53],
+                            "name": "Gobo 2",
+                            "center": true
+                        },
+                        {
+                            "range": [54, 78],
+                            "name": "Gobo 3",
+                            "center": true
+                        },
+                        {
+                            "range": [79, 109],
+                            "name": "Gobo 4",
+                            "center": true
+                        },
+                        {
+                            "range": [110, 137],
+                            "name": "Gobo 5",
+                            "center": true
+                        },
+                        {
+                            "range": [138, 159],
+                            "name": "Gobo 6",
+                            "center": true
+                        },
+                        {
+                            "range": [160, 199],
+                            "name": "Gobo 7",
+                            "center": true
+                        },
+                        {
+                            "range": [200, 209],
+                            "name": "Gobo 8",
+                            "center": true
+                        },
+                        {
+                            "range": [210, 239],
+                            "name": "Gobo 9",
+                            "center": true
+                        },
+                        {
+                            "range": [240, 255],
+                            "name": "Gobo 10",
+                            "center": true
+                        }
+                    ]
+                },
+                "Strobe": {
+                    "type": "Strobe",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "capabilities": [
+                        {
+                            "range": [0, 25],
+                            "name": "Closed"
+                        },
+                        {
+                            "range": [26, 50],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [51, 229],
+                            "name": "Speed"
+                        },
+                        {
+                            "range": [230, 241],
+                            "name": "Closed"
+                        },
+                        {
+                            "range": [242, 255],
+                            "name": "Open"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "P/T-Speed(*)": {
+                    "type": "Speed",
+                    "defaultValue": 255,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "Velocity"
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "7-channel Mode",
+                    "shortName": "7ch",
+                    "channels": [
+                        "Pan (*)",
+                        "Tilt (*)",
+                        "Colour",
+                        "Gobo",
+                        "Strobe",
+                        "Intensity",
+                        "P/T-Speed(*)"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "High End Systems",
+            "name": "xSpot",
+            "shortName": "xSpot",
+            "physical": {
+                "dimensions": [524, 524, 814],
+                "weight": 31.8,
+                "power": 1200
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Lamp Func": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 31],
+                            "name": "Normal"
+                        },
+                        {
+                            "range": [32, 63],
+                            "name": "Strobe"
+                        },
+                        {
+                            "range": [64, 95],
+                            "name": "Lamp Boost"
+                        },
+                        {
+                            "range": [96, 127],
+                            "name": "Dual Dim"
+                        },
+                        {
+                            "range": [128, 159],
+                            "name": "Elect. Dim"
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "Normal"
+                        }
+                    ]
+                },
+                "Shutter": {
+                    "type": "Shutter",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "capabilities": [
+                        {
+                            "range": [0, 23],
+                            "name": "Close"
+                        },
+                        {
+                            "range": [24, 49],
+                            "name": "Periodic"
+                        },
+                        {
+                            "range": [50, 75],
+                            "name": "Rand/Rand"
+                        },
+                        {
+                            "range": [76, 101],
+                            "name": "Rand/Sync"
+                        },
+                        {
+                            "range": [102, 127],
+                            "name": "Ramp open"
+                        },
+                        {
+                            "range": [128, 153],
+                            "name": "Snap open"
+                        },
+                        {
+                            "range": [154, 179],
+                            "name": "Ramp Open/Shut"
+                        },
+                        {
+                            "range": [180, 205],
+                            "name": "Rand Ramp/Snap"
+                        },
+                        {
+                            "range": [206, 231],
+                            "name": "Rand Snap/Ramp"
+                        },
+                        {
+                            "range": [232, 255],
+                            "name": "Open"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Frost": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [1, 127],
+                            "name": "Variable"
+                        },
+                        {
+                            "range": [128, 135],
+                            "name": "Full"
+                        },
+                        {
+                            "range": [136, 151],
+                            "name": "Periodic"
+                        },
+                        {
+                            "range": [152, 167],
+                            "name": "Random"
+                        },
+                        {
+                            "range": [168, 183],
+                            "name": "Ramp open"
+                        },
+                        {
+                            "range": [184, 199],
+                            "name": "Snap open"
+                        },
+                        {
+                            "range": [200, 215],
+                            "name": "Ramp Open/Shut"
+                        },
+                        {
+                            "range": [216, 231],
+                            "name": "Rand Ramp/Snap"
+                        },
+                        {
+                            "range": [232, 247],
+                            "name": "Rand Snap/Ramp"
+                        },
+                        {
+                            "range": [248, 255],
+                            "name": "Open"
+                        }
+                    ]
+                },
+                "Focus Fnc": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 31],
+                            "name": "Zoom Track"
+                        },
+                        {
+                            "range": [32, 63],
+                            "name": "Manual"
+                        }
+                    ]
+                },
+                "Focus": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "Distance"
+                        }
+                    ]
+                },
+                "Zoom": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "Beam"
+                        }
+                    ]
+                },
+                "MSpeed (*)": {
+                    "type": "Speed",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "Velocity"
+                        }
+                    ]
+                },
+                "*Macro": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 5],
+                            "name": "Off"
+                        },
+                        {
+                            "range": [6, 62],
+                            "name": "Pan sweep"
+                        },
+                        {
+                            "range": [63, 65],
+                            "name": "Off"
+                        },
+                        {
+                            "range": [66, 122],
+                            "name": "Tilt sweep"
+                        },
+                        {
+                            "range": [123, 125],
+                            "name": "Off"
+                        },
+                        {
+                            "range": [126, 160],
+                            "name": "CW circle"
+                        },
+                        {
+                            "range": [161, 163],
+                            "name": "Off"
+                        },
+                        {
+                            "range": [164, 198],
+                            "name": "CCW circle"
+                        }
+                    ]
+                },
+                "Control": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 9],
+                            "name": "Safe"
+                        },
+                        {
+                            "range": [10, 19],
+                            "name": "P/T-Speed off"
+                        },
+                        {
+                            "range": [20, 29],
+                            "name": "Display Off"
+                        },
+                        {
+                            "range": [30, 39],
+                            "name": "Display Dim"
+                        },
+                        {
+                            "range": [40, 59],
+                            "name": "Display Bright"
+                        },
+                        {
+                            "range": [60, 79],
+                            "name": "Home All"
+                        },
+                        {
+                            "range": [80, 89],
+                            "name": "Lamp On"
+                        },
+                        {
+                            "range": [90, 119],
+                            "name": "Lamo Off"
+                        },
+                        {
+                            "range": [120, 130],
+                            "name": "Shutdown"
+                        },
+                        {
+                            "range": [160, 169],
+                            "name": "Home P/T"
+                        },
+                        {
+                            "range": [170, 179],
+                            "name": "Home Colour"
+                        },
+                        {
+                            "range": [180, 189],
+                            "name": "Home Gobo"
+                        },
+                        {
+                            "range": [190, 199],
+                            "name": "Home Strobe"
+                        },
+                        {
+                            "range": [200, 209],
+                            "name": "Home Focus"
+                        },
+                        {
+                            "range": [210, 218],
+                            "name": "Home Iris"
+                        }
+                    ]
+                },
+                "Stat Col Fnc": {
+                    "type": "MultiColor",
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "Indexed"
+                        },
+                        {
+                            "range": [16, 31],
+                            "name": "Forward",
+                            "center": true
+                        },
+                        {
+                            "range": [32, 47],
+                            "name": "Reverse",
+                            "center": true
+                        },
+                        {
+                            "range": [48, 63],
+                            "name": "Continuous"
+                        },
+                        {
+                            "range": [64, 79],
+                            "name": "Slow Scan"
+                        },
+                        {
+                            "range": [80, 95],
+                            "name": "Fast Scan"
+                        },
+                        {
+                            "range": [96, 111],
+                            "name": "Random"
+                        },
+                        {
+                            "range": [112, 127],
+                            "name": "Blink-Ind."
+                        },
+                        {
+                            "range": [128, 143],
+                            "name": "*Indexed"
+                        },
+                        {
+                            "range": [144, 159],
+                            "name": "*Forward"
+                        },
+                        {
+                            "range": [160, 175],
+                            "name": "*Reverse"
+                        },
+                        {
+                            "range": [176, 191],
+                            "name": "*Continuous"
+                        },
+                        {
+                            "range": [192, 207],
+                            "name": "*Slow Scan"
+                        },
+                        {
+                            "range": [208, 223],
+                            "name": "*Fast Scan"
+                        },
+                        {
+                            "range": [224, 239],
+                            "name": "*Random"
+                        },
+                        {
+                            "range": [240, 255],
+                            "name": "*Blink-Ind."
+                        }
+                    ]
+                },
+                "Stat Col Pos": {
+                    "type": "MultiColor",
+                    "capabilities": [
+                        {
+                            "range": [0, 23],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [24, 42],
+                            "name": "Pos 1/2"
+                        },
+                        {
+                            "range": [43, 61],
+                            "name": "Position 2"
+                        },
+                        {
+                            "range": [62, 80],
+                            "name": "Pos 2/3"
+                        },
+                        {
+                            "range": [81, 99],
+                            "name": "Position 3"
+                        },
+                        {
+                            "range": [100, 118],
+                            "name": "Pos 3/4"
+                        },
+                        {
+                            "range": [119, 137],
+                            "name": "Position 4"
+                        },
+                        {
+                            "range": [138, 156],
+                            "name": "Pos 4/5"
+                        },
+                        {
+                            "range": [157, 175],
+                            "name": "Position 5"
+                        },
+                        {
+                            "range": [176, 194],
+                            "name": "Pos 5/6"
+                        },
+                        {
+                            "range": [195, 213],
+                            "name": "Position 6"
+                        },
+                        {
+                            "range": [214, 232],
+                            "name": "Pos 6/1"
+                        },
+                        {
+                            "range": [233, 255],
+                            "name": "Position 1"
+                        }
+                    ]
+                },
+                "Mix Col Fnc": {
+                    "type": "MultiColor",
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "Pure Mix"
+                        },
+                        {
+                            "range": [16, 31],
+                            "name": "Continuous"
+                        },
+                        {
+                            "range": [48, 63],
+                            "name": "Spin"
+                        },
+                        {
+                            "range": [64, 79],
+                            "name": "Cycle"
+                        },
+                        {
+                            "range": [96, 111],
+                            "name": "Random"
+                        },
+                        {
+                            "range": [112, 127],
+                            "name": "Blink"
+                        },
+                        {
+                            "range": [128, 143],
+                            "name": "*Pure Mix"
+                        },
+                        {
+                            "range": [144, 159],
+                            "name": "*Continuous"
+                        },
+                        {
+                            "range": [176, 191],
+                            "name": "*Spin"
+                        },
+                        {
+                            "range": [192, 207],
+                            "name": "*Cycle"
+                        },
+                        {
+                            "range": [224, 239],
+                            "name": "*Random"
+                        },
+                        {
+                            "range": [240, 255],
+                            "name": "*Blink"
+                        }
+                    ]
+                },
+                "Cyan": {
+                    "type": "SingleColor",
+                    "color": "Cyan",
+                    "invert": true,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Magenta": {
+                    "type": "SingleColor",
+                    "color": "Magenta",
+                    "invert": true,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Yellow": {
+                    "type": "SingleColor",
+                    "color": "Yellow",
+                    "invert": true,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "CT Orange": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 169],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [170, 212],
+                            "name": "Full CTO"
+                        },
+                        {
+                            "range": [213, 254],
+                            "name": "Beam flatten"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "Open"
+                        }
+                    ]
+                },
+                "CT Blue": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 169],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [170, 212],
+                            "name": "Full CTO"
+                        },
+                        {
+                            "range": [213, 254],
+                            "name": "Beam flatten"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "Open"
+                        }
+                    ]
+                },
+                "Gobo 1 Fnc": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "Indexed"
+                        },
+                        {
+                            "range": [16, 31],
+                            "name": "Forward",
+                            "center": true
+                        },
+                        {
+                            "range": [32, 47],
+                            "name": "Reverse",
+                            "center": true
+                        },
+                        {
+                            "range": [48, 63],
+                            "name": "Scan"
+                        },
+                        {
+                            "range": [64, 79],
+                            "name": "Random"
+                        },
+                        {
+                            "range": [80, 95],
+                            "name": "Blink"
+                        },
+                        {
+                            "range": [96, 111],
+                            "name": "TBC"
+                        },
+                        {
+                            "range": [112, 127],
+                            "name": "Continuous"
+                        },
+                        {
+                            "range": [128, 143],
+                            "name": "*Indexed"
+                        },
+                        {
+                            "range": [144, 159],
+                            "name": "*Forward",
+                            "center": true
+                        },
+                        {
+                            "range": [160, 175],
+                            "name": "*Reverse",
+                            "center": true
+                        },
+                        {
+                            "range": [176, 191],
+                            "name": "*Scan"
+                        },
+                        {
+                            "range": [192, 207],
+                            "name": "*Random"
+                        },
+                        {
+                            "range": [208, 223],
+                            "name": "*Blink"
+                        },
+                        {
+                            "range": [224, 239],
+                            "name": "*TBC"
+                        },
+                        {
+                            "range": [240, 255],
+                            "name": "*Continuous"
+                        }
+                    ]
+                },
+                "Gobo 1": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [16, 47],
+                            "name": "Position 2"
+                        },
+                        {
+                            "range": [48, 79],
+                            "name": "Position 3"
+                        },
+                        {
+                            "range": [80, 111],
+                            "name": "Position 4"
+                        },
+                        {
+                            "range": [112, 143],
+                            "name": "Position 5"
+                        },
+                        {
+                            "range": [144, 175],
+                            "name": "Position 6"
+                        },
+                        {
+                            "range": [176, 207],
+                            "name": "Position 7"
+                        },
+                        {
+                            "range": [208, 239],
+                            "name": "Position 8"
+                        },
+                        {
+                            "range": [240, 255],
+                            "name": "Open"
+                        }
+                    ]
+                },
+                "G1 Rot Fnc": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "Indexed"
+                        },
+                        {
+                            "range": [16, 31],
+                            "name": "Forward Rot"
+                        },
+                        {
+                            "range": [32, 47],
+                            "name": "Reverse Rot"
+                        },
+                        {
+                            "range": [48, 63],
+                            "name": "Scan"
+                        },
+                        {
+                            "range": [64, 79],
+                            "name": "Blink"
+                        },
+                        {
+                            "range": [128, 143],
+                            "name": "*Indexed"
+                        },
+                        {
+                            "range": [144, 159],
+                            "name": "*Forward Rot"
+                        },
+                        {
+                            "range": [160, 175],
+                            "name": "*Reverse Rot"
+                        },
+                        {
+                            "range": [176, 191],
+                            "name": "*Scan"
+                        },
+                        {
+                            "range": [192, 207],
+                            "name": "*Blink"
+                        }
+                    ]
+                },
+                "Gobo 1 Rot": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "Position",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "Gobo 1 Rot fine": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "Position",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "FX Func": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "Indexed"
+                        },
+                        {
+                            "range": [16, 31],
+                            "name": "Forward",
+                            "center": true
+                        },
+                        {
+                            "range": [32, 47],
+                            "name": "Reverse",
+                            "center": true
+                        },
+                        {
+                            "range": [48, 63],
+                            "name": "Scan"
+                        },
+                        {
+                            "range": [64, 79],
+                            "name": "Random"
+                        },
+                        {
+                            "range": [80, 95],
+                            "name": "Blink"
+                        },
+                        {
+                            "range": [96, 111],
+                            "name": "TBC"
+                        },
+                        {
+                            "range": [112, 127],
+                            "name": "Continuous"
+                        },
+                        {
+                            "range": [128, 143],
+                            "name": "*Indexed"
+                        },
+                        {
+                            "range": [144, 159],
+                            "name": "*Forward",
+                            "center": true
+                        },
+                        {
+                            "range": [160, 175],
+                            "name": "*Reverse",
+                            "center": true
+                        },
+                        {
+                            "range": [176, 191],
+                            "name": "*Scan"
+                        },
+                        {
+                            "range": [192, 207],
+                            "name": "*Random"
+                        },
+                        {
+                            "range": [208, 223],
+                            "name": "*Blink"
+                        },
+                        {
+                            "range": [224, 239],
+                            "name": "*TBC"
+                        },
+                        {
+                            "range": [240, 255],
+                            "name": "*Continuous"
+                        }
+                    ]
+                },
+                "FX Pos": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [16, 47],
+                            "name": "Position 2"
+                        },
+                        {
+                            "range": [48, 79],
+                            "name": "Position 3"
+                        },
+                        {
+                            "range": [80, 111],
+                            "name": "Position 4"
+                        },
+                        {
+                            "range": [112, 143],
+                            "name": "Position 5"
+                        },
+                        {
+                            "range": [144, 175],
+                            "name": "Position 6"
+                        },
+                        {
+                            "range": [176, 207],
+                            "name": "Position 7"
+                        },
+                        {
+                            "range": [208, 239],
+                            "name": "Position 8"
+                        },
+                        {
+                            "range": [240, 255],
+                            "name": "Open"
+                        }
+                    ]
+                },
+                "FX Rot Fnc": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "Indexed"
+                        },
+                        {
+                            "range": [16, 31],
+                            "name": "Forward Rot"
+                        },
+                        {
+                            "range": [32, 47],
+                            "name": "Reverse Rot"
+                        },
+                        {
+                            "range": [48, 63],
+                            "name": "Scan"
+                        },
+                        {
+                            "range": [64, 79],
+                            "name": "Blink"
+                        },
+                        {
+                            "range": [128, 143],
+                            "name": "*Indexed"
+                        },
+                        {
+                            "range": [144, 159],
+                            "name": "*Forward Rot"
+                        },
+                        {
+                            "range": [160, 175],
+                            "name": "*Reverse Rot"
+                        },
+                        {
+                            "range": [176, 191],
+                            "name": "*Scan"
+                        },
+                        {
+                            "range": [192, 207],
+                            "name": "*Blink"
+                        }
+                    ]
+                },
+                "FX Rot": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "Position",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "FX Rot fine": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "Position",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "Gobo 2 Fnc": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "Indexed"
+                        },
+                        {
+                            "range": [16, 31],
+                            "name": "Forward",
+                            "center": true
+                        },
+                        {
+                            "range": [32, 47],
+                            "name": "Reverse",
+                            "center": true
+                        },
+                        {
+                            "range": [48, 63],
+                            "name": "Scan"
+                        },
+                        {
+                            "range": [64, 79],
+                            "name": "Random"
+                        },
+                        {
+                            "range": [80, 95],
+                            "name": "Blink"
+                        },
+                        {
+                            "range": [96, 111],
+                            "name": "TBC"
+                        },
+                        {
+                            "range": [112, 127],
+                            "name": "Continuous"
+                        },
+                        {
+                            "range": [128, 143],
+                            "name": "*Indexed"
+                        },
+                        {
+                            "range": [144, 159],
+                            "name": "*Forward",
+                            "center": true
+                        },
+                        {
+                            "range": [160, 175],
+                            "name": "*Reverse",
+                            "center": true
+                        },
+                        {
+                            "range": [176, 191],
+                            "name": "*Scan"
+                        },
+                        {
+                            "range": [192, 207],
+                            "name": "*Random"
+                        },
+                        {
+                            "range": [208, 223],
+                            "name": "*Blink"
+                        },
+                        {
+                            "range": [224, 239],
+                            "name": "*TBC"
+                        },
+                        {
+                            "range": [240, 255],
+                            "name": "*Continuous"
+                        }
+                    ]
+                },
+                "Gobo 2": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [16, 47],
+                            "name": "Position 2"
+                        },
+                        {
+                            "range": [48, 79],
+                            "name": "Position 3"
+                        },
+                        {
+                            "range": [80, 111],
+                            "name": "Position 4"
+                        },
+                        {
+                            "range": [112, 143],
+                            "name": "Position 5"
+                        },
+                        {
+                            "range": [144, 175],
+                            "name": "Position 6"
+                        },
+                        {
+                            "range": [176, 207],
+                            "name": "Position 7"
+                        },
+                        {
+                            "range": [208, 239],
+                            "name": "Position 8"
+                        },
+                        {
+                            "range": [240, 255],
+                            "name": "Open"
+                        }
+                    ]
+                },
+                "G2 Rot Fnc": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "Indexed"
+                        },
+                        {
+                            "range": [16, 31],
+                            "name": "Forward Rot"
+                        },
+                        {
+                            "range": [32, 47],
+                            "name": "Reverse Rot"
+                        },
+                        {
+                            "range": [48, 63],
+                            "name": "Scan"
+                        },
+                        {
+                            "range": [64, 79],
+                            "name": "Blink"
+                        },
+                        {
+                            "range": [128, 143],
+                            "name": "*Indexed"
+                        },
+                        {
+                            "range": [144, 159],
+                            "name": "*Forward Rot"
+                        },
+                        {
+                            "range": [160, 175],
+                            "name": "*Reverse Rot"
+                        },
+                        {
+                            "range": [176, 191],
+                            "name": "*Scan"
+                        },
+                        {
+                            "range": [192, 207],
+                            "name": "*Blink"
+                        }
+                    ]
+                },
+                "Gobo 2 Rot": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "Position",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "Gobo 2 Rot fine": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "Position",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "Iris": {
+                    "type": "Beam",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "Close"
+                        },
+                        {
+                            "range": [1, 127],
+                            "name": "Variable Iris"
+                        },
+                        {
+                            "range": [128, 135],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [136, 151],
+                            "name": "Periodic Strobe"
+                        },
+                        {
+                            "range": [152, 167],
+                            "name": "Random Strobe"
+                        },
+                        {
+                            "range": [168, 183],
+                            "name": "Ramp open"
+                        },
+                        {
+                            "range": [184, 199],
+                            "name": "Snap open"
+                        },
+                        {
+                            "range": [200, 215],
+                            "name": "Ramp Open/Shut"
+                        },
+                        {
+                            "range": [216, 231],
+                            "name": "Rand Ramp/Snap"
+                        },
+                        {
+                            "range": [232, 247],
+                            "name": "Rand Snap/Ramp"
+                        },
+                        {
+                            "range": [248, 255],
+                            "name": "Open"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ],
+                [
+                    "Gobo 1 Rot",
+                    "Gobo 1 Rot fine"
+                ],
+                [
+                    "FX Rot",
+                    "FX Rot fine"
+                ],
+                [
+                    "Gobo 2 Rot",
+                    "Gobo 2 Rot fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "38-channel Mode",
+                    "shortName": "38ch",
+                    "channels": [
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "Lamp Func",
+                        "Shutter",
+                        "Intensity",
+                        "Frost",
+                        "Focus Fnc",
+                        "Focus",
+                        "Zoom",
+                        "MSpeed (*)",
+                        "*Macro",
+                        "Control",
+                        "Stat Col Fnc",
+                        "Stat Col Pos",
+                        "Mix Col Fnc",
+                        "Cyan",
+                        "Magenta",
+                        "Yellow",
+                        "CT Orange",
+                        "CT Blue",
+                        "Gobo 1 Fnc",
+                        "Gobo 1",
+                        "G1 Rot Fnc",
+                        "Gobo 1 Rot",
+                        "Gobo 1 Rot fine",
+                        "FX Func",
+                        "FX Pos",
+                        "FX Rot Fnc",
+                        "FX Rot",
+                        "FX Rot fine",
+                        "Gobo 2 Fnc",
+                        "Gobo 2",
+                        "G2 Rot Fnc",
+                        "Gobo 2 Rot",
+                        "Gobo 2 Rot fine",
+                        "Iris"
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/fixtures/imports/ecue-MainLibrary/Iguzzini.json
+++ b/fixtures/imports/ecue-MainLibrary/Iguzzini.json
@@ -1,0 +1,155 @@
+{
+    "manufacturers": {
+        "Iguzzini": {
+            "name": "Iguzzini",
+            "website": "www.iguzzini.com"
+        }
+    },
+    "fixtures": [
+        {
+            "manufacturer": "Iguzzini",
+            "name": "Color Woody",
+            "shortName": "CW",
+            "comment": "http://microsites.iguzzini.it/colourwoody/inglese/download/istruzioni.pdf",
+            "physical": {
+                "dimensions": [620, 380, 760],
+                "weight": 38
+            },
+            "availableChannels": {
+                "Filter_In": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Filter_Out": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Control": {
+                    "type": "Beam",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "capabilities": [
+                        {
+                            "range": [0, 64],
+                            "name": "Lamp_off"
+                        },
+                        {
+                            "range": [65, 255],
+                            "name": "Lamp_On"
+                        }
+                    ]
+                },
+                "Reset": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 64],
+                            "name": "off"
+                        },
+                        {
+                            "range": [100, 100],
+                            "name": "hold_10s"
+                        }
+                    ]
+                },
+                "Switch": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 85],
+                            "name": "Cursor 1+2"
+                        },
+                        {
+                            "range": [86, 170],
+                            "name": "reprogramming"
+                        },
+                        {
+                            "range": [171, 255],
+                            "name": "Cursor 8"
+                        }
+                    ]
+                },
+                "Color": {
+                    "type": "MultiColor",
+                    "capabilities": [
+                        {
+                            "range": [0, 31],
+                            "name": "White",
+                            "color": "#ffffff",
+                            "center": true
+                        },
+                        {
+                            "range": [32, 63],
+                            "name": "Magenta",
+                            "color": "#ca1f7b",
+                            "center": true
+                        },
+                        {
+                            "range": [64, 95],
+                            "name": "Cyan",
+                            "color": "#00ffff",
+                            "center": true
+                        },
+                        {
+                            "range": [96, 127],
+                            "name": "Yellow",
+                            "color": "#ffff00",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 159],
+                            "name": "Red",
+                            "color": "#ff0000",
+                            "center": true
+                        },
+                        {
+                            "range": [160, 191],
+                            "name": "Green",
+                            "color": "#00ff00",
+                            "center": true
+                        },
+                        {
+                            "range": [192, 223],
+                            "name": "Blue",
+                            "color": "#0000ff",
+                            "center": true
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "Yellow",
+                            "color": "#ffff00",
+                            "center": true
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "8-channel Mode",
+                    "shortName": "8ch",
+                    "channels": [
+                        "Filter_In",
+                        "Filter_Out",
+                        null,
+                        "Control",
+                        null,
+                        "Reset",
+                        "Switch",
+                        "Color"
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/fixtures/imports/ecue-MainLibrary/JB-Lighting.json
+++ b/fixtures/imports/ecue-MainLibrary/JB-Lighting.json
@@ -1,0 +1,6128 @@
+{
+    "manufacturers": {
+        "JB Lighting": {
+            "name": "JB Lighting",
+            "website": "www.jb-lighting.de"
+        }
+    },
+    "fixtures": [
+        {
+            "manufacturer": "JB Lighting",
+            "name": "A12 Compressed",
+            "shortName": "JB A12 Comp",
+            "physical": {
+                "dimensions": [318, 318, 400],
+                "weight": 15,
+                "power": 850
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Control": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 7],
+                            "name": "Boost Modus"
+                        },
+                        {
+                            "range": [8, 15],
+                            "name": "white balance"
+                        },
+                        {
+                            "range": [16, 239],
+                            "name": "safe"
+                        },
+                        {
+                            "range": [240, 247],
+                            "name": "reset"
+                        },
+                        {
+                            "range": [248, 255],
+                            "name": "safe"
+                        }
+                    ]
+                },
+                "Shutter": {
+                    "type": "Shutter",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [16, 95],
+                            "name": "open"
+                        },
+                        {
+                            "range": [96, 110],
+                            "name": "pulse open"
+                        },
+                        {
+                            "range": [111, 111],
+                            "name": "open"
+                        },
+                        {
+                            "range": [112, 125],
+                            "name": "strobe"
+                        },
+                        {
+                            "range": [126, 126],
+                            "name": "open"
+                        },
+                        {
+                            "range": [127, 127],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [128, 142],
+                            "name": "pulse open"
+                        },
+                        {
+                            "range": [143, 143],
+                            "name": "open"
+                        },
+                        {
+                            "range": [144, 158],
+                            "name": "puls closed"
+                        },
+                        {
+                            "range": [159, 159],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [160, 174],
+                            "name": "fade"
+                        },
+                        {
+                            "range": [175, 175],
+                            "name": "open"
+                        },
+                        {
+                            "range": [176, 190],
+                            "name": "fade"
+                        },
+                        {
+                            "range": [191, 191],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [192, 206],
+                            "name": "random"
+                        },
+                        {
+                            "range": [207, 207],
+                            "name": "open"
+                        },
+                        {
+                            "range": [208, 222],
+                            "name": "random"
+                        },
+                        {
+                            "range": [223, 223],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [224, 238],
+                            "name": "random fade"
+                        },
+                        {
+                            "range": [239, 239],
+                            "name": "open"
+                        },
+                        {
+                            "range": [240, 254],
+                            "name": "random fade"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "open"
+                        }
+                    ]
+                },
+                "Dimmer": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "zoom 8-48": {
+                    "type": "Beam",
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Pattern": {
+                    "type": "Beam",
+                    "highlightValue": 255
+                },
+                "CTO": {
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "White": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "14-channel Mode",
+                    "shortName": "14ch",
+                    "channels": [
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "Control",
+                        "Shutter",
+                        "Dimmer",
+                        "zoom 8-48",
+                        "Pattern",
+                        "CTO",
+                        "Red",
+                        "Green",
+                        "Blue",
+                        "White"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "JB Lighting",
+            "name": "A12 Extended 8Bit",
+            "shortName": "JB A12 E8",
+            "physical": {
+                "dimensions": [437, 536, 308],
+                "weight": 15,
+                "power": 850
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Control": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 7],
+                            "name": "Boost Modus"
+                        },
+                        {
+                            "range": [8, 15],
+                            "name": "white balance"
+                        },
+                        {
+                            "range": [16, 239],
+                            "name": "safe"
+                        },
+                        {
+                            "range": [240, 247],
+                            "name": "reset"
+                        },
+                        {
+                            "range": [248, 255],
+                            "name": "safe"
+                        }
+                    ]
+                },
+                "Shutter": {
+                    "type": "Shutter",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [16, 95],
+                            "name": "open"
+                        },
+                        {
+                            "range": [96, 110],
+                            "name": "pulse open"
+                        },
+                        {
+                            "range": [111, 111],
+                            "name": "open"
+                        },
+                        {
+                            "range": [112, 125],
+                            "name": "strobe"
+                        },
+                        {
+                            "range": [126, 126],
+                            "name": "open"
+                        },
+                        {
+                            "range": [127, 127],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [128, 142],
+                            "name": "pulse open"
+                        },
+                        {
+                            "range": [143, 143],
+                            "name": "open"
+                        },
+                        {
+                            "range": [144, 158],
+                            "name": "puls closed"
+                        },
+                        {
+                            "range": [159, 159],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [160, 174],
+                            "name": "fade"
+                        },
+                        {
+                            "range": [175, 175],
+                            "name": "open"
+                        },
+                        {
+                            "range": [176, 190],
+                            "name": "fade"
+                        },
+                        {
+                            "range": [191, 191],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [192, 206],
+                            "name": "random"
+                        },
+                        {
+                            "range": [207, 207],
+                            "name": "open"
+                        },
+                        {
+                            "range": [208, 222],
+                            "name": "random"
+                        },
+                        {
+                            "range": [223, 223],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [224, 238],
+                            "name": "random fade"
+                        },
+                        {
+                            "range": [239, 239],
+                            "name": "open"
+                        },
+                        {
+                            "range": [240, 254],
+                            "name": "random fade"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "open"
+                        }
+                    ]
+                },
+                "Dimmer": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "zoom 8-48": {
+                    "type": "Beam",
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Pattern": {
+                    "type": "Beam",
+                    "highlightValue": 255
+                },
+                "CTO": {
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Color": {
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Pan_Tilt speed": {
+                    "type": "Speed",
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Effect speed": {
+                    "type": "Speed",
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Black Out Move": {
+                    "type": "Beam",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 95],
+                            "name": "no function",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [96, 127],
+                            "name": "black at  P_T",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [128, 159],
+                            "name": "black at colorm",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [160, 223],
+                            "name": "no function",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "close at P_T_Co",
+                            "showInMenu": false
+                        }
+                    ]
+                },
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "White": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Red-4047p": {
+                    "name": "Red",
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green-0a7jq": {
+                    "name": "Green",
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue-m76qu": {
+                    "name": "Blue",
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "White-dgwdc": {
+                    "name": "White",
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Red-3b0kg": {
+                    "name": "Red",
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green-cy38f": {
+                    "name": "Green",
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue-q949t": {
+                    "name": "Blue",
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "White-2dv09": {
+                    "name": "White",
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Red-8ua48": {
+                    "name": "Red",
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green-z7kv7": {
+                    "name": "Green",
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue-ydxno": {
+                    "name": "Blue",
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "White-0bsu8": {
+                    "name": "White",
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Red-pau8f": {
+                    "name": "Red",
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green-6tq7o": {
+                    "name": "Green",
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue-oj1a0": {
+                    "name": "Blue",
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "White-gh48s": {
+                    "name": "White",
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Red-e5isn": {
+                    "name": "Red",
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green-al92r": {
+                    "name": "Green",
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue-ktyfb": {
+                    "name": "Blue",
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "White-ahzy4": {
+                    "name": "White",
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "38-channel Mode",
+                    "shortName": "38ch",
+                    "channels": [
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "Control",
+                        "Shutter",
+                        "Dimmer",
+                        "zoom 8-48",
+                        "Pattern",
+                        "CTO",
+                        "Color",
+                        "Pan_Tilt speed",
+                        "Effect speed",
+                        "Black Out Move",
+                        "Red",
+                        "Green",
+                        "Blue",
+                        "White",
+                        "Red-4047p",
+                        "Green-0a7jq",
+                        "Blue-m76qu",
+                        "White-dgwdc",
+                        "Red-3b0kg",
+                        "Green-cy38f",
+                        "Blue-q949t",
+                        "White-2dv09",
+                        "Red-8ua48",
+                        "Green-z7kv7",
+                        "Blue-ydxno",
+                        "White-0bsu8",
+                        "Red-pau8f",
+                        "Green-6tq7o",
+                        "Blue-oj1a0",
+                        "White-gh48s",
+                        "Red-e5isn",
+                        "Green-al92r",
+                        "Blue-ktyfb",
+                        "White-ahzy4"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "JB Lighting",
+            "name": "A12 Standard 8Bit",
+            "shortName": "JB A12 St 8Bit",
+            "physical": {
+                "dimensions": [437, 536, 308],
+                "weight": 15,
+                "power": 850
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Control": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 7],
+                            "name": "Boost Modus"
+                        },
+                        {
+                            "range": [8, 15],
+                            "name": "white balance"
+                        },
+                        {
+                            "range": [16, 239],
+                            "name": "safe"
+                        },
+                        {
+                            "range": [240, 247],
+                            "name": "reset"
+                        },
+                        {
+                            "range": [248, 255],
+                            "name": "safe"
+                        }
+                    ]
+                },
+                "Shutter": {
+                    "type": "Shutter",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [16, 95],
+                            "name": "open"
+                        },
+                        {
+                            "range": [96, 110],
+                            "name": "pulse open"
+                        },
+                        {
+                            "range": [111, 111],
+                            "name": "open"
+                        },
+                        {
+                            "range": [112, 125],
+                            "name": "strobe"
+                        },
+                        {
+                            "range": [126, 126],
+                            "name": "open"
+                        },
+                        {
+                            "range": [127, 127],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [128, 142],
+                            "name": "pulse open"
+                        },
+                        {
+                            "range": [143, 143],
+                            "name": "open"
+                        },
+                        {
+                            "range": [144, 158],
+                            "name": "puls closed"
+                        },
+                        {
+                            "range": [159, 159],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [160, 174],
+                            "name": "fade"
+                        },
+                        {
+                            "range": [175, 175],
+                            "name": "open"
+                        },
+                        {
+                            "range": [176, 190],
+                            "name": "fade"
+                        },
+                        {
+                            "range": [191, 191],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [192, 206],
+                            "name": "random"
+                        },
+                        {
+                            "range": [207, 207],
+                            "name": "open"
+                        },
+                        {
+                            "range": [208, 222],
+                            "name": "random"
+                        },
+                        {
+                            "range": [223, 223],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [224, 238],
+                            "name": "random fade"
+                        },
+                        {
+                            "range": [239, 239],
+                            "name": "open"
+                        },
+                        {
+                            "range": [240, 254],
+                            "name": "random fade"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "open"
+                        }
+                    ]
+                },
+                "Dimmer": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "zoom 8-48": {
+                    "type": "Beam",
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Pattern": {
+                    "type": "Beam",
+                    "highlightValue": 255
+                },
+                "CTO": {
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Color": {
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Pan_Tilt Geschw": {
+                    "type": "Pan",
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Effektgeschw": {
+                    "type": "Beam",
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Black Out Move": {
+                    "type": "Beam",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 95],
+                            "name": "no function",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [96, 127],
+                            "name": "black at  P_T",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [128, 159],
+                            "name": "black at colorm",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [160, 223],
+                            "name": "no function",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "close at P_T_Co",
+                            "showInMenu": false
+                        }
+                    ]
+                },
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "White": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "18-channel Mode",
+                    "shortName": "18ch",
+                    "channels": [
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "Control",
+                        "Shutter",
+                        "Dimmer",
+                        "zoom 8-48",
+                        "Pattern",
+                        "CTO",
+                        "Color",
+                        "Pan_Tilt Geschw",
+                        "Effektgeschw",
+                        "Black Out Move",
+                        "Red",
+                        "Green",
+                        "Blue",
+                        "White"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "JB Lighting",
+            "name": "JBLED A7 Standard RGB 16 BIT S16",
+            "shortName": "JBLED A7.1",
+            "physical": {
+                "dimensions": [318, 318, 400],
+                "weight": 9,
+                "power": 350
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Control": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 7],
+                            "name": "Boost Modus"
+                        },
+                        {
+                            "range": [8, 15],
+                            "name": "white balance"
+                        },
+                        {
+                            "range": [16, 239],
+                            "name": "safe"
+                        },
+                        {
+                            "range": [240, 247],
+                            "name": "reset"
+                        },
+                        {
+                            "range": [248, 255],
+                            "name": "safe"
+                        }
+                    ]
+                },
+                "Shutter": {
+                    "type": "Shutter",
+                    "highlightValue": 80,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [16, 95],
+                            "name": "open"
+                        },
+                        {
+                            "range": [96, 110],
+                            "name": "pulse open"
+                        },
+                        {
+                            "range": [111, 111],
+                            "name": "open"
+                        },
+                        {
+                            "range": [112, 125],
+                            "name": "strobe"
+                        },
+                        {
+                            "range": [126, 126],
+                            "name": "open"
+                        },
+                        {
+                            "range": [127, 127],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [128, 142],
+                            "name": "pulse open"
+                        },
+                        {
+                            "range": [143, 143],
+                            "name": "open"
+                        },
+                        {
+                            "range": [144, 158],
+                            "name": "puls closed"
+                        },
+                        {
+                            "range": [159, 159],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [160, 174],
+                            "name": "fade"
+                        },
+                        {
+                            "range": [175, 175],
+                            "name": "open"
+                        },
+                        {
+                            "range": [176, 190],
+                            "name": "fade"
+                        },
+                        {
+                            "range": [191, 191],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [192, 206],
+                            "name": "random"
+                        },
+                        {
+                            "range": [207, 207],
+                            "name": "open"
+                        },
+                        {
+                            "range": [208, 222],
+                            "name": "random"
+                        },
+                        {
+                            "range": [223, 223],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [224, 238],
+                            "name": "random fade"
+                        },
+                        {
+                            "range": [239, 239],
+                            "name": "open"
+                        },
+                        {
+                            "range": [240, 254],
+                            "name": "random fade"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "open"
+                        }
+                    ]
+                },
+                "Dimmer": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "zoom 8-28": {
+                    "type": "Beam",
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 0,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "defaultValue": null
+                },
+                "Red fine": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "defaultValue": null
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 0,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "defaultValue": null
+                },
+                "Green fine": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "defaultValue": null
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 0,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "defaultValue": null
+                },
+                "Blue fine": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "defaultValue": null
+                },
+                "_CTC": {
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "_Color Preset": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 1],
+                            "name": "open"
+                        },
+                        {
+                            "range": [2, 3],
+                            "name": "white",
+                            "color": "#ffffff"
+                        },
+                        {
+                            "range": [4, 7],
+                            "name": "white/red"
+                        },
+                        {
+                            "range": [8, 11],
+                            "name": "red",
+                            "color": "#ff0000"
+                        },
+                        {
+                            "range": [12, 15],
+                            "name": "red/ yellow"
+                        },
+                        {
+                            "range": [16, 19],
+                            "name": "yellow",
+                            "color": "#ffff00"
+                        },
+                        {
+                            "range": [20, 23],
+                            "name": "yellow/ magenta"
+                        },
+                        {
+                            "range": [24, 27],
+                            "name": "magenta",
+                            "color": "#ca1f7b"
+                        },
+                        {
+                            "range": [28, 31],
+                            "name": "magenta/ green"
+                        },
+                        {
+                            "range": [32, 35],
+                            "name": "green",
+                            "color": "#00ff00"
+                        },
+                        {
+                            "range": [36, 39],
+                            "name": "green/ amber"
+                        },
+                        {
+                            "range": [40, 43],
+                            "name": "amber",
+                            "color": "#ffbf00"
+                        },
+                        {
+                            "range": [44, 47],
+                            "name": "amber/ blue"
+                        },
+                        {
+                            "range": [48, 51],
+                            "name": "blue",
+                            "color": "#0000ff"
+                        },
+                        {
+                            "range": [52, 55],
+                            "name": "blue/ cyan"
+                        },
+                        {
+                            "range": [56, 59],
+                            "name": "cyan",
+                            "color": "#00ffff"
+                        },
+                        {
+                            "range": [60, 63],
+                            "name": "cyan/ white"
+                        },
+                        {
+                            "range": [64, 191],
+                            "name": "color posit."
+                        },
+                        {
+                            "range": [192, 222],
+                            "name": "rot. clw. f-s"
+                        },
+                        {
+                            "range": [223, 224],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [225, 255],
+                            "name": "rot. cclw. s-f"
+                        }
+                    ]
+                },
+                "P/T speed": {
+                    "type": "Speed",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 3],
+                            "name": "realtime"
+                        },
+                        {
+                            "range": [4, 255],
+                            "name": "speed f-s"
+                        }
+                    ]
+                },
+                "Effect speed": {
+                    "type": "Speed",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 3],
+                            "name": "realtime"
+                        },
+                        {
+                            "range": [4, 255],
+                            "name": "speed f-s"
+                        }
+                    ]
+                },
+                "bl. out move": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 95],
+                            "name": "no function"
+                        },
+                        {
+                            "range": [96, 127],
+                            "name": "b. out at move"
+                        },
+                        {
+                            "range": [128, 159],
+                            "name": "b. out at color"
+                        },
+                        {
+                            "range": [160, 223],
+                            "name": "no function"
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "b. out at all"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ],
+                [
+                    "Red",
+                    "Red fine"
+                ],
+                [
+                    "Green",
+                    "Green fine"
+                ],
+                [
+                    "Blue",
+                    "Blue fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "19-channel Mode",
+                    "shortName": "19ch",
+                    "channels": [
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "Control",
+                        "Shutter",
+                        "Dimmer",
+                        "zoom 8-28",
+                        "Red",
+                        "Red fine",
+                        "Green",
+                        "Green fine",
+                        "Blue",
+                        "Blue fine",
+                        "_CTC",
+                        "_Color Preset",
+                        "P/T speed",
+                        "Effect speed",
+                        "bl. out move"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "JB Lighting",
+            "name": "Vary LED 384 HOG mode",
+            "shortName": "VaryLED",
+            "comment": "cd",
+            "physical": {
+                "dimensions": [418, 369, 371],
+                "weight": 10,
+                "power": 250
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "CTC": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 7],
+                            "name": "5600K"
+                        },
+                        {
+                            "range": [8, 15],
+                            "name": "3200K"
+                        },
+                        {
+                            "range": [16, 255],
+                            "name": "5600K"
+                        }
+                    ]
+                },
+                "Shutter": {
+                    "type": "Shutter",
+                    "highlightValue": 80,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [16, 95],
+                            "name": "open"
+                        },
+                        {
+                            "range": [96, 110],
+                            "name": "pulse open"
+                        },
+                        {
+                            "range": [111, 111],
+                            "name": "open"
+                        },
+                        {
+                            "range": [112, 125],
+                            "name": "strobe"
+                        },
+                        {
+                            "range": [126, 126],
+                            "name": "open"
+                        },
+                        {
+                            "range": [127, 127],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [128, 142],
+                            "name": "pulse open"
+                        },
+                        {
+                            "range": [143, 143],
+                            "name": "open"
+                        },
+                        {
+                            "range": [144, 158],
+                            "name": "puls closed"
+                        },
+                        {
+                            "range": [159, 159],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [160, 174],
+                            "name": "fade"
+                        },
+                        {
+                            "range": [175, 175],
+                            "name": "open"
+                        },
+                        {
+                            "range": [176, 190],
+                            "name": "fade"
+                        },
+                        {
+                            "range": [191, 191],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [192, 206],
+                            "name": "random"
+                        },
+                        {
+                            "range": [207, 207],
+                            "name": "open"
+                        },
+                        {
+                            "range": [208, 222],
+                            "name": "random"
+                        },
+                        {
+                            "range": [223, 223],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [224, 238],
+                            "name": "s. random"
+                        },
+                        {
+                            "range": [239, 239],
+                            "name": "open"
+                        },
+                        {
+                            "range": [240, 254],
+                            "name": "s. random"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "open"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Color macro": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 1],
+                            "name": "idle"
+                        },
+                        {
+                            "range": [2, 7],
+                            "name": "open"
+                        },
+                        {
+                            "range": [8, 15],
+                            "name": "lavender tint"
+                        },
+                        {
+                            "range": [16, 23],
+                            "name": "pale yellow"
+                        },
+                        {
+                            "range": [24, 31],
+                            "name": "medium yellow"
+                        },
+                        {
+                            "range": [32, 39],
+                            "name": "spring yellow"
+                        },
+                        {
+                            "range": [40, 47],
+                            "name": "deep amber"
+                        },
+                        {
+                            "range": [48, 55],
+                            "name": "orange",
+                            "color": "#ff7f00"
+                        },
+                        {
+                            "range": [56, 63],
+                            "name": "golden amber"
+                        },
+                        {
+                            "range": [64, 71],
+                            "name": "dark amber"
+                        },
+                        {
+                            "range": [72, 79],
+                            "name": "scaret"
+                        },
+                        {
+                            "range": [80, 87],
+                            "name": "primary red"
+                        },
+                        {
+                            "range": [88, 95],
+                            "name": "bright rose"
+                        },
+                        {
+                            "range": [96, 103],
+                            "name": "pink carnation"
+                        },
+                        {
+                            "range": [104, 111],
+                            "name": "dark magenta",
+                            "color": "#8b008b"
+                        },
+                        {
+                            "range": [112, 119],
+                            "name": "magenta",
+                            "color": "#ca1f7b"
+                        },
+                        {
+                            "range": [120, 127],
+                            "name": "mauve",
+                            "color": "#e0b0ff"
+                        },
+                        {
+                            "range": [128, 135],
+                            "name": "rose purble"
+                        },
+                        {
+                            "range": [136, 143],
+                            "name": "rose pink",
+                            "color": "#ff66cc"
+                        },
+                        {
+                            "range": [144, 151],
+                            "name": "medium pink"
+                        },
+                        {
+                            "range": [152, 159],
+                            "name": "carnation pink",
+                            "color": "#ffa6c9"
+                        },
+                        {
+                            "range": [160, 167],
+                            "name": "deep lavender"
+                        },
+                        {
+                            "range": [168, 175],
+                            "name": "paler lavender"
+                        },
+                        {
+                            "range": [176, 183],
+                            "name": "light lavender"
+                        },
+                        {
+                            "range": [184, 191],
+                            "name": "mist blue"
+                        },
+                        {
+                            "range": [192, 199],
+                            "name": "pale blue"
+                        },
+                        {
+                            "range": [200, 207],
+                            "name": "sky blue",
+                            "color": "#87ceeb"
+                        },
+                        {
+                            "range": [208, 215],
+                            "name": "dark blue",
+                            "color": "#00008b"
+                        },
+                        {
+                            "range": [216, 223],
+                            "name": "peacock blue"
+                        },
+                        {
+                            "range": [224, 231],
+                            "name": "lime green",
+                            "color": "#32cd32"
+                        },
+                        {
+                            "range": [232, 239],
+                            "name": "light green",
+                            "color": "#90ee90"
+                        },
+                        {
+                            "range": [240, 247],
+                            "name": "fern green",
+                            "color": "#4f7942"
+                        },
+                        {
+                            "range": [248, 255],
+                            "name": "dark green",
+                            "color": "#013220"
+                        }
+                    ]
+                },
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Color": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 7],
+                            "name": "open"
+                        },
+                        {
+                            "range": [8, 15],
+                            "name": "red",
+                            "color": "#ff0000"
+                        },
+                        {
+                            "range": [16, 23],
+                            "name": "yellow",
+                            "color": "#ffff00"
+                        },
+                        {
+                            "range": [24, 31],
+                            "name": "magenta",
+                            "color": "#ca1f7b"
+                        },
+                        {
+                            "range": [32, 39],
+                            "name": "green",
+                            "color": "#00ff00"
+                        },
+                        {
+                            "range": [40, 47],
+                            "name": "orange",
+                            "color": "#ff7f00"
+                        },
+                        {
+                            "range": [48, 55],
+                            "name": "blue",
+                            "color": "#0000ff"
+                        },
+                        {
+                            "range": [56, 63],
+                            "name": "cyan",
+                            "color": "#00ffff"
+                        },
+                        {
+                            "range": [64, 191],
+                            "name": "step"
+                        },
+                        {
+                            "range": [192, 222],
+                            "name": ">>"
+                        },
+                        {
+                            "range": [223, 224],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [225, 255],
+                            "name": "<<"
+                        }
+                    ]
+                },
+                "P/T speed": {
+                    "type": "Speed",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 3],
+                            "name": "track"
+                        },
+                        {
+                            "range": [4, 255],
+                            "name": "speed"
+                        }
+                    ]
+                },
+                "Effect speed": {
+                    "type": "Speed",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 3],
+                            "name": "track"
+                        },
+                        {
+                            "range": [4, 255],
+                            "name": "speed"
+                        }
+                    ]
+                },
+                "MIB": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 95],
+                            "name": "idle"
+                        },
+                        {
+                            "range": [96, 127],
+                            "name": "MIB"
+                        },
+                        {
+                            "range": [128, 159],
+                            "name": "CIB"
+                        },
+                        {
+                            "range": [160, 223],
+                            "name": "idle"
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "ALL in Black"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "15-channel Mode",
+                    "shortName": "15ch",
+                    "channels": [
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "CTC",
+                        "Shutter",
+                        "Intensity",
+                        "Color macro",
+                        "Red",
+                        "Green",
+                        "Blue",
+                        "Color",
+                        "P/T speed",
+                        "Effect speed",
+                        "MIB"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "JB Lighting",
+            "name": "Varycolor 7",
+            "shortName": "VaryC7",
+            "comment": "JB Mode",
+            "physical": {
+                "dimensions": [484, 484, 682],
+                "weight": 42,
+                "power": 1200
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 0,
+                    "highlightValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 0,
+                    "highlightValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Control": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 231],
+                            "name": "nofunction"
+                        },
+                        {
+                            "range": [232, 239],
+                            "name": "Lamp_off"
+                        },
+                        {
+                            "range": [240, 247],
+                            "name": "reset"
+                        },
+                        {
+                            "range": [248, 255],
+                            "name": "lamp_on"
+                        }
+                    ]
+                },
+                "Shutter": {
+                    "type": "Shutter",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [16, 111],
+                            "name": "open"
+                        },
+                        {
+                            "range": [112, 125],
+                            "name": "effects"
+                        },
+                        {
+                            "range": [126, 126],
+                            "name": "open"
+                        },
+                        {
+                            "range": [127, 127],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [128, 142],
+                            "name": "pulse_open"
+                        },
+                        {
+                            "range": [143, 143],
+                            "name": "open"
+                        },
+                        {
+                            "range": [144, 158],
+                            "name": "pulse_close"
+                        },
+                        {
+                            "range": [159, 159],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [160, 174],
+                            "name": "fade"
+                        },
+                        {
+                            "range": [175, 175],
+                            "name": "open"
+                        },
+                        {
+                            "range": [176, 190],
+                            "name": "fade"
+                        },
+                        {
+                            "range": [191, 191],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [192, 206],
+                            "name": "random"
+                        },
+                        {
+                            "range": [207, 207],
+                            "name": "open"
+                        },
+                        {
+                            "range": [208, 222],
+                            "name": "random"
+                        },
+                        {
+                            "range": [223, 223],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [224, 238],
+                            "name": "randomfade"
+                        },
+                        {
+                            "range": [239, 239],
+                            "name": "open"
+                        },
+                        {
+                            "range": [240, 254],
+                            "name": "randomfade"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "open"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Effects": {
+                    "type": "Effect",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 5],
+                            "name": "open"
+                        },
+                        {
+                            "range": [6, 63],
+                            "name": "Shape"
+                        },
+                        {
+                            "range": [64, 127],
+                            "name": "Frost",
+                            "color": "#edf5dd"
+                        },
+                        {
+                            "range": [143, 143],
+                            "name": "open"
+                        },
+                        {
+                            "range": [144, 159],
+                            "name": "Frost pulse"
+                        },
+                        {
+                            "range": [160, 191],
+                            "name": "Frost fade"
+                        },
+                        {
+                            "range": [192, 223],
+                            "name": "Frost random pu"
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "Frost random fa"
+                        }
+                    ]
+                },
+                "Zoom": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "CMakro": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 7],
+                            "name": "white",
+                            "color": "#ffffff"
+                        },
+                        {
+                            "range": [8, 15],
+                            "name": "Lavender Tint"
+                        },
+                        {
+                            "range": [16, 23],
+                            "name": "Pale Yellow"
+                        },
+                        {
+                            "range": [24, 31],
+                            "name": "Medium Yellow"
+                        },
+                        {
+                            "range": [32, 39],
+                            "name": "Spring Yellow"
+                        },
+                        {
+                            "range": [40, 47],
+                            "name": "Deep Amber"
+                        },
+                        {
+                            "range": [48, 55],
+                            "name": "Orange",
+                            "color": "#ff7f00"
+                        },
+                        {
+                            "range": [56, 63],
+                            "name": "Gold Amber"
+                        },
+                        {
+                            "range": [64, 71],
+                            "name": "Dark Amber"
+                        },
+                        {
+                            "range": [72, 79],
+                            "name": "Scarlet",
+                            "color": "#ff2400"
+                        },
+                        {
+                            "range": [80, 87],
+                            "name": "Primary Red"
+                        },
+                        {
+                            "range": [88, 95],
+                            "name": "Bright Rose"
+                        },
+                        {
+                            "range": [96, 103],
+                            "name": "Pink Carnation"
+                        },
+                        {
+                            "range": [104, 111],
+                            "name": "Dark Magenta",
+                            "color": "#8b008b"
+                        },
+                        {
+                            "range": [112, 119],
+                            "name": "Magenta",
+                            "color": "#ca1f7b"
+                        },
+                        {
+                            "range": [120, 127],
+                            "name": "Mauve",
+                            "color": "#e0b0ff"
+                        },
+                        {
+                            "range": [128, 135],
+                            "name": "Rose Purple"
+                        },
+                        {
+                            "range": [136, 143],
+                            "name": "Rose Pink",
+                            "color": "#ff66cc"
+                        },
+                        {
+                            "range": [144, 151],
+                            "name": "Medium Pink"
+                        },
+                        {
+                            "range": [152, 159],
+                            "name": "Carnation Pink",
+                            "color": "#ffa6c9"
+                        },
+                        {
+                            "range": [160, 167],
+                            "name": "Deep Lavender"
+                        },
+                        {
+                            "range": [168, 175],
+                            "name": "Paler Lavender"
+                        },
+                        {
+                            "range": [176, 183],
+                            "name": "Light Lavender"
+                        },
+                        {
+                            "range": [184, 191],
+                            "name": "Mist Blue"
+                        },
+                        {
+                            "range": [192, 199],
+                            "name": "Pale Blue"
+                        },
+                        {
+                            "range": [200, 207],
+                            "name": "Sky Blue",
+                            "color": "#87ceeb"
+                        },
+                        {
+                            "range": [208, 215],
+                            "name": "Dark Blue",
+                            "color": "#00008b"
+                        },
+                        {
+                            "range": [216, 223],
+                            "name": "Peacock Blue"
+                        },
+                        {
+                            "range": [224, 231],
+                            "name": "Lime Green",
+                            "color": "#32cd32"
+                        },
+                        {
+                            "range": [232, 239],
+                            "name": "Light Green",
+                            "color": "#90ee90"
+                        },
+                        {
+                            "range": [240, 247],
+                            "name": "Fern Green",
+                            "color": "#4f7942"
+                        },
+                        {
+                            "range": [248, 255],
+                            "name": "Dark Green",
+                            "color": "#013220"
+                        }
+                    ]
+                },
+                "Cyan": {
+                    "type": "SingleColor",
+                    "color": "Cyan",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Magenta": {
+                    "type": "SingleColor",
+                    "color": "Magenta",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Yellow": {
+                    "type": "SingleColor",
+                    "color": "Yellow",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "CTO": {
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Color": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 3],
+                            "name": "white",
+                            "color": "#ffffff",
+                            "center": true
+                        },
+                        {
+                            "range": [8, 11],
+                            "name": "red",
+                            "color": "#ff0000",
+                            "center": true
+                        },
+                        {
+                            "range": [16, 19],
+                            "name": "yellow",
+                            "color": "#ffff00",
+                            "center": true
+                        },
+                        {
+                            "range": [24, 27],
+                            "name": "magenta",
+                            "color": "#ca1f7b",
+                            "center": true
+                        },
+                        {
+                            "range": [32, 35],
+                            "name": "green",
+                            "color": "#00ff00",
+                            "center": true
+                        },
+                        {
+                            "range": [40, 43],
+                            "name": "orange",
+                            "color": "#ff7f00",
+                            "center": true
+                        },
+                        {
+                            "range": [48, 51],
+                            "name": "blue",
+                            "color": "#0000ff",
+                            "center": true
+                        },
+                        {
+                            "range": [56, 59],
+                            "name": "turqoise",
+                            "center": true
+                        },
+                        {
+                            "range": [64, 191],
+                            "name": "position"
+                        },
+                        {
+                            "range": [192, 222],
+                            "name": "turn cw"
+                        },
+                        {
+                            "range": [223, 224],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [225, 255],
+                            "name": "turn ccw"
+                        }
+                    ]
+                },
+                "Speed": {
+                    "type": "Speed",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 3],
+                            "name": "move realtime"
+                        },
+                        {
+                            "range": [4, 255],
+                            "name": "delay"
+                        }
+                    ]
+                },
+                "Speed_E": {
+                    "type": "Speed",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 3],
+                            "name": "effect realtime"
+                        },
+                        {
+                            "range": [4, 255],
+                            "name": "delay"
+                        }
+                    ]
+                },
+                "B_Move": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 95],
+                            "name": "no function"
+                        },
+                        {
+                            "range": [96, 127],
+                            "name": "DBO Move"
+                        },
+                        {
+                            "range": [159, 0],
+                            "name": "Color"
+                        },
+                        {
+                            "range": [191, 0],
+                            "name": "Color"
+                        },
+                        {
+                            "range": [223, 0],
+                            "name": "Color"
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "DBO"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "16-channel Mode",
+                    "shortName": "16ch",
+                    "channels": [
+                        "Pan",
+                        "Tilt",
+                        "Control",
+                        "Shutter",
+                        "Intensity",
+                        "Effects",
+                        "Zoom",
+                        "CMakro",
+                        "Cyan",
+                        "Magenta",
+                        "Yellow",
+                        "CTO",
+                        "Color",
+                        "Speed",
+                        "Speed_E",
+                        "B_Move"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "JB Lighting",
+            "name": "Varycolor P6",
+            "shortName": "VaryC6",
+            "comment": "JB Mode",
+            "physical": {
+                "dimensions": [480, 480, 660],
+                "weight": 32,
+                "power": 575
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 0,
+                    "highlightValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 0,
+                    "highlightValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Control": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 231],
+                            "name": "nofunction"
+                        },
+                        {
+                            "range": [232, 239],
+                            "name": "lamp_off"
+                        },
+                        {
+                            "range": [240, 247],
+                            "name": "reset"
+                        },
+                        {
+                            "range": [248, 255],
+                            "name": "lamp_on"
+                        }
+                    ]
+                },
+                "Shutter": {
+                    "type": "Shutter",
+                    "defaultValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [16, 111],
+                            "name": "open"
+                        },
+                        {
+                            "range": [112, 125],
+                            "name": "fade_out"
+                        },
+                        {
+                            "range": [126, 126],
+                            "name": "open"
+                        },
+                        {
+                            "range": [127, 127],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [128, 142],
+                            "name": "pulse_open"
+                        },
+                        {
+                            "range": [143, 143],
+                            "name": "open"
+                        },
+                        {
+                            "range": [144, 158],
+                            "name": "pulse_close"
+                        },
+                        {
+                            "range": [159, 159],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [160, 174],
+                            "name": "fade 0"
+                        },
+                        {
+                            "range": [175, 175],
+                            "name": "open"
+                        },
+                        {
+                            "range": [176, 190],
+                            "name": "fade 100"
+                        },
+                        {
+                            "range": [191, 191],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [192, 206],
+                            "name": "random 100"
+                        },
+                        {
+                            "range": [207, 207],
+                            "name": "open"
+                        },
+                        {
+                            "range": [208, 222],
+                            "name": "random 0"
+                        },
+                        {
+                            "range": [223, 223],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [224, 238],
+                            "name": "random fade 0"
+                        },
+                        {
+                            "range": [239, 239],
+                            "name": "open"
+                        },
+                        {
+                            "range": [240, 254],
+                            "name": "random fade 100"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "open"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Effects": {
+                    "type": "Effect",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 5],
+                            "name": "open"
+                        },
+                        {
+                            "range": [6, 63],
+                            "name": "Beamshape"
+                        },
+                        {
+                            "range": [64, 127],
+                            "name": "frost",
+                            "color": "#edf5dd"
+                        },
+                        {
+                            "range": [128, 142],
+                            "name": "pulse open"
+                        },
+                        {
+                            "range": [143, 143],
+                            "name": "open"
+                        },
+                        {
+                            "range": [144, 158],
+                            "name": "pulse close"
+                        },
+                        {
+                            "range": [159, 159],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [160, 174],
+                            "name": "frost fade clos"
+                        },
+                        {
+                            "range": [175, 175],
+                            "name": "open"
+                        },
+                        {
+                            "range": [176, 190],
+                            "name": "fade open"
+                        },
+                        {
+                            "range": [191, 191],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [192, 206],
+                            "name": "random open"
+                        },
+                        {
+                            "range": [207, 207],
+                            "name": "open"
+                        },
+                        {
+                            "range": [208, 222],
+                            "name": "random closed"
+                        },
+                        {
+                            "range": [223, 223],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [224, 238],
+                            "name": "random fade clo"
+                        },
+                        {
+                            "range": [239, 239],
+                            "name": "open"
+                        },
+                        {
+                            "range": [240, 254],
+                            "name": "random fade clo"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "open"
+                        }
+                    ]
+                },
+                "Zoom": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Color1": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 7],
+                            "name": "white",
+                            "color": "#ffffff",
+                            "center": true
+                        },
+                        {
+                            "range": [8, 15],
+                            "name": "lavender Tint",
+                            "center": true
+                        },
+                        {
+                            "range": [16, 23],
+                            "name": "pale yellow",
+                            "center": true
+                        },
+                        {
+                            "range": [24, 31],
+                            "name": "medium yellow",
+                            "center": true
+                        },
+                        {
+                            "range": [32, 39],
+                            "name": "spring yellow",
+                            "center": true
+                        },
+                        {
+                            "range": [40, 47],
+                            "name": "deep amber",
+                            "center": true
+                        },
+                        {
+                            "range": [48, 55],
+                            "name": "orange",
+                            "color": "#ff7f00",
+                            "center": true
+                        },
+                        {
+                            "range": [56, 63],
+                            "name": "gold amber",
+                            "center": true
+                        },
+                        {
+                            "range": [64, 71],
+                            "name": "dark amber",
+                            "center": true
+                        },
+                        {
+                            "range": [72, 79],
+                            "name": "scarlet",
+                            "color": "#ff2400",
+                            "center": true
+                        },
+                        {
+                            "range": [80, 87],
+                            "name": "primary red",
+                            "center": true
+                        },
+                        {
+                            "range": [88, 95],
+                            "name": "bright rose",
+                            "center": true
+                        },
+                        {
+                            "range": [96, 103],
+                            "name": "pink carnation",
+                            "center": true
+                        },
+                        {
+                            "range": [104, 111],
+                            "name": "dark magenta",
+                            "color": "#8b008b",
+                            "center": true
+                        },
+                        {
+                            "range": [112, 119],
+                            "name": "magenta",
+                            "color": "#ca1f7b",
+                            "center": true
+                        },
+                        {
+                            "range": [120, 127],
+                            "name": "mauve",
+                            "color": "#e0b0ff",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 135],
+                            "name": "rose purple",
+                            "center": true
+                        },
+                        {
+                            "range": [136, 143],
+                            "name": "rose pink",
+                            "color": "#ff66cc",
+                            "center": true
+                        },
+                        {
+                            "range": [144, 151],
+                            "name": "medium pink",
+                            "center": true
+                        },
+                        {
+                            "range": [152, 159],
+                            "name": "carnation pink",
+                            "color": "#ffa6c9",
+                            "center": true
+                        },
+                        {
+                            "range": [160, 167],
+                            "name": "deep lavender",
+                            "center": true
+                        },
+                        {
+                            "range": [168, 175],
+                            "name": "paler lavender",
+                            "center": true
+                        },
+                        {
+                            "range": [176, 183],
+                            "name": "light lavender",
+                            "center": true
+                        },
+                        {
+                            "range": [184, 191],
+                            "name": "mist blue",
+                            "center": true
+                        },
+                        {
+                            "range": [192, 199],
+                            "name": "pale blue",
+                            "center": true
+                        },
+                        {
+                            "range": [200, 207],
+                            "name": "sky blue",
+                            "color": "#87ceeb",
+                            "center": true
+                        },
+                        {
+                            "range": [208, 215],
+                            "name": "dark blue",
+                            "color": "#00008b",
+                            "center": true
+                        },
+                        {
+                            "range": [216, 223],
+                            "name": "peacock blue",
+                            "center": true
+                        },
+                        {
+                            "range": [224, 231],
+                            "name": "lime green",
+                            "color": "#32cd32",
+                            "center": true
+                        },
+                        {
+                            "range": [232, 239],
+                            "name": "light green",
+                            "color": "#90ee90",
+                            "center": true
+                        },
+                        {
+                            "range": [240, 247],
+                            "name": "fern green",
+                            "color": "#4f7942",
+                            "center": true
+                        },
+                        {
+                            "range": [248, 255],
+                            "name": "dark green",
+                            "color": "#013220",
+                            "center": true
+                        }
+                    ]
+                },
+                "Cyan": {
+                    "type": "SingleColor",
+                    "color": "Cyan",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Magenta": {
+                    "type": "SingleColor",
+                    "color": "Magenta",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Yellow": {
+                    "type": "SingleColor",
+                    "color": "Yellow",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Color2": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 3],
+                            "name": "white",
+                            "color": "#ffffff",
+                            "center": true
+                        },
+                        {
+                            "range": [8, 11],
+                            "name": "red",
+                            "color": "#ff0000",
+                            "center": true
+                        },
+                        {
+                            "range": [16, 19],
+                            "name": "yellow",
+                            "color": "#ffff00",
+                            "center": true
+                        },
+                        {
+                            "range": [24, 27],
+                            "name": "magenta",
+                            "color": "#ca1f7b",
+                            "center": true
+                        },
+                        {
+                            "range": [32, 35],
+                            "name": "green",
+                            "color": "#00ff00",
+                            "center": true
+                        },
+                        {
+                            "range": [40, 43],
+                            "name": "orange",
+                            "color": "#ff7f00",
+                            "center": true
+                        },
+                        {
+                            "range": [48, 51],
+                            "name": "blue",
+                            "color": "#0000ff",
+                            "center": true
+                        },
+                        {
+                            "range": [56, 59],
+                            "name": "turquise",
+                            "center": true
+                        },
+                        {
+                            "range": [64, 191],
+                            "name": "index"
+                        },
+                        {
+                            "range": [192, 222],
+                            "name": "rot cw"
+                        },
+                        {
+                            "range": [223, 224],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [225, 255],
+                            "name": "turn ccw"
+                        }
+                    ]
+                },
+                "SpeedM": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 3],
+                            "name": "realtime"
+                        },
+                        {
+                            "range": [4, 255],
+                            "name": "delay"
+                        }
+                    ]
+                },
+                "SpeedE": {
+                    "type": "Speed",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 3],
+                            "name": "realtime"
+                        },
+                        {
+                            "range": [4, 255],
+                            "name": "delay"
+                        }
+                    ]
+                },
+                "DBOMove": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 95],
+                            "name": "nofunction"
+                        },
+                        {
+                            "range": [96, 127],
+                            "name": "Pan-Tilt"
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "all"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "18-channel Mode",
+                    "shortName": "18ch",
+                    "channels": [
+                        "Pan",
+                        "Tilt",
+                        "Control",
+                        "Shutter",
+                        "Intensity",
+                        "Effects",
+                        "Zoom",
+                        "Color1",
+                        "Cyan",
+                        "Magenta",
+                        "Yellow",
+                        null,
+                        null,
+                        null,
+                        "Color2",
+                        "SpeedM",
+                        "SpeedE",
+                        "DBOMove"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "JB Lighting",
+            "name": "Varyscan 6 HMI 575",
+            "shortName": "Varyscan 6",
+            "physical": {
+                "dimensions": [480, 480, 660],
+                "weight": 19,
+                "power": 575
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Gobo": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 31],
+                            "name": "open"
+                        },
+                        {
+                            "range": [32, 63],
+                            "name": "Gobo 1"
+                        },
+                        {
+                            "range": [64, 95],
+                            "name": "Gobo 2"
+                        },
+                        {
+                            "range": [96, 127],
+                            "name": "Gobo 3"
+                        },
+                        {
+                            "range": [128, 159],
+                            "name": "Gobo 4"
+                        },
+                        {
+                            "range": [160, 254],
+                            "name": "Gobo 5"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "Reset"
+                        }
+                    ]
+                },
+                "Color": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 7],
+                            "name": "white",
+                            "color": "#ffffff"
+                        },
+                        {
+                            "range": [8, 15],
+                            "name": "white/red"
+                        },
+                        {
+                            "range": [17, 23],
+                            "name": "red",
+                            "color": "#ff0000"
+                        },
+                        {
+                            "range": [24, 31],
+                            "name": "red/yellow"
+                        },
+                        {
+                            "range": [33, 39],
+                            "name": "yellow",
+                            "color": "#ffff00"
+                        },
+                        {
+                            "range": [40, 47],
+                            "name": "yellow/pink"
+                        },
+                        {
+                            "range": [50, 55],
+                            "name": "pink",
+                            "color": "#ffc0cb"
+                        },
+                        {
+                            "range": [56, 63],
+                            "name": "pink/green"
+                        },
+                        {
+                            "range": [66, 71],
+                            "name": "green",
+                            "color": "#00ff00"
+                        },
+                        {
+                            "range": [72, 79],
+                            "name": "green/orange"
+                        },
+                        {
+                            "range": [83, 87],
+                            "name": "orange",
+                            "color": "#ff7f00"
+                        },
+                        {
+                            "range": [88, 95],
+                            "name": "orange/blue"
+                        },
+                        {
+                            "range": [100, 103],
+                            "name": "blue",
+                            "color": "#0000ff"
+                        },
+                        {
+                            "range": [104, 111],
+                            "name": "blue/aqua"
+                        },
+                        {
+                            "range": [116, 119],
+                            "name": "aqua"
+                        },
+                        {
+                            "range": [120, 127],
+                            "name": "aqua/white"
+                        },
+                        {
+                            "range": [128, 255],
+                            "name": "Rainbow"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Iris": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Gobo Rot": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [-1, 0],
+                            "name": "o",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [-1, 63],
+                            "name": "180",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [-1, 126],
+                            "name": "360",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [-1, 191],
+                            "name": "540",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [192, -2],
+                            "name": "Rot left f.",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [-1, 222],
+                            "name": "Rot left sl.",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [223, 224],
+                            "name": "Stop Rot"
+                        },
+                        {
+                            "range": [-1, 225],
+                            "name": "Rot right sl.",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [-1, 255],
+                            "name": "Rot right f.",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "FX": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [-1, 31],
+                            "name": "open",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [32, 63],
+                            "name": "CTO"
+                        },
+                        {
+                            "range": [64, 95],
+                            "name": "CTB"
+                        },
+                        {
+                            "range": [96, 111],
+                            "name": "Prisma"
+                        },
+                        {
+                            "range": [112, 127],
+                            "name": "FX Prisma"
+                        },
+                        {
+                            "range": [128, 159],
+                            "name": "open"
+                        },
+                        {
+                            "range": [160, 175],
+                            "name": "Frost",
+                            "color": "#edf5dd"
+                        },
+                        {
+                            "range": [176, 223],
+                            "name": "Frost linear"
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "open"
+                        }
+                    ]
+                },
+                "Focus": {
+                    "type": "Intensity",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Shutter": {
+                    "type": "Shutter",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 10],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [11, 240],
+                            "name": "shutter seq"
+                        },
+                        {
+                            "range": [241, 255],
+                            "name": "open"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "12-channel Mode",
+                    "shortName": "12ch",
+                    "channels": [
+                        "Pan",
+                        "Tilt",
+                        "Gobo",
+                        "Color",
+                        "Intensity",
+                        "Iris",
+                        "Gobo Rot",
+                        "FX",
+                        "Focus",
+                        "Shutter",
+                        "Pan fine",
+                        "Tilt fine"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "JB Lighting",
+            "name": "Varyscan 7",
+            "shortName": "VScan7",
+            "physical": {
+                "dimensions": [500, 500, 700],
+                "weight": 42,
+                "power": 1200
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 0,
+                    "highlightValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 0,
+                    "highlightValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Control": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 231],
+                            "name": "nofunction"
+                        },
+                        {
+                            "range": [232, 239],
+                            "name": "Lamp_off"
+                        },
+                        {
+                            "range": [240, 247],
+                            "name": "reset"
+                        },
+                        {
+                            "range": [248, 255],
+                            "name": "lamp_on"
+                        }
+                    ]
+                },
+                "Shutter": {
+                    "type": "Shutter",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [16, 111],
+                            "name": "open"
+                        },
+                        {
+                            "range": [112, 125],
+                            "name": "effects"
+                        },
+                        {
+                            "range": [126, 126],
+                            "name": "open"
+                        },
+                        {
+                            "range": [127, 127],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [128, 142],
+                            "name": "pulse_open"
+                        },
+                        {
+                            "range": [143, 143],
+                            "name": "open"
+                        },
+                        {
+                            "range": [144, 158],
+                            "name": "pulse_close"
+                        },
+                        {
+                            "range": [159, 159],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [160, 174],
+                            "name": "fade"
+                        },
+                        {
+                            "range": [175, 175],
+                            "name": "open"
+                        },
+                        {
+                            "range": [176, 190],
+                            "name": "fade"
+                        },
+                        {
+                            "range": [191, 191],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [192, 206],
+                            "name": "random"
+                        },
+                        {
+                            "range": [207, 207],
+                            "name": "open"
+                        },
+                        {
+                            "range": [208, 222],
+                            "name": "random"
+                        },
+                        {
+                            "range": [223, 223],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [224, 238],
+                            "name": "randomfade"
+                        },
+                        {
+                            "range": [239, 239],
+                            "name": "open"
+                        },
+                        {
+                            "range": [240, 254],
+                            "name": "randomfade"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "open"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Iris": {
+                    "type": "Beam",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 126],
+                            "name": "%"
+                        },
+                        {
+                            "range": [127, 127],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [128, 158],
+                            "name": "shutter_effect"
+                        },
+                        {
+                            "range": [159, 159],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [160, 190],
+                            "name": "fade"
+                        },
+                        {
+                            "range": [191, 191],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [192, 222],
+                            "name": "random"
+                        },
+                        {
+                            "range": [223, 223],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [192, 222],
+                            "name": "randompulse"
+                        },
+                        {
+                            "range": [223, 223],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [224, 254],
+                            "name": "randomfade"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "open"
+                        }
+                    ]
+                },
+                "Fokus": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Gobo1": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "gobo1 through",
+                            "center": true
+                        },
+                        {
+                            "range": [16, 31],
+                            "name": "gobo1",
+                            "center": true
+                        },
+                        {
+                            "range": [32, 47],
+                            "name": "gobo2",
+                            "center": true
+                        },
+                        {
+                            "range": [48, 63],
+                            "name": "gobo3",
+                            "center": true
+                        },
+                        {
+                            "range": [64, 79],
+                            "name": "gobo4",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 135],
+                            "name": "gobo1 through s",
+                            "center": true
+                        },
+                        {
+                            "range": [136, 143],
+                            "name": "gobo1 swing",
+                            "center": true
+                        },
+                        {
+                            "range": [144, 151],
+                            "name": "gobo2 swing",
+                            "center": true
+                        },
+                        {
+                            "range": [152, 159],
+                            "name": "gobo3 swing",
+                            "center": true
+                        },
+                        {
+                            "range": [160, 167],
+                            "name": "gobo4 swing",
+                            "center": true
+                        },
+                        {
+                            "range": [223, 224],
+                            "name": "turn cw"
+                        },
+                        {
+                            "range": [225, 255],
+                            "name": "turn ccw"
+                        }
+                    ]
+                },
+                "Goborot1": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 191],
+                            "name": "position"
+                        },
+                        {
+                            "range": [192, 222],
+                            "name": "turn cw"
+                        },
+                        {
+                            "range": [223, 224],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [225, 255],
+                            "name": "turn ccw"
+                        }
+                    ]
+                },
+                "Gobo2": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "gobo2 through",
+                            "center": true
+                        },
+                        {
+                            "range": [16, 31],
+                            "name": "gobo1",
+                            "center": true
+                        },
+                        {
+                            "range": [32, 47],
+                            "name": "gobo2",
+                            "center": true
+                        },
+                        {
+                            "range": [48, 63],
+                            "name": "gobo3",
+                            "center": true
+                        },
+                        {
+                            "range": [64, 79],
+                            "name": "gobo4",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 135],
+                            "name": "gobo1 through s",
+                            "center": true
+                        },
+                        {
+                            "range": [136, 143],
+                            "name": "gobo1 swing",
+                            "center": true
+                        },
+                        {
+                            "range": [144, 151],
+                            "name": "gobo2 swing",
+                            "center": true
+                        },
+                        {
+                            "range": [152, 159],
+                            "name": "gobo3 swing",
+                            "center": true
+                        },
+                        {
+                            "range": [160, 167],
+                            "name": "gobo4 swing",
+                            "center": true
+                        },
+                        {
+                            "range": [223, 224],
+                            "name": "turn cw"
+                        },
+                        {
+                            "range": [225, 255],
+                            "name": "turn ccw"
+                        }
+                    ]
+                },
+                "Goborot2": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 191],
+                            "name": "position"
+                        },
+                        {
+                            "range": [192, 222],
+                            "name": "turn cw"
+                        },
+                        {
+                            "range": [223, 224],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [225, 255],
+                            "name": "turn ccw"
+                        }
+                    ]
+                },
+                "Color": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 3],
+                            "name": "white",
+                            "color": "#ffffff",
+                            "center": true
+                        },
+                        {
+                            "range": [8, 11],
+                            "name": "red",
+                            "color": "#ff0000",
+                            "center": true
+                        },
+                        {
+                            "range": [16, 19],
+                            "name": "yellow",
+                            "color": "#ffff00",
+                            "center": true
+                        },
+                        {
+                            "range": [24, 27],
+                            "name": "magenta",
+                            "color": "#ca1f7b",
+                            "center": true
+                        },
+                        {
+                            "range": [32, 35],
+                            "name": "green",
+                            "color": "#00ff00",
+                            "center": true
+                        },
+                        {
+                            "range": [40, 43],
+                            "name": "orange",
+                            "color": "#ff7f00",
+                            "center": true
+                        },
+                        {
+                            "range": [48, 51],
+                            "name": "blue",
+                            "color": "#0000ff",
+                            "center": true
+                        },
+                        {
+                            "range": [56, 59],
+                            "name": "turqoise",
+                            "center": true
+                        },
+                        {
+                            "range": [64, 191],
+                            "name": "position"
+                        },
+                        {
+                            "range": [192, 222],
+                            "name": "turn cw"
+                        },
+                        {
+                            "range": [223, 224],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [225, 255],
+                            "name": "turn ccw"
+                        }
+                    ]
+                },
+                "CEffects": {
+                    "type": "Effect",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "%"
+                        },
+                        {
+                            "range": [16, 31],
+                            "name": "CTB"
+                        },
+                        {
+                            "range": [32, 47],
+                            "name": "CTO"
+                        },
+                        {
+                            "range": [48, 63],
+                            "name": "4 color"
+                        },
+                        {
+                            "range": [64, 79],
+                            "name": "UV"
+                        },
+                        {
+                            "range": [80, 95],
+                            "name": "empty"
+                        },
+                        {
+                            "range": [96, 111],
+                            "name": "empty"
+                        },
+                        {
+                            "range": [128, 255],
+                            "name": "comb. mode"
+                        }
+                    ]
+                },
+                "Prism": {
+                    "type": "Prism",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "open"
+                        },
+                        {
+                            "range": [16, 31],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [128, 135],
+                            "name": "swing"
+                        }
+                    ]
+                },
+                "Prismrot": {
+                    "type": "Prism",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 191],
+                            "name": "position"
+                        },
+                        {
+                            "range": [192, 222],
+                            "name": "turn cw"
+                        },
+                        {
+                            "range": [223, 224],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [225, 255],
+                            "name": "turn ccw"
+                        }
+                    ]
+                },
+                "Frost": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "%"
+                        },
+                        {
+                            "range": [128, 158],
+                            "name": "shutter effect"
+                        },
+                        {
+                            "range": [159, 159],
+                            "name": "100"
+                        },
+                        {
+                            "range": [160, 190],
+                            "name": "fade"
+                        },
+                        {
+                            "range": [191, 191],
+                            "name": "100"
+                        },
+                        {
+                            "range": [192, 222],
+                            "name": "random pulse"
+                        },
+                        {
+                            "range": [223, 223],
+                            "name": "100"
+                        },
+                        {
+                            "range": [224, 254],
+                            "name": "random fade"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "100"
+                        }
+                    ]
+                },
+                "Speed": {
+                    "type": "Speed",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 3],
+                            "name": "move realtime"
+                        },
+                        {
+                            "range": [4, 255],
+                            "name": "delay"
+                        }
+                    ]
+                },
+                "Speed_E": {
+                    "type": "Speed",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 3],
+                            "name": "effect realtime"
+                        },
+                        {
+                            "range": [4, 255],
+                            "name": "delay"
+                        }
+                    ]
+                },
+                "B_Move": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 95],
+                            "name": "no function"
+                        },
+                        {
+                            "range": [96, 127],
+                            "name": "DBO Move"
+                        },
+                        {
+                            "range": [159, 0],
+                            "name": "Color"
+                        },
+                        {
+                            "range": [191, 0],
+                            "name": "Color"
+                        },
+                        {
+                            "range": [223, 0],
+                            "name": "Color"
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "DBO"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "22-channel Mode",
+                    "shortName": "22ch",
+                    "channels": [
+                        "Pan",
+                        "Tilt",
+                        "Control",
+                        "Shutter",
+                        "Intensity",
+                        "Iris",
+                        "Fokus",
+                        "Gobo1",
+                        "Goborot1",
+                        "Gobo2",
+                        "Goborot2",
+                        "Color",
+                        "CEffects",
+                        null,
+                        null,
+                        null,
+                        "Prism",
+                        "Prismrot",
+                        "Frost",
+                        "Speed",
+                        "Speed_E",
+                        "B_Move"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "JB Lighting",
+            "name": "Varyscan P2 HOG mode",
+            "shortName": "VaryscanP2",
+            "comment": "cd",
+            "physical": {
+                "dimensions": [400, 400, 600],
+                "weight": 22,
+                "power": 250
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 0,
+                    "highlightValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Control": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 231],
+                            "name": "nofunction"
+                        },
+                        {
+                            "range": [232, 239],
+                            "name": "lamp off"
+                        },
+                        {
+                            "range": [240, 247],
+                            "name": "reset"
+                        },
+                        {
+                            "range": [248, 255],
+                            "name": "lamp on"
+                        }
+                    ]
+                },
+                "Shutter": {
+                    "type": "Shutter",
+                    "highlightValue": 17,
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [16, 111],
+                            "name": "open"
+                        },
+                        {
+                            "range": [112, 125],
+                            "name": "strobe"
+                        },
+                        {
+                            "range": [126, 126],
+                            "name": "open"
+                        },
+                        {
+                            "range": [127, 127],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [128, 142],
+                            "name": "pulse opening"
+                        },
+                        {
+                            "range": [143, 143],
+                            "name": "open"
+                        },
+                        {
+                            "range": [144, 158],
+                            "name": "pulse closing"
+                        },
+                        {
+                            "range": [159, 159],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [160, 174],
+                            "name": "fade 0%"
+                        },
+                        {
+                            "range": [175, 175],
+                            "name": "open"
+                        },
+                        {
+                            "range": [176, 190],
+                            "name": "fade 100%"
+                        },
+                        {
+                            "range": [191, 191],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [192, 206],
+                            "name": "random 100%"
+                        },
+                        {
+                            "range": [207, 207],
+                            "name": "open"
+                        },
+                        {
+                            "range": [208, 222],
+                            "name": "random 0%"
+                        },
+                        {
+                            "range": [223, 223],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [224, 238],
+                            "name": "r. fade 0%"
+                        },
+                        {
+                            "range": [239, 239],
+                            "name": "open"
+                        },
+                        {
+                            "range": [240, 254],
+                            "name": "r. fade 100%"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "open"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "z no func.": {
+                    "type": "Beam"
+                },
+                "Focus": {
+                    "type": "Beam",
+                    "defaultValue": 128,
+                    "crossfade": true
+                },
+                "z no func.-tw6gr": {
+                    "name": "z no func.",
+                    "type": "Beam"
+                },
+                "z no func.-qmyey": {
+                    "name": "z no func.",
+                    "type": "Beam"
+                },
+                "Gobo": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "open"
+                        },
+                        {
+                            "range": [16, 31],
+                            "name": "slot1"
+                        },
+                        {
+                            "range": [32, 47],
+                            "name": "slot2"
+                        },
+                        {
+                            "range": [48, 63],
+                            "name": "slot3"
+                        },
+                        {
+                            "range": [64, 79],
+                            "name": "slot4"
+                        },
+                        {
+                            "range": [80, 127],
+                            "name": "slot5"
+                        },
+                        {
+                            "range": [128, 135],
+                            "name": "open sh."
+                        },
+                        {
+                            "range": [136, 143],
+                            "name": "slot1 sh."
+                        },
+                        {
+                            "range": [144, 151],
+                            "name": "slot2 sh."
+                        },
+                        {
+                            "range": [152, 159],
+                            "name": "slot3 sh."
+                        },
+                        {
+                            "range": [160, 175],
+                            "name": "slot4 sh."
+                        },
+                        {
+                            "range": [176, 191],
+                            "name": "slot5 sh."
+                        },
+                        {
+                            "range": [192, 223],
+                            "name": ">>"
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "<<"
+                        }
+                    ]
+                },
+                "Gobo rot.": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 191],
+                            "name": "ind."
+                        },
+                        {
+                            "range": [192, 222],
+                            "name": "<<"
+                        },
+                        {
+                            "range": [223, 224],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [225, 255],
+                            "name": ">>"
+                        }
+                    ]
+                },
+                "Color1": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 7],
+                            "name": "open"
+                        },
+                        {
+                            "range": [8, 15],
+                            "name": "red",
+                            "color": "#ff0000"
+                        },
+                        {
+                            "range": [16, 23],
+                            "name": "yellow",
+                            "color": "#ffff00"
+                        },
+                        {
+                            "range": [24, 31],
+                            "name": "magenta",
+                            "color": "#ca1f7b"
+                        },
+                        {
+                            "range": [32, 39],
+                            "name": "green",
+                            "color": "#00ff00"
+                        },
+                        {
+                            "range": [40, 47],
+                            "name": "orange",
+                            "color": "#ff7f00"
+                        },
+                        {
+                            "range": [48, 55],
+                            "name": "blue",
+                            "color": "#0000ff"
+                        },
+                        {
+                            "range": [56, 63],
+                            "name": "cyan",
+                            "color": "#00ffff"
+                        },
+                        {
+                            "range": [64, 191],
+                            "name": "position"
+                        },
+                        {
+                            "range": [192, 222],
+                            "name": ">>"
+                        },
+                        {
+                            "range": [223, 224],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [225, 255],
+                            "name": "<<"
+                        }
+                    ]
+                },
+                "Color2": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "open"
+                        },
+                        {
+                            "range": [16, 31],
+                            "name": "CTB"
+                        },
+                        {
+                            "range": [32, 47],
+                            "name": "CTO"
+                        },
+                        {
+                            "range": [48, 63],
+                            "name": "pink",
+                            "color": "#ffc0cb"
+                        },
+                        {
+                            "range": [64, 79],
+                            "name": "cyan",
+                            "color": "#00ffff"
+                        },
+                        {
+                            "range": [80, 127],
+                            "name": "frost",
+                            "color": "#edf5dd"
+                        },
+                        {
+                            "range": [128, 255],
+                            "name": "macro"
+                        }
+                    ]
+                },
+                "z no func.-7fn82": {
+                    "name": "z no func.",
+                    "type": "Beam"
+                },
+                "Prisma": {
+                    "type": "Prism",
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "out"
+                        },
+                        {
+                            "range": [16, 255],
+                            "name": "in"
+                        }
+                    ]
+                },
+                "Prisma rot.": {
+                    "type": "Prism",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 191],
+                            "name": "ind."
+                        },
+                        {
+                            "range": [192, 222],
+                            "name": ">>"
+                        },
+                        {
+                            "range": [223, 224],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [225, 255],
+                            "name": "<<"
+                        }
+                    ]
+                },
+                "z no func.-y6sts": {
+                    "name": "z no func.",
+                    "type": "Beam"
+                },
+                "P/T speed": {
+                    "type": "Speed",
+                    "capabilities": [
+                        {
+                            "range": [0, 3],
+                            "name": "track"
+                        },
+                        {
+                            "range": [4, 255],
+                            "name": "speed"
+                        }
+                    ]
+                },
+                "FX speed": {
+                    "type": "Speed",
+                    "capabilities": [
+                        {
+                            "range": [0, 3],
+                            "name": "track"
+                        },
+                        {
+                            "range": [4, 255],
+                            "name": "speed"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "20-channel Mode",
+                    "shortName": "20ch",
+                    "channels": [
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Control",
+                        "Shutter",
+                        "Intensity",
+                        "z no func.",
+                        "Focus",
+                        "z no func.-tw6gr",
+                        "z no func.-qmyey",
+                        "Gobo",
+                        "Gobo rot.",
+                        "Color1",
+                        "Color2",
+                        "z no func.-7fn82",
+                        "Prisma",
+                        "Prisma rot.",
+                        "z no func.-y6sts",
+                        "P/T speed",
+                        "FX speed"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "JB Lighting",
+            "name": "Varyscan P3 HOG mode",
+            "shortName": "VaryscanP3",
+            "comment": "cd",
+            "physical": {
+                "dimensions": [400, 400, 600],
+                "weight": 22,
+                "power": 250
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 0,
+                    "highlightValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Control": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 231],
+                            "name": "nofunction"
+                        },
+                        {
+                            "range": [232, 239],
+                            "name": "lamp off"
+                        },
+                        {
+                            "range": [240, 247],
+                            "name": "reset"
+                        },
+                        {
+                            "range": [248, 255],
+                            "name": "lamp on"
+                        }
+                    ]
+                },
+                "Shutter": {
+                    "type": "Shutter",
+                    "highlightValue": 17,
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [16, 111],
+                            "name": "open"
+                        },
+                        {
+                            "range": [112, 125],
+                            "name": "strobe"
+                        },
+                        {
+                            "range": [126, 126],
+                            "name": "open"
+                        },
+                        {
+                            "range": [127, 127],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [128, 142],
+                            "name": "pulse opening"
+                        },
+                        {
+                            "range": [143, 143],
+                            "name": "open"
+                        },
+                        {
+                            "range": [144, 158],
+                            "name": "pulse closing"
+                        },
+                        {
+                            "range": [159, 159],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [160, 174],
+                            "name": "fade 0%"
+                        },
+                        {
+                            "range": [175, 175],
+                            "name": "open"
+                        },
+                        {
+                            "range": [176, 190],
+                            "name": "fade 100%"
+                        },
+                        {
+                            "range": [191, 191],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [192, 206],
+                            "name": "random 100%"
+                        },
+                        {
+                            "range": [207, 207],
+                            "name": "open"
+                        },
+                        {
+                            "range": [208, 222],
+                            "name": "random 0%"
+                        },
+                        {
+                            "range": [223, 223],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [224, 238],
+                            "name": "r. fade 0%"
+                        },
+                        {
+                            "range": [239, 239],
+                            "name": "open"
+                        },
+                        {
+                            "range": [240, 254],
+                            "name": "r. fade 100%"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "open"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Iris": {
+                    "type": "Beam",
+                    "defaultValue": 143,
+                    "highlightValue": 143,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 126],
+                            "name": "%"
+                        },
+                        {
+                            "range": [128, 142],
+                            "name": "pulse closing"
+                        },
+                        {
+                            "range": [143, 143],
+                            "name": "open"
+                        },
+                        {
+                            "range": [144, 158],
+                            "name": "pulse opening"
+                        },
+                        {
+                            "range": [159, 159],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [160, 174],
+                            "name": "fade closed"
+                        },
+                        {
+                            "range": [175, 175],
+                            "name": "open"
+                        },
+                        {
+                            "range": [176, 190],
+                            "name": "fade open"
+                        },
+                        {
+                            "range": [191, 191],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [192, 206],
+                            "name": "random open"
+                        },
+                        {
+                            "range": [207, 207],
+                            "name": "open"
+                        },
+                        {
+                            "range": [208, 222],
+                            "name": "random close"
+                        },
+                        {
+                            "range": [223, 223],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [224, 238],
+                            "name": "r. fade close"
+                        },
+                        {
+                            "range": [239, 239],
+                            "name": "open"
+                        },
+                        {
+                            "range": [240, 254],
+                            "name": "r. fade open"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "open"
+                        }
+                    ]
+                },
+                "Focus": {
+                    "type": "Beam",
+                    "defaultValue": 128,
+                    "crossfade": true
+                },
+                "Gobo1": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "open"
+                        },
+                        {
+                            "range": [16, 31],
+                            "name": "slot1"
+                        },
+                        {
+                            "range": [32, 47],
+                            "name": "slot2"
+                        },
+                        {
+                            "range": [48, 63],
+                            "name": "slot3"
+                        },
+                        {
+                            "range": [64, 79],
+                            "name": "slot4"
+                        },
+                        {
+                            "range": [80, 95],
+                            "name": "slot5"
+                        },
+                        {
+                            "range": [96, 111],
+                            "name": "slot6"
+                        },
+                        {
+                            "range": [112, 127],
+                            "name": "slot7"
+                        },
+                        {
+                            "range": [128, 135],
+                            "name": "open sh."
+                        },
+                        {
+                            "range": [136, 143],
+                            "name": "slot1 sh."
+                        },
+                        {
+                            "range": [144, 151],
+                            "name": "slot2 sh."
+                        },
+                        {
+                            "range": [152, 159],
+                            "name": "slot3 sh."
+                        },
+                        {
+                            "range": [160, 167],
+                            "name": "slot4 sh."
+                        },
+                        {
+                            "range": [168, 175],
+                            "name": "slot5 sh."
+                        },
+                        {
+                            "range": [176, 183],
+                            "name": "slot6 sh."
+                        },
+                        {
+                            "range": [184, 191],
+                            "name": "slot7 sh."
+                        },
+                        {
+                            "range": [192, 223],
+                            "name": ">>"
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "<<"
+                        }
+                    ]
+                },
+                "z no func.": {
+                    "type": "Beam"
+                },
+                "Gobo2": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "open"
+                        },
+                        {
+                            "range": [16, 31],
+                            "name": "slot1"
+                        },
+                        {
+                            "range": [32, 47],
+                            "name": "slot2"
+                        },
+                        {
+                            "range": [48, 63],
+                            "name": "slot3"
+                        },
+                        {
+                            "range": [64, 79],
+                            "name": "slot4"
+                        },
+                        {
+                            "range": [80, 127],
+                            "name": "slot5"
+                        },
+                        {
+                            "range": [128, 135],
+                            "name": "open sh."
+                        },
+                        {
+                            "range": [136, 143],
+                            "name": "slot1 sh."
+                        },
+                        {
+                            "range": [144, 151],
+                            "name": "slot2 sh."
+                        },
+                        {
+                            "range": [152, 159],
+                            "name": "slot3 sh."
+                        },
+                        {
+                            "range": [160, 175],
+                            "name": "slot4 sh."
+                        },
+                        {
+                            "range": [176, 191],
+                            "name": "slot5 sh."
+                        },
+                        {
+                            "range": [192, 223],
+                            "name": ">>"
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "<<"
+                        }
+                    ]
+                },
+                "Gobo2 rot.": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 191],
+                            "name": "ind."
+                        },
+                        {
+                            "range": [192, 222],
+                            "name": "<<"
+                        },
+                        {
+                            "range": [223, 224],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [225, 255],
+                            "name": ">>"
+                        }
+                    ]
+                },
+                "Color1": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 7],
+                            "name": "open"
+                        },
+                        {
+                            "range": [8, 15],
+                            "name": "red",
+                            "color": "#ff0000"
+                        },
+                        {
+                            "range": [16, 23],
+                            "name": "yellow",
+                            "color": "#ffff00"
+                        },
+                        {
+                            "range": [24, 31],
+                            "name": "magenta",
+                            "color": "#ca1f7b"
+                        },
+                        {
+                            "range": [32, 39],
+                            "name": "green",
+                            "color": "#00ff00"
+                        },
+                        {
+                            "range": [40, 47],
+                            "name": "orange",
+                            "color": "#ff7f00"
+                        },
+                        {
+                            "range": [48, 55],
+                            "name": "blue",
+                            "color": "#0000ff"
+                        },
+                        {
+                            "range": [56, 63],
+                            "name": "cyan",
+                            "color": "#00ffff"
+                        },
+                        {
+                            "range": [64, 191],
+                            "name": "position"
+                        },
+                        {
+                            "range": [192, 222],
+                            "name": ">>"
+                        },
+                        {
+                            "range": [223, 224],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [225, 255],
+                            "name": "<<"
+                        }
+                    ]
+                },
+                "Color2": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "open"
+                        },
+                        {
+                            "range": [16, 31],
+                            "name": "CTB"
+                        },
+                        {
+                            "range": [32, 47],
+                            "name": "CTO"
+                        },
+                        {
+                            "range": [48, 63],
+                            "name": "pink",
+                            "color": "#ffc0cb"
+                        },
+                        {
+                            "range": [64, 79],
+                            "name": "cyan",
+                            "color": "#00ffff"
+                        },
+                        {
+                            "range": [80, 127],
+                            "name": "frost",
+                            "color": "#edf5dd"
+                        },
+                        {
+                            "range": [128, 255],
+                            "name": "macro"
+                        }
+                    ]
+                },
+                "z no func.-i2yvp": {
+                    "name": "z no func.",
+                    "type": "Beam"
+                },
+                "Prisma": {
+                    "type": "Prism",
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "out"
+                        },
+                        {
+                            "range": [16, 255],
+                            "name": "in"
+                        }
+                    ]
+                },
+                "Prisma rot.": {
+                    "type": "Prism",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 191],
+                            "name": "ind."
+                        },
+                        {
+                            "range": [192, 222],
+                            "name": ">>"
+                        },
+                        {
+                            "range": [223, 224],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [225, 255],
+                            "name": "<<"
+                        }
+                    ]
+                },
+                "z no func.-xuyob": {
+                    "name": "z no func.",
+                    "type": "Beam"
+                },
+                "P/T speed": {
+                    "type": "Speed",
+                    "capabilities": [
+                        {
+                            "range": [0, 3],
+                            "name": "track"
+                        },
+                        {
+                            "range": [4, 255],
+                            "name": "speed"
+                        }
+                    ]
+                },
+                "FX speed": {
+                    "type": "Speed",
+                    "capabilities": [
+                        {
+                            "range": [0, 3],
+                            "name": "track"
+                        },
+                        {
+                            "range": [4, 255],
+                            "name": "speed"
+                        }
+                    ]
+                },
+                "MIB": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 95],
+                            "name": "idle"
+                        },
+                        {
+                            "range": [96, 127],
+                            "name": "P/T"
+                        },
+                        {
+                            "range": [128, 159],
+                            "name": "G/C/P"
+                        },
+                        {
+                            "range": [160, 191],
+                            "name": "G/C/P/F"
+                        },
+                        {
+                            "range": [192, 223],
+                            "name": "G/C/P/P/T"
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "all"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "21-channel Mode",
+                    "shortName": "21ch",
+                    "channels": [
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Control",
+                        "Shutter",
+                        "Intensity",
+                        "Iris",
+                        "Focus",
+                        "Gobo1",
+                        "z no func.",
+                        "Gobo2",
+                        "Gobo2 rot.",
+                        "Color1",
+                        "Color2",
+                        "z no func.-i2yvp",
+                        "Prisma",
+                        "Prisma rot.",
+                        "z no func.-xuyob",
+                        "P/T speed",
+                        "FX speed",
+                        "MIB"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "JB Lighting",
+            "name": "Varyscan P6",
+            "shortName": "VaryscanP6",
+            "comment": "please check the manual for special Fadings on Channel 22",
+            "physical": {
+                "dimensions": [480, 480, 660],
+                "weight": 33,
+                "power": 3
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Control1": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 231],
+                            "name": "Safe"
+                        },
+                        {
+                            "range": [232, 239],
+                            "name": "lamp off"
+                        },
+                        {
+                            "range": [240, 247],
+                            "name": "reset"
+                        },
+                        {
+                            "range": [248, 255],
+                            "name": "lamp on"
+                        }
+                    ]
+                },
+                "Control2": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "shutter closed"
+                        },
+                        {
+                            "range": [16, 111],
+                            "name": "shutter open"
+                        },
+                        {
+                            "range": [112, 125],
+                            "name": "strobe"
+                        },
+                        {
+                            "range": [126, 126],
+                            "name": "shutter open"
+                        },
+                        {
+                            "range": [127, 127],
+                            "name": "shutter closed"
+                        },
+                        {
+                            "range": [128, 142],
+                            "name": "pulse opening"
+                        },
+                        {
+                            "range": [143, 143],
+                            "name": "shutter open"
+                        },
+                        {
+                            "range": [144, 158],
+                            "name": "pulse closing"
+                        },
+                        {
+                            "range": [159, 159],
+                            "name": "shutter closed"
+                        },
+                        {
+                            "range": [160, 174],
+                            "name": "snap open/ramp"
+                        },
+                        {
+                            "range": [175, 175],
+                            "name": "shutter open"
+                        },
+                        {
+                            "range": [176, 190],
+                            "name": "ramp open/snap"
+                        },
+                        {
+                            "range": [191, 191],
+                            "name": "shutter closed"
+                        },
+                        {
+                            "range": [192, 206],
+                            "name": "random opening"
+                        },
+                        {
+                            "range": [207, 207],
+                            "name": "shutter open"
+                        },
+                        {
+                            "range": [208, 222],
+                            "name": "random closing"
+                        },
+                        {
+                            "range": [223, 223],
+                            "name": "shutter closed"
+                        },
+                        {
+                            "range": [224, 238],
+                            "name": "random snap"
+                        },
+                        {
+                            "range": [239, 239],
+                            "name": "shutter open"
+                        },
+                        {
+                            "range": [240, 254],
+                            "name": "random ramp"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "shutter open"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 254,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Iris": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 126],
+                            "name": "%"
+                        },
+                        {
+                            "range": [127, 127],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [128, 142],
+                            "name": "open pulse"
+                        },
+                        {
+                            "range": [143, 143],
+                            "name": "open"
+                        },
+                        {
+                            "range": [144, 158],
+                            "name": "closing pulse"
+                        },
+                        {
+                            "range": [159, 159],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [160, 174],
+                            "name": "snap open/ramp"
+                        },
+                        {
+                            "range": [175, 175],
+                            "name": "open"
+                        },
+                        {
+                            "range": [176, 190],
+                            "name": "ramp open/snap"
+                        },
+                        {
+                            "range": [191, 191],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [192, 206],
+                            "name": "random open pul"
+                        },
+                        {
+                            "range": [207, 207],
+                            "name": "open"
+                        },
+                        {
+                            "range": [208, 222],
+                            "name": "random closing"
+                        },
+                        {
+                            "range": [223, 223],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [224, 238],
+                            "name": "random snap"
+                        },
+                        {
+                            "range": [239, 239],
+                            "name": "open"
+                        },
+                        {
+                            "range": [240, 254],
+                            "name": "random ramp"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "open"
+                        }
+                    ]
+                },
+                "focus": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Gobo1": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "open"
+                        },
+                        {
+                            "range": [16, 31],
+                            "name": "Gobo 1"
+                        },
+                        {
+                            "range": [32, 47],
+                            "name": "Gobo 2"
+                        },
+                        {
+                            "range": [48, 63],
+                            "name": "Gobo 3"
+                        },
+                        {
+                            "range": [64, 79],
+                            "name": "Gobo 4"
+                        },
+                        {
+                            "range": [80, 127],
+                            "name": "Gobo 5"
+                        },
+                        {
+                            "range": [128, 135],
+                            "name": "open shake"
+                        },
+                        {
+                            "range": [136, 143],
+                            "name": "Gobo 1 shake"
+                        },
+                        {
+                            "range": [144, 151],
+                            "name": "Gobo 2 shake"
+                        },
+                        {
+                            "range": [152, 159],
+                            "name": "Gobo 3 shake"
+                        },
+                        {
+                            "range": [160, 167],
+                            "name": "Gobo 4 shake"
+                        },
+                        {
+                            "range": [168, 191],
+                            "name": "Gobo 5 shake"
+                        },
+                        {
+                            "range": [192, 223],
+                            "name": "spin clockwise"
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "spin anti clock"
+                        }
+                    ]
+                },
+                "reserved": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Gobo2": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "open"
+                        },
+                        {
+                            "range": [16, 31],
+                            "name": "Gobo 1"
+                        },
+                        {
+                            "range": [32, 47],
+                            "name": "Gobo 2"
+                        },
+                        {
+                            "range": [48, 63],
+                            "name": "Gobo 3"
+                        },
+                        {
+                            "range": [64, 79],
+                            "name": "Gobo 4"
+                        },
+                        {
+                            "range": [80, 127],
+                            "name": "Gobo 5"
+                        },
+                        {
+                            "range": [128, 135],
+                            "name": "open shake"
+                        },
+                        {
+                            "range": [136, 143],
+                            "name": "Gobo 1 shake"
+                        },
+                        {
+                            "range": [144, 151],
+                            "name": "Gobo 2 shake"
+                        },
+                        {
+                            "range": [152, 159],
+                            "name": "Gobo 3 shake"
+                        },
+                        {
+                            "range": [160, 167],
+                            "name": "Gobo 4 shake"
+                        },
+                        {
+                            "range": [168, 191],
+                            "name": "Gobo 5 shake"
+                        },
+                        {
+                            "range": [192, 223],
+                            "name": "spin clockwise"
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "spin anti clock"
+                        }
+                    ]
+                },
+                "Gobo Pos.": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 91],
+                            "name": "%"
+                        },
+                        {
+                            "range": [192, 222],
+                            "name": "Gobo rotation r"
+                        },
+                        {
+                            "range": [223, 224],
+                            "name": "rotation stop"
+                        },
+                        {
+                            "range": [225, 255],
+                            "name": "gobo rotation l"
+                        }
+                    ]
+                },
+                "Color": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 3],
+                            "name": "white",
+                            "color": "#ffffff"
+                        },
+                        {
+                            "range": [4, 7],
+                            "name": "white/red"
+                        },
+                        {
+                            "range": [8, 11],
+                            "name": "red",
+                            "color": "#ff0000"
+                        },
+                        {
+                            "range": [12, 15],
+                            "name": "red/yellow"
+                        },
+                        {
+                            "range": [16, 19],
+                            "name": "yellow",
+                            "color": "#ffff00"
+                        },
+                        {
+                            "range": [20, 23],
+                            "name": "yellow/magenta"
+                        },
+                        {
+                            "range": [24, 27],
+                            "name": "magenta",
+                            "color": "#ca1f7b"
+                        },
+                        {
+                            "range": [28, 31],
+                            "name": "magenta/green"
+                        },
+                        {
+                            "range": [32, 35],
+                            "name": "green",
+                            "color": "#00ff00"
+                        },
+                        {
+                            "range": [36, 39],
+                            "name": "green/orange"
+                        },
+                        {
+                            "range": [40, 43],
+                            "name": "orange",
+                            "color": "#ff7f00"
+                        },
+                        {
+                            "range": [44, 47],
+                            "name": "orange/blue"
+                        },
+                        {
+                            "range": [48, 51],
+                            "name": "blue",
+                            "color": "#0000ff"
+                        },
+                        {
+                            "range": [52, 55],
+                            "name": "blue/cyan"
+                        },
+                        {
+                            "range": [56, 59],
+                            "name": "cyan",
+                            "color": "#00ffff"
+                        },
+                        {
+                            "range": [60, 63],
+                            "name": "cyan/white"
+                        },
+                        {
+                            "range": [64, 191],
+                            "name": "positioning"
+                        },
+                        {
+                            "range": [192, 222],
+                            "name": "rotation right"
+                        },
+                        {
+                            "range": [223, 224],
+                            "name": "rotation stop"
+                        },
+                        {
+                            "range": [225, 255],
+                            "name": "rotation left"
+                        }
+                    ]
+                },
+                "FX": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [15, 0],
+                            "name": "open"
+                        },
+                        {
+                            "range": [16, 31],
+                            "name": "CTB"
+                        },
+                        {
+                            "range": [32, 47],
+                            "name": "CTO"
+                        },
+                        {
+                            "range": [48, 63],
+                            "name": "pink",
+                            "color": "#ffc0cb"
+                        },
+                        {
+                            "range": [64, 79],
+                            "name": "cyan",
+                            "color": "#00ffff"
+                        },
+                        {
+                            "range": [80, 95],
+                            "name": "open"
+                        },
+                        {
+                            "range": [96, 11],
+                            "name": "frost",
+                            "color": "#edf5dd"
+                        },
+                        {
+                            "range": [128, 255],
+                            "name": "clour macros"
+                        }
+                    ]
+                },
+                "reserved-2j7ve": {
+                    "name": "reserved",
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Prisma1": {
+                    "type": "Prism",
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "open"
+                        },
+                        {
+                            "range": [16, 31],
+                            "name": "prism"
+                        },
+                        {
+                            "range": [128, 135],
+                            "name": "prism shake"
+                        }
+                    ]
+                },
+                "Prisma2": {
+                    "type": "Prism",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 191],
+                            "name": "index"
+                        },
+                        {
+                            "range": [192, 222],
+                            "name": "rot cw"
+                        },
+                        {
+                            "range": [223, 224],
+                            "name": "rotation stop"
+                        },
+                        {
+                            "range": [225, 255],
+                            "name": "rot ccw"
+                        }
+                    ]
+                },
+                "reserved-wi5oi": {
+                    "name": "reserved",
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "p/t moves": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 3],
+                            "name": "realtime"
+                        },
+                        {
+                            "range": [4, 255],
+                            "name": "delayed"
+                        }
+                    ]
+                },
+                "FX Tim.": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 3],
+                            "name": "realtime"
+                        },
+                        {
+                            "range": [4, 255],
+                            "name": "delayed"
+                        }
+                    ]
+                },
+                "Control3": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 95],
+                            "name": "no function"
+                        },
+                        {
+                            "range": [96, 127],
+                            "name": "Fade1"
+                        },
+                        {
+                            "range": [0, 0],
+                            "name": "Fade2"
+                        },
+                        {
+                            "range": [128, 159],
+                            "name": "Fade3"
+                        },
+                        {
+                            "range": [160, 191],
+                            "name": "Fade4"
+                        },
+                        {
+                            "range": [192, 223],
+                            "name": "Fade 5"
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "Fade 6"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "22-channel Mode",
+                    "shortName": "22ch",
+                    "channels": [
+                        "Pan",
+                        "Tilt",
+                        "Pan fine",
+                        "Tilt fine",
+                        "Control1",
+                        "Control2",
+                        "Intensity",
+                        "Iris",
+                        "focus",
+                        "Gobo1",
+                        "reserved",
+                        "Gobo2",
+                        "Gobo Pos.",
+                        "Color",
+                        "FX",
+                        "reserved-2j7ve",
+                        "Prisma1",
+                        "Prisma2",
+                        "reserved-wi5oi",
+                        "p/t moves",
+                        "FX Tim.",
+                        "Control3"
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/fixtures/imports/ecue-MainLibrary/LDDE.json
+++ b/fixtures/imports/ecue-MainLibrary/LDDE.json
@@ -1,0 +1,260 @@
+{
+    "manufacturers": {
+        "LDDE": {
+            "name": "LDDE",
+            "website": "www.ldde.com"
+        }
+    },
+    "fixtures": [
+        {
+            "manufacturer": "LDDE",
+            "name": "Spectra WOW +",
+            "shortName": "SpectraWOW+",
+            "comment": "cd",
+            "physical": {
+                "dimensions": [130, 130, 155],
+                "weight": 1.6,
+                "power": 48
+            },
+            "availableChannels": {
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Strobe": {
+                    "type": "Strobe",
+                    "highlightValue": 255,
+                    "crossfade": true
+                }
+            },
+            "modes": [
+                {
+                    "name": "5-channel Mode",
+                    "shortName": "5ch",
+                    "channels": [
+                        "Intensity",
+                        "Red",
+                        "Green",
+                        "Blue",
+                        "Strobe"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "LDDE",
+            "name": "Spectra WOW Aqua",
+            "shortName": "SpectraWOW Aqua",
+            "comment": "cd",
+            "physical": {
+                "dimensions": [109, 109, 181],
+                "weight": 1.35,
+                "power": 12
+            },
+            "availableChannels": {
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Strobe": {
+                    "type": "Strobe",
+                    "highlightValue": 255,
+                    "crossfade": true
+                }
+            },
+            "modes": [
+                {
+                    "name": "5-channel Mode",
+                    "shortName": "5ch",
+                    "channels": [
+                        "Intensity",
+                        "Red",
+                        "Green",
+                        "Blue",
+                        "Strobe"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "LDDE",
+            "name": "Spectra WOW MkII",
+            "shortName": "SpectraWOW",
+            "comment": "cd",
+            "physical": {
+                "dimensions": [130, 130, 96],
+                "weight": 1.3,
+                "power": 25
+            },
+            "availableChannels": {
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Strobe": {
+                    "type": "Strobe",
+                    "highlightValue": 255,
+                    "crossfade": true
+                }
+            },
+            "modes": [
+                {
+                    "name": "5-channel Mode",
+                    "shortName": "5ch",
+                    "channels": [
+                        "Intensity",
+                        "Red",
+                        "Green",
+                        "Blue",
+                        "Strobe"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "LDDE",
+            "name": "SpectraConnecT5",
+            "shortName": "SpectraT5",
+            "comment": "cd",
+            "physical": {
+                "dimensions": [1485, 115, 80],
+                "weight": 5.65,
+                "power": 175
+            },
+            "availableChannels": {
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Strobe": {
+                    "type": "Strobe",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 25],
+                            "name": "open"
+                        },
+                        {
+                            "range": [26, 228],
+                            "name": "strobe"
+                        },
+                        {
+                            "range": [229, 255],
+                            "name": "open"
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "5-channel Mode",
+                    "shortName": "5ch",
+                    "channels": [
+                        "Intensity",
+                        "Red",
+                        "Green",
+                        "Blue",
+                        "Strobe"
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/fixtures/imports/ecue-MainLibrary/LeMaitre.json
+++ b/fixtures/imports/ecue-MainLibrary/LeMaitre.json
@@ -1,0 +1,41 @@
+{
+    "manufacturers": {
+        "LeMaitre": {
+            "name": "LeMaitre",
+            "website": "http://www.lemaitre.co.uk/"
+        }
+    },
+    "fixtures": [
+        {
+            "manufacturer": "LeMaitre",
+            "name": "Radiance",
+            "shortName": "Radiance",
+            "comment": "DMX Control for Hazer",
+            "physical": {
+                "dimensions": [100, 100, 100]
+            },
+            "availableChannels": {
+                "Haze": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255
+                },
+                "Blower": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255
+                }
+            },
+            "modes": [
+                {
+                    "name": "2-channel Mode",
+                    "shortName": "2ch",
+                    "channels": [
+                        "Haze",
+                        "Blower"
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/fixtures/imports/ecue-MainLibrary/Lightmaxx.json
+++ b/fixtures/imports/ecue-MainLibrary/Lightmaxx.json
@@ -1,0 +1,71 @@
+{
+    "manufacturers": {
+        "Lightmaxx": {
+            "name": "Lightmaxx"
+        }
+    },
+    "fixtures": [
+        {
+            "manufacturer": "Lightmaxx",
+            "name": "LED PAR 64",
+            "shortName": "LED64",
+            "comment": "cd",
+            "physical": {
+                "dimensions": [260, 260, 300]
+            },
+            "availableChannels": {
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 189,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 189],
+                            "name": "intensity"
+                        },
+                        {
+                            "range": [190, 250],
+                            "name": "strobe"
+                        },
+                        {
+                            "range": [251, 255],
+                            "name": "idle"
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "4-channel Mode",
+                    "shortName": "4ch",
+                    "channels": [
+                        "Red",
+                        "Green",
+                        "Blue",
+                        "Intensity"
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/fixtures/imports/ecue-MainLibrary/Litecraft.json
+++ b/fixtures/imports/ecue-MainLibrary/Litecraft.json
@@ -1,0 +1,2182 @@
+{
+    "manufacturers": {
+        "Litecraft": {
+            "name": "Litecraft",
+            "website": "http://www.litecraft-online.com/"
+        }
+    },
+    "fixtures": [
+        {
+            "manufacturer": "Litecraft",
+            "name": "Battled AT5 AT10 Mode1",
+            "shortName": "Battled5-10 M1",
+            "comment": "http://www.litecraft-online.com/",
+            "physical": {
+                "dimensions": [372, 402, 277],
+                "weight": 11.4,
+                "power": 69
+            },
+            "availableChannels": {
+                "Colour Macro": {
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "crossfade": true,
+                    "precendence": "HTP"
+                }
+            },
+            "modes": [
+                {
+                    "name": "1-channel Mode",
+                    "shortName": "1ch",
+                    "channels": [
+                        "Colour Macro"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Litecraft",
+            "name": "Battled AT5 AT10 Mode2 ",
+            "shortName": "Battled5-10 M2",
+            "comment": "http://www.litecraft-online.com/",
+            "physical": {
+                "dimensions": [372, 402, 277],
+                "weight": 11.4,
+                "power": 69
+            },
+            "availableChannels": {
+                "Colour Macro": {
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                }
+            },
+            "modes": [
+                {
+                    "name": "2-channel Mode",
+                    "shortName": "2ch",
+                    "channels": [
+                        "Colour Macro",
+                        "Intensity"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Litecraft",
+            "name": "Battled AT5 AT10 Mode3",
+            "shortName": "Battled5-10 M3",
+            "comment": "http://www.litecraft-online.com/",
+            "physical": {
+                "dimensions": [372, 402, 277],
+                "weight": 11.4,
+                "power": 69
+            },
+            "availableChannels": {
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                }
+            },
+            "modes": [
+                {
+                    "name": "3-channel Mode",
+                    "shortName": "3ch",
+                    "channels": [
+                        "Red",
+                        "Green",
+                        "Blue"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Litecraft",
+            "name": "Battled AT5 AT10 Mode4",
+            "shortName": "Battled5-10 M4",
+            "comment": "http://www.litecraft-online.com/",
+            "physical": {
+                "dimensions": [372, 402, 277],
+                "weight": 11.4,
+                "power": 69
+            },
+            "availableChannels": {
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "White": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                }
+            },
+            "modes": [
+                {
+                    "name": "4-channel Mode",
+                    "shortName": "4ch",
+                    "channels": [
+                        "Red",
+                        "Green",
+                        "Blue",
+                        "White"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Litecraft",
+            "name": "Battled AT5 AT10 Mode8",
+            "shortName": "Battled5-10 M8",
+            "comment": "http://www.litecraft-online.com/",
+            "physical": {
+                "dimensions": [372, 402, 277],
+                "weight": 11.4,
+                "power": 69
+            },
+            "availableChannels": {
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "White": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Colour Macro": {
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Strobe": {
+                    "type": "Strobe",
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "no function"
+                        },
+                        {
+                            "range": [14, 255],
+                            "name": "Strobe"
+                        }
+                    ]
+                },
+                "Macro": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 35],
+                            "name": "no function"
+                        },
+                        {
+                            "range": [36, 71],
+                            "name": "Intensity up"
+                        },
+                        {
+                            "range": [72, 107],
+                            "name": "Intensity down"
+                        },
+                        {
+                            "range": [108, 143],
+                            "name": "Intens up down"
+                        },
+                        {
+                            "range": [144, 179],
+                            "name": "auto col mix"
+                        },
+                        {
+                            "range": [180, 215],
+                            "name": "RND 3 color"
+                        },
+                        {
+                            "range": [216, 251],
+                            "name": "RND 7 color"
+                        },
+                        {
+                            "range": [252, 255],
+                            "name": "Audio Modus",
+                            "showInMenu": false
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                }
+            },
+            "modes": [
+                {
+                    "name": "8-channel Mode",
+                    "shortName": "8ch",
+                    "channels": [
+                        "Red",
+                        "Green",
+                        "Blue",
+                        "White",
+                        "Colour Macro",
+                        "Strobe",
+                        "Macro",
+                        "Intensity"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Litecraft",
+            "name": "ChiPo RGB",
+            "shortName": "ChiPo",
+            "availableChannels": {
+                "Shutter": {
+                    "type": "Shutter",
+                    "defaultValue": 255,
+                    "crossfade": true
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "precendence": "HTP"
+                },
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "CTB": {
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "crossfade": true
+                },
+                "Macro": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 7],
+                            "name": "No Macro",
+                            "center": true
+                        },
+                        {
+                            "range": [8, 15],
+                            "name": "Macro 1",
+                            "center": true
+                        },
+                        {
+                            "range": [16, 23],
+                            "name": "Macro 2",
+                            "center": true
+                        },
+                        {
+                            "range": [24, 31],
+                            "name": "Macro 3",
+                            "center": true
+                        },
+                        {
+                            "range": [32, 39],
+                            "name": "Macro 4",
+                            "center": true
+                        },
+                        {
+                            "range": [40, 47],
+                            "name": "Macro 5",
+                            "center": true
+                        },
+                        {
+                            "range": [48, 55],
+                            "name": "Macro 6",
+                            "center": true
+                        },
+                        {
+                            "range": [56, 63],
+                            "name": "Macro 7",
+                            "center": true
+                        },
+                        {
+                            "range": [71, 71],
+                            "name": "Non Function",
+                            "center": true
+                        },
+                        {
+                            "range": [64, 70],
+                            "name": "Macro 8",
+                            "center": true
+                        },
+                        {
+                            "range": [72, 79],
+                            "name": "Macro 9",
+                            "center": true
+                        },
+                        {
+                            "range": [80, 87],
+                            "name": "Macro 10",
+                            "center": true
+                        }
+                    ]
+                },
+                "White Balance": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 63],
+                            "name": "WB disabled"
+                        },
+                        {
+                            "range": [64, 189],
+                            "name": "WB activ FF"
+                        },
+                        {
+                            "range": [190, 250],
+                            "name": "WB disabled"
+                        },
+                        {
+                            "range": [0, 0],
+                            "name": "WB activ NEW Wh"
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "8-channel Mode",
+                    "shortName": "8ch",
+                    "channels": [
+                        "Shutter",
+                        "Intensity",
+                        "Red",
+                        "Green",
+                        "Blue",
+                        "CTB",
+                        "Macro",
+                        "White Balance"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Litecraft",
+            "name": "MiniPAR AT3-M1",
+            "shortName": "MPAR AT3-M1",
+            "comment": "1 Channel Mode",
+            "physical": {
+                "dimensions": [150, 150, 250],
+                "weight": 2.4,
+                "power": 30
+            },
+            "availableChannels": {
+                "Colour Macro": {
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                }
+            },
+            "modes": [
+                {
+                    "name": "1-channel Mode",
+                    "shortName": "1ch",
+                    "channels": [
+                        "Colour Macro"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Litecraft",
+            "name": "MiniPAR AT3-M2",
+            "shortName": "MPAR AT3-M2",
+            "comment": "2 Channel Mode",
+            "physical": {
+                "dimensions": [150, 150, 250],
+                "weight": 2.4,
+                "power": 30
+            },
+            "availableChannels": {
+                "Colour Macro": {
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Dimmer": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                }
+            },
+            "modes": [
+                {
+                    "name": "2-channel Mode",
+                    "shortName": "2ch",
+                    "channels": [
+                        "Colour Macro",
+                        "Dimmer"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Litecraft",
+            "name": "MiniPAR AT3-M3",
+            "shortName": "MPAR AT3-M3",
+            "comment": "3 Channel Mode",
+            "physical": {
+                "dimensions": [150, 150, 250],
+                "weight": 2.4,
+                "power": 30
+            },
+            "availableChannels": {
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                }
+            },
+            "modes": [
+                {
+                    "name": "3-channel Mode",
+                    "shortName": "3ch",
+                    "channels": [
+                        "Red",
+                        "Green",
+                        "Blue"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Litecraft",
+            "name": "MiniPAR AT3-M4",
+            "shortName": "MPAR AT3-M4",
+            "comment": "7 Channel Mode",
+            "physical": {
+                "dimensions": [150, 150, 250],
+                "weight": 2.4,
+                "power": 30
+            },
+            "availableChannels": {
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Macro": {
+                    "type": "MultiColor",
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 13],
+                            "name": "No Macro",
+                            "center": true
+                        },
+                        {
+                            "range": [16, 255],
+                            "name": "Colour Macro",
+                            "center": true
+                        }
+                    ]
+                },
+                "Strobe": {
+                    "type": "Strobe",
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [16, 255],
+                            "name": "Strobe s -> f",
+                            "center": true
+                        }
+                    ]
+                },
+                "Mode": {
+                    "type": "Beam",
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 35],
+                            "name": "No Function",
+                            "center": true
+                        },
+                        {
+                            "range": [36, 71],
+                            "name": "Auto. Up Dim",
+                            "center": true
+                        },
+                        {
+                            "range": [72, 107],
+                            "name": "Auto. Down Dim",
+                            "center": true
+                        },
+                        {
+                            "range": [108, 143],
+                            "name": "Auto Up/Down Di",
+                            "center": true
+                        },
+                        {
+                            "range": [144, 179],
+                            "name": "Auto Colour Mix",
+                            "center": true
+                        },
+                        {
+                            "range": [180, 215],
+                            "name": "Random 3 Colour",
+                            "center": true
+                        },
+                        {
+                            "range": [216, 251],
+                            "name": "Random 7 Colour",
+                            "center": true
+                        },
+                        {
+                            "range": [252, 255],
+                            "name": "Audio Mode",
+                            "center": true
+                        }
+                    ]
+                },
+                "Dimmer": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                }
+            },
+            "modes": [
+                {
+                    "name": "7-channel Mode",
+                    "shortName": "7ch",
+                    "channels": [
+                        "Red",
+                        "Green",
+                        "Blue",
+                        "Macro",
+                        "Strobe",
+                        "Mode",
+                        "Dimmer"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Litecraft",
+            "name": "MiniPAR RGB Pro-M1",
+            "shortName": "MPAR RGB-M1",
+            "comment": "1 Channel Mode",
+            "physical": {
+                "dimensions": [150, 150, 250],
+                "weight": 2.4,
+                "power": 23
+            },
+            "availableChannels": {
+                "Colour Macro": {
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                }
+            },
+            "modes": [
+                {
+                    "name": "1-channel Mode",
+                    "shortName": "1ch",
+                    "channels": [
+                        "Colour Macro"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Litecraft",
+            "name": "MiniPAR RGB Pro-M2",
+            "shortName": "MPAR RGB-M2",
+            "comment": "2 Channel Mode",
+            "physical": {
+                "dimensions": [150, 150, 250],
+                "weight": 2.4,
+                "power": 23
+            },
+            "availableChannels": {
+                "Colour Macro": {
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Dimmer": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                }
+            },
+            "modes": [
+                {
+                    "name": "2-channel Mode",
+                    "shortName": "2ch",
+                    "channels": [
+                        "Colour Macro",
+                        "Dimmer"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Litecraft",
+            "name": "MiniPAR RGB Pro-M3",
+            "shortName": "MPAR RGB-M3",
+            "comment": "3 Channel Mode",
+            "physical": {
+                "dimensions": [150, 150, 250],
+                "weight": 2.4,
+                "power": 23
+            },
+            "availableChannels": {
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                }
+            },
+            "modes": [
+                {
+                    "name": "3-channel Mode",
+                    "shortName": "3ch",
+                    "channels": [
+                        "Red",
+                        "Green",
+                        "Blue"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Litecraft",
+            "name": "MiniPAR RGB-Pro-M4",
+            "shortName": "MPAR RGB-M4",
+            "comment": "7 Channel Mode",
+            "physical": {
+                "dimensions": [150, 150, 250],
+                "weight": 2.4,
+                "power": 23
+            },
+            "availableChannels": {
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Macro": {
+                    "type": "MultiColor",
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 13],
+                            "name": "No Macro",
+                            "center": true
+                        },
+                        {
+                            "range": [16, 255],
+                            "name": "Colour Macro",
+                            "center": true
+                        }
+                    ]
+                },
+                "Strobe": {
+                    "type": "Strobe",
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [16, 255],
+                            "name": "Strobe s -> f",
+                            "center": true
+                        }
+                    ]
+                },
+                "Mode": {
+                    "type": "Beam",
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 35],
+                            "name": "No Function",
+                            "center": true
+                        },
+                        {
+                            "range": [36, 71],
+                            "name": "Auto. Up Dim",
+                            "center": true
+                        },
+                        {
+                            "range": [72, 107],
+                            "name": "Auto. Down Dim",
+                            "center": true
+                        },
+                        {
+                            "range": [108, 143],
+                            "name": "Auto Up/Down Di",
+                            "center": true
+                        },
+                        {
+                            "range": [144, 179],
+                            "name": "Auto Colour Mix",
+                            "center": true
+                        },
+                        {
+                            "range": [180, 215],
+                            "name": "Random 3 Colour",
+                            "center": true
+                        },
+                        {
+                            "range": [216, 251],
+                            "name": "Random 7 Colour",
+                            "center": true
+                        },
+                        {
+                            "range": [252, 255],
+                            "name": "Audio Mode",
+                            "center": true
+                        }
+                    ]
+                },
+                "Dimmer": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                }
+            },
+            "modes": [
+                {
+                    "name": "7-channel Mode",
+                    "shortName": "7ch",
+                    "channels": [
+                        "Red",
+                        "Green",
+                        "Blue",
+                        "Macro",
+                        "Strobe",
+                        "Mode",
+                        "Dimmer"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Litecraft",
+            "name": "OutdoorPAR AT3-M1",
+            "shortName": "OutPAR AT3-M1",
+            "comment": "1 Channel Mode",
+            "physical": {
+                "dimensions": [300, 300, 365],
+                "weight": 7.1,
+                "power": 80
+            },
+            "availableChannels": {
+                "Colour Macro": {
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                }
+            },
+            "modes": [
+                {
+                    "name": "1-channel Mode",
+                    "shortName": "1ch",
+                    "channels": [
+                        "Colour Macro"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Litecraft",
+            "name": "OutdoorPAR AT3-M2",
+            "shortName": "OutPAR AT3-M2",
+            "comment": "2 Channel Mode",
+            "physical": {
+                "dimensions": [300, 300, 365],
+                "weight": 7.1,
+                "power": 80
+            },
+            "availableChannels": {
+                "Colour Macro": {
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Dimmer": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                }
+            },
+            "modes": [
+                {
+                    "name": "2-channel Mode",
+                    "shortName": "2ch",
+                    "channels": [
+                        "Colour Macro",
+                        "Dimmer"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Litecraft",
+            "name": "OutdoorPAR AT3-M3",
+            "shortName": "OutPAR AT3-M3",
+            "comment": "3 Channel Mode",
+            "physical": {
+                "dimensions": [300, 300, 365],
+                "weight": 7.1,
+                "power": 80
+            },
+            "availableChannels": {
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                }
+            },
+            "modes": [
+                {
+                    "name": "3-channel Mode",
+                    "shortName": "3ch",
+                    "channels": [
+                        "Red",
+                        "Green",
+                        "Blue"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Litecraft",
+            "name": "OutdoorPAR AT3-M4",
+            "shortName": "OutPAR AT3-M4",
+            "comment": "7 Channel Mode",
+            "physical": {
+                "dimensions": [300, 300, 365],
+                "weight": 7.1,
+                "power": 80
+            },
+            "availableChannels": {
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Macro": {
+                    "type": "MultiColor",
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 13],
+                            "name": "No Macro",
+                            "center": true
+                        },
+                        {
+                            "range": [16, 255],
+                            "name": "Colour Macro",
+                            "center": true
+                        }
+                    ]
+                },
+                "Strobe": {
+                    "type": "Strobe",
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [16, 255],
+                            "name": "Strobe s -> f",
+                            "center": true
+                        }
+                    ]
+                },
+                "Mode": {
+                    "type": "Beam",
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 35],
+                            "name": "No Function",
+                            "center": true
+                        },
+                        {
+                            "range": [36, 71],
+                            "name": "Auto. Up Dim",
+                            "center": true
+                        },
+                        {
+                            "range": [72, 107],
+                            "name": "Auto. Down Dim",
+                            "center": true
+                        },
+                        {
+                            "range": [108, 143],
+                            "name": "Auto Up/Down Di",
+                            "center": true
+                        },
+                        {
+                            "range": [144, 179],
+                            "name": "Auto Colour Mix",
+                            "center": true
+                        },
+                        {
+                            "range": [180, 215],
+                            "name": "Random 3 Colour",
+                            "center": true
+                        },
+                        {
+                            "range": [216, 251],
+                            "name": "Random 7 Colour",
+                            "center": true
+                        },
+                        {
+                            "range": [252, 255],
+                            "name": "Audio Mode",
+                            "center": true
+                        }
+                    ]
+                },
+                "Dimmer": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                }
+            },
+            "modes": [
+                {
+                    "name": "7-channel Mode",
+                    "shortName": "7ch",
+                    "channels": [
+                        "Red",
+                        "Green",
+                        "Blue",
+                        "Macro",
+                        "Strobe",
+                        "Mode",
+                        "Dimmer"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Litecraft",
+            "name": "PAR 64 AT3-M1",
+            "shortName": "PAR 64 AT3-M1",
+            "comment": "1 Channel Mode",
+            "physical": {
+                "dimensions": [270, 270, 321],
+                "weight": 4,
+                "power": 70
+            },
+            "availableChannels": {
+                "Colour Macro": {
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                }
+            },
+            "modes": [
+                {
+                    "name": "1-channel Mode",
+                    "shortName": "1ch",
+                    "channels": [
+                        "Colour Macro"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Litecraft",
+            "name": "PAR 64 AT3-M2",
+            "shortName": "PAR 64 AT3-M2",
+            "comment": "2 Channel Mode",
+            "physical": {
+                "dimensions": [270, 270, 321],
+                "weight": 4,
+                "power": 70
+            },
+            "availableChannels": {
+                "Colour Macro": {
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Dimmer": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                }
+            },
+            "modes": [
+                {
+                    "name": "2-channel Mode",
+                    "shortName": "2ch",
+                    "channels": [
+                        "Colour Macro",
+                        "Dimmer"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Litecraft",
+            "name": "PAR 64 AT3-M3",
+            "shortName": "PAR 64 AT3-M3",
+            "comment": "3 Channel Mode",
+            "physical": {
+                "dimensions": [270, 270, 321],
+                "weight": 4,
+                "power": 70
+            },
+            "availableChannels": {
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                }
+            },
+            "modes": [
+                {
+                    "name": "3-channel Mode",
+                    "shortName": "3ch",
+                    "channels": [
+                        "Red",
+                        "Green",
+                        "Blue"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Litecraft",
+            "name": "PAR 64 AT3-M4",
+            "shortName": "PAR 64 AT3-M4",
+            "comment": "7 Channel Mode",
+            "physical": {
+                "dimensions": [270, 270, 321],
+                "weight": 4,
+                "power": 70
+            },
+            "availableChannels": {
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Macro": {
+                    "type": "MultiColor",
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 13],
+                            "name": "No Macro",
+                            "center": true
+                        },
+                        {
+                            "range": [16, 255],
+                            "name": "Colour Macro",
+                            "center": true
+                        }
+                    ]
+                },
+                "Strobe": {
+                    "type": "Strobe",
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [16, 255],
+                            "name": "Strobe s -> f",
+                            "center": true
+                        }
+                    ]
+                },
+                "Mode": {
+                    "type": "Beam",
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 35],
+                            "name": "No Function",
+                            "center": true
+                        },
+                        {
+                            "range": [36, 71],
+                            "name": "Auto. Up Dim",
+                            "center": true
+                        },
+                        {
+                            "range": [72, 107],
+                            "name": "Auto. Down Dim",
+                            "center": true
+                        },
+                        {
+                            "range": [108, 143],
+                            "name": "Auto Up/Down Di",
+                            "center": true
+                        },
+                        {
+                            "range": [144, 179],
+                            "name": "Auto Colour Mix",
+                            "center": true
+                        },
+                        {
+                            "range": [180, 215],
+                            "name": "Random 3 Colour",
+                            "center": true
+                        },
+                        {
+                            "range": [216, 251],
+                            "name": "Random 7 Colour",
+                            "center": true
+                        },
+                        {
+                            "range": [252, 255],
+                            "name": "Audio Mode",
+                            "center": true
+                        }
+                    ]
+                },
+                "Dimmer": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                }
+            },
+            "modes": [
+                {
+                    "name": "7-channel Mode",
+                    "shortName": "7ch",
+                    "channels": [
+                        "Red",
+                        "Green",
+                        "Blue",
+                        "Macro",
+                        "Strobe",
+                        "Mode",
+                        "Dimmer"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Litecraft",
+            "name": "PowerBAR 4 DMX-M1",
+            "shortName": "PBAR 4 DMX-M1",
+            "comment": "4 Channel Mode",
+            "physical": {
+                "dimensions": [1070, 185, 160],
+                "weight": 4.8,
+                "power": 80
+            },
+            "availableChannels": {
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "White": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                }
+            },
+            "modes": [
+                {
+                    "name": "4-channel Mode",
+                    "shortName": "4ch",
+                    "channels": [
+                        "Red",
+                        "Green",
+                        "Blue",
+                        "White"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Litecraft",
+            "name": "PowerBAR 4 DMX-M2",
+            "shortName": "PBAR 4 DMX-M2",
+            "comment": "6 Channel Mode",
+            "physical": {
+                "dimensions": [1070, 185, 160],
+                "weight": 4.8,
+                "power": 80
+            },
+            "availableChannels": {
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "White": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Dimmer": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Strobe": {
+                    "type": "Strobe",
+                    "crossfade": true,
+                    "precendence": "HTP"
+                }
+            },
+            "modes": [
+                {
+                    "name": "6-channel Mode",
+                    "shortName": "6ch",
+                    "channels": [
+                        "Red",
+                        "Green",
+                        "Blue",
+                        "White",
+                        "Dimmer",
+                        "Strobe"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Litecraft",
+            "name": "PowerBAR 4 DMX-M3",
+            "shortName": "PBAR 4 DMX-M3",
+            "comment": "4 Channel Mode",
+            "physical": {
+                "dimensions": [1070, 185, 160],
+                "weight": 4.8,
+                "power": 80
+            },
+            "availableChannels": {
+                "All Colours Z1": {
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "All Colours Z2": {
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "All Colours Z3": {
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "All Colours Z4": {
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                }
+            },
+            "modes": [
+                {
+                    "name": "4-channel Mode",
+                    "shortName": "4ch",
+                    "channels": [
+                        "All Colours Z1",
+                        "All Colours Z2",
+                        "All Colours Z3",
+                        "All Colours Z4"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Litecraft",
+            "name": "PowerBAR 4 DMX-M4",
+            "shortName": "PBAR 4 DMX-M4",
+            "comment": "16 Channel Mode",
+            "physical": {
+                "dimensions": [1070, 185, 160],
+                "weight": 4.8,
+                "power": 80
+            },
+            "availableChannels": {
+                "Red 1": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green 1": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue 1": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "White 1": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Red 2": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green 2": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue 2": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "White 2": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Red 3": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green 3": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue 3": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "White 3": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Red 4": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green 4": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue 4": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "White": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                }
+            },
+            "modes": [
+                {
+                    "name": "16-channel Mode",
+                    "shortName": "16ch",
+                    "channels": [
+                        "Red 1",
+                        "Green 1",
+                        "Blue 1",
+                        "White 1",
+                        "Red 2",
+                        "Green 2",
+                        "Blue 2",
+                        "White 2",
+                        "Red 3",
+                        "Green 3",
+                        "Blue 3",
+                        "White 3",
+                        "Red 4",
+                        "Green 4",
+                        "Blue 4",
+                        "White"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Litecraft",
+            "name": "SPAR RGB Pro",
+            "shortName": "SPAR RGB Pro",
+            "comment": "7 Channel Mode",
+            "physical": {
+                "dimensions": [100, 100, 100],
+                "weight": 3,
+                "power": 46
+            },
+            "availableChannels": {
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Macro": {
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "Colour Macro",
+                            "center": true
+                        }
+                    ]
+                },
+                "Strobe": {
+                    "type": "Strobe",
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [16, 255],
+                            "name": "Strobe s -> f",
+                            "center": true
+                        }
+                    ]
+                },
+                "Mode": {
+                    "type": "Beam",
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 31],
+                            "name": "No Function",
+                            "center": true
+                        },
+                        {
+                            "range": [32, 63],
+                            "name": "Auto. Up Dim",
+                            "center": true
+                        },
+                        {
+                            "range": [64, 95],
+                            "name": "Auto. Down Dim",
+                            "center": true
+                        },
+                        {
+                            "range": [96, 127],
+                            "name": "Auto Up/Down Di",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 159],
+                            "name": "Auto Colour Mix",
+                            "center": true
+                        },
+                        {
+                            "range": [160, 191],
+                            "name": "Random 3 Colour",
+                            "center": true
+                        },
+                        {
+                            "range": [192, 223],
+                            "name": "Random 7 Colour",
+                            "center": true
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "Audio Mode",
+                            "center": true
+                        }
+                    ]
+                },
+                "Dimmer": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                }
+            },
+            "modes": [
+                {
+                    "name": "7-channel Mode",
+                    "shortName": "7ch",
+                    "channels": [
+                        "Red",
+                        "Green",
+                        "Blue",
+                        "Macro",
+                        "Strobe",
+                        "Mode",
+                        "Dimmer"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Litecraft",
+            "name": "StudioPAR AT3-M1",
+            "shortName": "SPAR AT3-M1",
+            "comment": "1 Channel Mode",
+            "physical": {
+                "dimensions": [267, 267, 321],
+                "weight": 6.6,
+                "power": 80
+            },
+            "availableChannels": {
+                "Colour Macro": {
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                }
+            },
+            "modes": [
+                {
+                    "name": "1-channel Mode",
+                    "shortName": "1ch",
+                    "channels": [
+                        "Colour Macro"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Litecraft",
+            "name": "StudioPAR AT3-M2",
+            "shortName": "SPAR AT3-M2",
+            "comment": "2 Channel Mode",
+            "physical": {
+                "dimensions": [267, 267, 321],
+                "weight": 6.6,
+                "power": 80
+            },
+            "availableChannels": {
+                "Colour Macro": {
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Dimmer": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                }
+            },
+            "modes": [
+                {
+                    "name": "2-channel Mode",
+                    "shortName": "2ch",
+                    "channels": [
+                        "Colour Macro",
+                        "Dimmer"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Litecraft",
+            "name": "StudioPAR AT3-M3",
+            "shortName": "SPAR AT3-M3",
+            "comment": "3 Channel Mode",
+            "physical": {
+                "dimensions": [267, 267, 321],
+                "weight": 6.6,
+                "power": 80
+            },
+            "availableChannels": {
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                }
+            },
+            "modes": [
+                {
+                    "name": "3-channel Mode",
+                    "shortName": "3ch",
+                    "channels": [
+                        "Red",
+                        "Green",
+                        "Blue"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Litecraft",
+            "name": "StudioPAR AT3-M4",
+            "shortName": "SPAR AT3-M4",
+            "comment": "7 Channel Mode",
+            "physical": {
+                "dimensions": [267, 267, 321],
+                "weight": 6.6,
+                "power": 80
+            },
+            "availableChannels": {
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Macro": {
+                    "type": "MultiColor",
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 13],
+                            "name": "No Macro",
+                            "center": true
+                        },
+                        {
+                            "range": [16, 255],
+                            "name": "Colour Macro",
+                            "center": true
+                        }
+                    ]
+                },
+                "Strobe": {
+                    "type": "Strobe",
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [16, 255],
+                            "name": "Strobe s -> f",
+                            "center": true
+                        }
+                    ]
+                },
+                "Mode": {
+                    "type": "Beam",
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 35],
+                            "name": "No Function",
+                            "center": true
+                        },
+                        {
+                            "range": [36, 71],
+                            "name": "Auto. Up Dim",
+                            "center": true
+                        },
+                        {
+                            "range": [72, 107],
+                            "name": "Auto. Down Dim",
+                            "center": true
+                        },
+                        {
+                            "range": [108, 143],
+                            "name": "Auto Up/Down Di",
+                            "center": true
+                        },
+                        {
+                            "range": [144, 179],
+                            "name": "Auto Colour Mix",
+                            "center": true
+                        },
+                        {
+                            "range": [180, 215],
+                            "name": "Random 3 Colour",
+                            "center": true
+                        },
+                        {
+                            "range": [216, 251],
+                            "name": "Random 7 Colour",
+                            "center": true
+                        },
+                        {
+                            "range": [252, 255],
+                            "name": "Audio Mode",
+                            "center": true
+                        }
+                    ]
+                },
+                "Dimmer": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                }
+            },
+            "modes": [
+                {
+                    "name": "7-channel Mode",
+                    "shortName": "7ch",
+                    "channels": [
+                        "Red",
+                        "Green",
+                        "Blue",
+                        "Macro",
+                        "Strobe",
+                        "Mode",
+                        "Dimmer"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Litecraft",
+            "name": "StudioPAR SW Pro",
+            "shortName": "SPAR SW Pro",
+            "comment": "3 Channel Mode",
+            "physical": {
+                "dimensions": [267, 267, 321],
+                "weight": 5,
+                "power": 80
+            },
+            "availableChannels": {
+                "Cold White": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Warm White": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Strobe": {
+                    "type": "Strobe",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 7],
+                            "name": "Open",
+                            "center": true
+                        },
+                        {
+                            "range": [8, 127],
+                            "name": "Strobe s -> f",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 255],
+                            "name": "Random Strobe",
+                            "center": true
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "3-channel Mode",
+                    "shortName": "3ch",
+                    "channels": [
+                        "Cold White",
+                        "Warm White",
+                        "Strobe"
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/fixtures/imports/ecue-MainLibrary/Lumitech.json
+++ b/fixtures/imports/ecue-MainLibrary/Lumitech.json
@@ -1,0 +1,174 @@
+{
+    "manufacturers": {
+        "Lumitech": {
+            "name": "Lumitech",
+            "website": "www.lumitech.at"
+        }
+    },
+    "fixtures": [
+        {
+            "manufacturer": "Lumitech",
+            "name": "Downlight E8 Mode 1-3",
+            "shortName": "Downlight E8 M1-3",
+            "physical": {
+                "dimensions": [100, 100, 100],
+                "weight": 0.36,
+                "power": 12
+            },
+            "availableChannels": {
+                "Operating Mode": {
+                    "type": "Beam",
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [101, 200],
+                            "name": "RPB-Mode",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [0, 100],
+                            "name": "CTC-Mode",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [201, 255],
+                            "name": "CIE-Mode",
+                            "showInMenu": false
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "ch3": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "ch4": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "crossfade": true,
+                    "precendence": "HTP"
+                }
+            },
+            "modes": [
+                {
+                    "name": "4-channel Mode",
+                    "shortName": "4ch",
+                    "channels": [
+                        "Operating Mode",
+                        "Intensity",
+                        "ch3",
+                        "ch4"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Lumitech",
+            "name": "Downlight E8 Mode CTC",
+            "shortName": "Downlight E8 M CTC",
+            "physical": {
+                "dimensions": [100, 100, 100],
+                "weight": 0.36,
+                "power": 12
+            },
+            "availableChannels": {
+                "Operating Mode": {
+                    "type": "Beam",
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [101, 200],
+                            "name": "RPB-Mode",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [0, 100],
+                            "name": "CTC-Mode",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [201, 255],
+                            "name": "CIE-Mode",
+                            "showInMenu": false
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Color Temp": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "2500 K",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [20, 20],
+                            "name": "3000 K"
+                        },
+                        {
+                            "range": [53, 53],
+                            "name": "3500 K"
+                        },
+                        {
+                            "range": [88, 88],
+                            "name": "4000 K"
+                        },
+                        {
+                            "range": [122, 122],
+                            "name": "4500 K"
+                        },
+                        {
+                            "range": [160, 160],
+                            "name": "5000 K"
+                        },
+                        {
+                            "range": [188, 188],
+                            "name": "5500 K"
+                        },
+                        {
+                            "range": [220, 220],
+                            "name": "6000 K"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "6500 K"
+                        }
+                    ]
+                },
+                "n a": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "crossfade": true,
+                    "precendence": "HTP"
+                }
+            },
+            "modes": [
+                {
+                    "name": "4-channel Mode",
+                    "shortName": "4ch",
+                    "channels": [
+                        "Operating Mode",
+                        "Intensity",
+                        "Color Temp",
+                        "n a"
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/fixtures/imports/ecue-MainLibrary/Lux.json
+++ b/fixtures/imports/ecue-MainLibrary/Lux.json
@@ -1,0 +1,386 @@
+{
+    "manufacturers": {
+        "Lux": {
+            "name": "Lux",
+            "website": "http://www.elationlighting.com/"
+        }
+    },
+    "fixtures": [
+        {
+            "manufacturer": "Lux",
+            "name": "Wash 575",
+            "shortName": "Wash 575",
+            "physical": {
+                "dimensions": [500, 500, 700],
+                "weight": 30,
+                "power": 700
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Scan Spd": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 249],
+                            "name": "speed"
+                        },
+                        {
+                            "range": [250, 252],
+                            "name": "black_change",
+                            "center": true
+                        },
+                        {
+                            "range": [253, 255],
+                            "name": "black_move",
+                            "center": true
+                        }
+                    ]
+                },
+                "Lamp": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "fan_speed"
+                        },
+                        {
+                            "range": [128, 139],
+                            "name": "lamp_on",
+                            "center": true
+                        },
+                        {
+                            "range": [140, 239],
+                            "name": "nofunction"
+                        },
+                        {
+                            "range": [230, 239],
+                            "name": "lamp_off",
+                            "center": true
+                        },
+                        {
+                            "range": [240, 255],
+                            "name": "nofunction",
+                            "center": true
+                        }
+                    ]
+                },
+                "Color": {
+                    "type": "MultiColor",
+                    "capabilities": [
+                        {
+                            "range": [0, 24],
+                            "name": "open"
+                        },
+                        {
+                            "range": [25, 49],
+                            "name": "red",
+                            "color": "#ff0000",
+                            "center": true
+                        },
+                        {
+                            "range": [50, 74],
+                            "name": "blue",
+                            "color": "#0000ff",
+                            "center": true
+                        },
+                        {
+                            "range": [75, 99],
+                            "name": "green",
+                            "color": "#00ff00",
+                            "center": true
+                        },
+                        {
+                            "range": [100, 124],
+                            "name": "orange",
+                            "color": "#ff7f00",
+                            "center": true
+                        },
+                        {
+                            "range": [125, 149],
+                            "name": "6000k",
+                            "center": true
+                        },
+                        {
+                            "range": [150, 174],
+                            "name": "3200k",
+                            "center": true
+                        },
+                        {
+                            "range": [175, 199],
+                            "name": "UV",
+                            "center": true
+                        },
+                        {
+                            "range": [200, 255],
+                            "name": "rainbow"
+                        }
+                    ]
+                },
+                "Cyan": {
+                    "type": "SingleColor",
+                    "color": "Cyan",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Magenta": {
+                    "type": "SingleColor",
+                    "color": "Magenta",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Yellow": {
+                    "type": "SingleColor",
+                    "color": "Yellow",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "CMY Spd": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Macro": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 7],
+                            "name": "No Effect"
+                        },
+                        {
+                            "range": [8, 13],
+                            "name": "macro1",
+                            "center": true
+                        },
+                        {
+                            "range": [14, 28],
+                            "name": "macro2",
+                            "center": true
+                        },
+                        {
+                            "range": [29, 43],
+                            "name": "macro3",
+                            "center": true
+                        },
+                        {
+                            "range": [44, 58],
+                            "name": "macro4",
+                            "center": true
+                        },
+                        {
+                            "range": [59, 73],
+                            "name": "macro5",
+                            "center": true
+                        },
+                        {
+                            "range": [74, 88],
+                            "name": "macro6",
+                            "center": true
+                        },
+                        {
+                            "range": [89, 103],
+                            "name": "macro7",
+                            "center": true
+                        },
+                        {
+                            "range": [104, 118],
+                            "name": "macro8",
+                            "center": true
+                        },
+                        {
+                            "range": [119, 133],
+                            "name": "macro9",
+                            "center": true
+                        },
+                        {
+                            "range": [134, 148],
+                            "name": "macro10",
+                            "center": true
+                        },
+                        {
+                            "range": [149, 163],
+                            "name": "macro11",
+                            "center": true
+                        },
+                        {
+                            "range": [164, 178],
+                            "name": "macro12",
+                            "center": true
+                        },
+                        {
+                            "range": [179, 193],
+                            "name": "macro13",
+                            "center": true
+                        },
+                        {
+                            "range": [194, 208],
+                            "name": "macro14",
+                            "center": true
+                        },
+                        {
+                            "range": [209, 223],
+                            "name": "macro15",
+                            "center": true
+                        },
+                        {
+                            "range": [224, 238],
+                            "name": "macro16",
+                            "center": true
+                        },
+                        {
+                            "range": [239, 253],
+                            "name": "macro17",
+                            "center": true
+                        },
+                        {
+                            "range": [254, 255],
+                            "name": "macro18",
+                            "center": true
+                        }
+                    ]
+                },
+                "Beam Shape": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 49],
+                            "name": "circle"
+                        },
+                        {
+                            "range": [50, 255],
+                            "name": "shaper"
+                        }
+                    ]
+                },
+                "Zoom": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Shutter": {
+                    "type": "Shutter",
+                    "defaultValue": 45,
+                    "highlightValue": 45,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 9],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [10, 40],
+                            "name": "open",
+                            "center": true
+                        },
+                        {
+                            "range": [41, 250],
+                            "name": "strobe"
+                        },
+                        {
+                            "range": [251, 255],
+                            "name": "open",
+                            "center": true
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "16-channel Mode",
+                    "shortName": "16ch",
+                    "channels": [
+                        "Pan",
+                        "Tilt",
+                        "Pan fine",
+                        "Tilt fine",
+                        "Scan Spd",
+                        "Lamp",
+                        "Color",
+                        "Cyan",
+                        "Magenta",
+                        "Yellow",
+                        "CMY Spd",
+                        "Macro",
+                        "Beam Shape",
+                        "Zoom",
+                        "Shutter",
+                        "Intensity"
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/fixtures/imports/ecue-MainLibrary/Martin.json
+++ b/fixtures/imports/ecue-MainLibrary/Martin.json
@@ -1,0 +1,26056 @@
+{
+    "manufacturers": {
+        "Martin": {
+            "name": "Martin",
+            "website": "www.martin.dk"
+        }
+    },
+    "fixtures": [
+        {
+            "manufacturer": "Martin",
+            "name": "Alien 05 m1",
+            "shortName": "Alien05m1",
+            "comment": "Mode 1",
+            "physical": {
+                "dimensions": [200, 200, 200]
+            },
+            "availableChannels": {
+                "Farbe Kanal 1": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 19],
+                            "name": "Farbe 1"
+                        },
+                        {
+                            "range": [19, 38],
+                            "name": "Farbe 2"
+                        },
+                        {
+                            "range": [38, 57],
+                            "name": "Farbe 3"
+                        },
+                        {
+                            "range": [57, 76],
+                            "name": "Farbe 4"
+                        },
+                        {
+                            "range": [76, 95],
+                            "name": "Farbe 5"
+                        },
+                        {
+                            "range": [95, 114],
+                            "name": "Farbe 6"
+                        },
+                        {
+                            "range": [114, 133],
+                            "name": "Farbe 7"
+                        },
+                        {
+                            "range": [133, 152],
+                            "name": "Farbe 8"
+                        },
+                        {
+                            "range": [153, 163],
+                            "name": "Wechsel Farbe 9"
+                        },
+                        {
+                            "range": [164, 174],
+                            "name": "Wechsel Farbe 8"
+                        },
+                        {
+                            "range": [175, 185],
+                            "name": "Wechsel Farbe 7"
+                        },
+                        {
+                            "range": [186, 196],
+                            "name": "Wechsel Farbe 6"
+                        },
+                        {
+                            "range": [197, 207],
+                            "name": "Wechsel Farbe 5"
+                        },
+                        {
+                            "range": [208, 218],
+                            "name": "Wechsel Farbe 4"
+                        },
+                        {
+                            "range": [219, 229],
+                            "name": "Wechsel Farbe 3"
+                        },
+                        {
+                            "range": [230, 240],
+                            "name": "Wechsel Farbe 2"
+                        },
+                        {
+                            "range": [241, 255],
+                            "name": "Wechsel Farbe 1"
+                        }
+                    ]
+                },
+                "Farbe Kanal 2": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 19],
+                            "name": "Farbe 1"
+                        },
+                        {
+                            "range": [19, 38],
+                            "name": "Farbe 2"
+                        },
+                        {
+                            "range": [38, 57],
+                            "name": "Farbe 3"
+                        },
+                        {
+                            "range": [57, 76],
+                            "name": "Farbe 4"
+                        },
+                        {
+                            "range": [76, 95],
+                            "name": "Farbe 5"
+                        },
+                        {
+                            "range": [95, 114],
+                            "name": "Farbe 6"
+                        },
+                        {
+                            "range": [114, 133],
+                            "name": "Farbe 7"
+                        },
+                        {
+                            "range": [133, 152],
+                            "name": "Farbe 8"
+                        },
+                        {
+                            "range": [153, 163],
+                            "name": "Wechsel Farbe 9"
+                        },
+                        {
+                            "range": [164, 174],
+                            "name": "Wechsel Farbe 8"
+                        },
+                        {
+                            "range": [175, 185],
+                            "name": "Wechsel Farbe 7"
+                        },
+                        {
+                            "range": [186, 196],
+                            "name": "Wechsel Farbe 6"
+                        },
+                        {
+                            "range": [197, 207],
+                            "name": "Wechsel Farbe 5"
+                        },
+                        {
+                            "range": [208, 218],
+                            "name": "Wechsel Farbe 4"
+                        },
+                        {
+                            "range": [219, 229],
+                            "name": "Wechsel Farbe 3"
+                        },
+                        {
+                            "range": [230, 240],
+                            "name": "Wechsel Farbe 2"
+                        },
+                        {
+                            "range": [241, 255],
+                            "name": "Wechsel Farbe 1"
+                        }
+                    ]
+                },
+                "Farbe Kanal 3": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 19],
+                            "name": "Farbe 1"
+                        },
+                        {
+                            "range": [19, 38],
+                            "name": "Farbe 2"
+                        },
+                        {
+                            "range": [38, 57],
+                            "name": "Farbe 3"
+                        },
+                        {
+                            "range": [57, 76],
+                            "name": "Farbe 4"
+                        },
+                        {
+                            "range": [76, 95],
+                            "name": "Farbe 5"
+                        },
+                        {
+                            "range": [95, 114],
+                            "name": "Farbe 6"
+                        },
+                        {
+                            "range": [114, 133],
+                            "name": "Farbe 7"
+                        },
+                        {
+                            "range": [133, 152],
+                            "name": "Farbe 8"
+                        },
+                        {
+                            "range": [153, 163],
+                            "name": "Wechsel Farbe 9"
+                        },
+                        {
+                            "range": [164, 174],
+                            "name": "Wechsel Farbe 8"
+                        },
+                        {
+                            "range": [175, 185],
+                            "name": "Wechsel Farbe 7"
+                        },
+                        {
+                            "range": [186, 196],
+                            "name": "Wechsel Farbe 6"
+                        },
+                        {
+                            "range": [197, 207],
+                            "name": "Wechsel Farbe 5"
+                        },
+                        {
+                            "range": [208, 218],
+                            "name": "Wechsel Farbe 4"
+                        },
+                        {
+                            "range": [219, 229],
+                            "name": "Wechsel Farbe 3"
+                        },
+                        {
+                            "range": [230, 240],
+                            "name": "Wechsel Farbe 2"
+                        },
+                        {
+                            "range": [241, 255],
+                            "name": "Wechsel Farbe 1"
+                        }
+                    ]
+                },
+                "Farbe Kanal 4": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 19],
+                            "name": "Farbe 1"
+                        },
+                        {
+                            "range": [19, 38],
+                            "name": "Farbe 2"
+                        },
+                        {
+                            "range": [38, 57],
+                            "name": "Farbe 3"
+                        },
+                        {
+                            "range": [57, 76],
+                            "name": "Farbe 4"
+                        },
+                        {
+                            "range": [76, 95],
+                            "name": "Farbe 5"
+                        },
+                        {
+                            "range": [95, 114],
+                            "name": "Farbe 6"
+                        },
+                        {
+                            "range": [114, 133],
+                            "name": "Farbe 7"
+                        },
+                        {
+                            "range": [133, 152],
+                            "name": "Farbe 8"
+                        },
+                        {
+                            "range": [153, 163],
+                            "name": "Wechsel Farbe 9"
+                        },
+                        {
+                            "range": [164, 174],
+                            "name": "Wechsel Farbe 8"
+                        },
+                        {
+                            "range": [175, 185],
+                            "name": "Wechsel Farbe 7"
+                        },
+                        {
+                            "range": [186, 196],
+                            "name": "Wechsel Farbe 6"
+                        },
+                        {
+                            "range": [197, 207],
+                            "name": "Wechsel Farbe 5"
+                        },
+                        {
+                            "range": [208, 218],
+                            "name": "Wechsel Farbe 4"
+                        },
+                        {
+                            "range": [219, 229],
+                            "name": "Wechsel Farbe 3"
+                        },
+                        {
+                            "range": [230, 240],
+                            "name": "Wechsel Farbe 2"
+                        },
+                        {
+                            "range": [241, 255],
+                            "name": "Wechsel Farbe 1"
+                        }
+                    ]
+                },
+                "Farbe Kanal 5": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 19],
+                            "name": "Farbe 1"
+                        },
+                        {
+                            "range": [19, 38],
+                            "name": "Farbe 2"
+                        },
+                        {
+                            "range": [38, 57],
+                            "name": "Farbe 3"
+                        },
+                        {
+                            "range": [57, 76],
+                            "name": "Farbe 4"
+                        },
+                        {
+                            "range": [76, 95],
+                            "name": "Farbe 5"
+                        },
+                        {
+                            "range": [95, 114],
+                            "name": "Farbe 6"
+                        },
+                        {
+                            "range": [114, 133],
+                            "name": "Farbe 7"
+                        },
+                        {
+                            "range": [133, 152],
+                            "name": "Farbe 8"
+                        },
+                        {
+                            "range": [153, 163],
+                            "name": "Wechsel Farbe 9"
+                        },
+                        {
+                            "range": [164, 174],
+                            "name": "Wechsel Farbe 8"
+                        },
+                        {
+                            "range": [175, 185],
+                            "name": "Wechsel Farbe 7"
+                        },
+                        {
+                            "range": [186, 196],
+                            "name": "Wechsel Farbe 6"
+                        },
+                        {
+                            "range": [197, 207],
+                            "name": "Wechsel Farbe 5"
+                        },
+                        {
+                            "range": [208, 218],
+                            "name": "Wechsel Farbe 4"
+                        },
+                        {
+                            "range": [219, 229],
+                            "name": "Wechsel Farbe 3"
+                        },
+                        {
+                            "range": [230, 240],
+                            "name": "Wechsel Farbe 2"
+                        },
+                        {
+                            "range": [241, 255],
+                            "name": "Wechsel Farbe 1"
+                        }
+                    ]
+                },
+                "Farbe Kanal 6": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 19],
+                            "name": "Farbe 1"
+                        },
+                        {
+                            "range": [19, 38],
+                            "name": "Farbe 2"
+                        },
+                        {
+                            "range": [38, 57],
+                            "name": "Farbe 3"
+                        },
+                        {
+                            "range": [57, 76],
+                            "name": "Farbe 4"
+                        },
+                        {
+                            "range": [76, 95],
+                            "name": "Farbe 5"
+                        },
+                        {
+                            "range": [95, 114],
+                            "name": "Farbe 6"
+                        },
+                        {
+                            "range": [114, 133],
+                            "name": "Farbe 7"
+                        },
+                        {
+                            "range": [133, 152],
+                            "name": "Farbe 8"
+                        },
+                        {
+                            "range": [153, 163],
+                            "name": "Wechsel Farbe 9"
+                        },
+                        {
+                            "range": [164, 174],
+                            "name": "Wechsel Farbe 8"
+                        },
+                        {
+                            "range": [175, 185],
+                            "name": "Wechsel Farbe 7"
+                        },
+                        {
+                            "range": [186, 196],
+                            "name": "Wechsel Farbe 6"
+                        },
+                        {
+                            "range": [197, 207],
+                            "name": "Wechsel Farbe 5"
+                        },
+                        {
+                            "range": [208, 218],
+                            "name": "Wechsel Farbe 4"
+                        },
+                        {
+                            "range": [219, 229],
+                            "name": "Wechsel Farbe 3"
+                        },
+                        {
+                            "range": [230, 240],
+                            "name": "Wechsel Farbe 2"
+                        },
+                        {
+                            "range": [241, 255],
+                            "name": "Wechsel Farbe 1"
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "6-channel Mode",
+                    "shortName": "6ch",
+                    "channels": [
+                        "Farbe Kanal 1",
+                        "Farbe Kanal 2",
+                        "Farbe Kanal 3",
+                        "Farbe Kanal 4",
+                        "Farbe Kanal 5",
+                        "Farbe Kanal 6"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Martin",
+            "name": "Alien 05 m2",
+            "shortName": "Alien05m2",
+            "comment": "Mode 2",
+            "physical": {
+                "dimensions": [200, 200, 200]
+            },
+            "availableChannels": {
+                "Helligkeit": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Farbe Kanal 1": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 19],
+                            "name": "Farbe 1"
+                        },
+                        {
+                            "range": [19, 38],
+                            "name": "Farbe 2"
+                        },
+                        {
+                            "range": [38, 57],
+                            "name": "Farbe 3"
+                        },
+                        {
+                            "range": [57, 76],
+                            "name": "Farbe 4"
+                        },
+                        {
+                            "range": [76, 95],
+                            "name": "Farbe 5"
+                        },
+                        {
+                            "range": [95, 114],
+                            "name": "Farbe 6"
+                        },
+                        {
+                            "range": [114, 133],
+                            "name": "Farbe 7"
+                        },
+                        {
+                            "range": [133, 152],
+                            "name": "Farbe 8"
+                        },
+                        {
+                            "range": [153, 163],
+                            "name": "Wechsel Farbe 9"
+                        },
+                        {
+                            "range": [164, 174],
+                            "name": "Wechsel Farbe 8"
+                        },
+                        {
+                            "range": [175, 185],
+                            "name": "Wechsel Farbe 7"
+                        },
+                        {
+                            "range": [186, 196],
+                            "name": "Wechsel Farbe 6"
+                        },
+                        {
+                            "range": [197, 207],
+                            "name": "Wechsel Farbe 5"
+                        },
+                        {
+                            "range": [208, 218],
+                            "name": "Wechsel Farbe 4"
+                        },
+                        {
+                            "range": [219, 229],
+                            "name": "Wechsel Farbe 3"
+                        },
+                        {
+                            "range": [230, 240],
+                            "name": "Wechsel Farbe 2"
+                        },
+                        {
+                            "range": [241, 255],
+                            "name": "Wechsel Farbe 1"
+                        }
+                    ]
+                },
+                "Farbe Kanal 2": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 19],
+                            "name": "Farbe 1"
+                        },
+                        {
+                            "range": [19, 38],
+                            "name": "Farbe 2"
+                        },
+                        {
+                            "range": [38, 57],
+                            "name": "Farbe 3"
+                        },
+                        {
+                            "range": [57, 76],
+                            "name": "Farbe 4"
+                        },
+                        {
+                            "range": [76, 95],
+                            "name": "Farbe 5"
+                        },
+                        {
+                            "range": [95, 114],
+                            "name": "Farbe 6"
+                        },
+                        {
+                            "range": [114, 133],
+                            "name": "Farbe 7"
+                        },
+                        {
+                            "range": [133, 152],
+                            "name": "Farbe 8"
+                        },
+                        {
+                            "range": [153, 163],
+                            "name": "Wechsel Farbe 9"
+                        },
+                        {
+                            "range": [164, 174],
+                            "name": "Wechsel Farbe 8"
+                        },
+                        {
+                            "range": [175, 185],
+                            "name": "Wechsel Farbe 7"
+                        },
+                        {
+                            "range": [186, 196],
+                            "name": "Wechsel Farbe 6"
+                        },
+                        {
+                            "range": [197, 207],
+                            "name": "Wechsel Farbe 5"
+                        },
+                        {
+                            "range": [208, 218],
+                            "name": "Wechsel Farbe 4"
+                        },
+                        {
+                            "range": [219, 229],
+                            "name": "Wechsel Farbe 3"
+                        },
+                        {
+                            "range": [230, 240],
+                            "name": "Wechsel Farbe 2"
+                        },
+                        {
+                            "range": [241, 255],
+                            "name": "Wechsel Farbe 1"
+                        }
+                    ]
+                },
+                "Farbe Kanal 3": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 19],
+                            "name": "Farbe 1"
+                        },
+                        {
+                            "range": [19, 38],
+                            "name": "Farbe 2"
+                        },
+                        {
+                            "range": [38, 57],
+                            "name": "Farbe 3"
+                        },
+                        {
+                            "range": [57, 76],
+                            "name": "Farbe 4"
+                        },
+                        {
+                            "range": [76, 95],
+                            "name": "Farbe 5"
+                        },
+                        {
+                            "range": [95, 114],
+                            "name": "Farbe 6"
+                        },
+                        {
+                            "range": [114, 133],
+                            "name": "Farbe 7"
+                        },
+                        {
+                            "range": [133, 152],
+                            "name": "Farbe 8"
+                        },
+                        {
+                            "range": [153, 163],
+                            "name": "Wechsel Farbe 9"
+                        },
+                        {
+                            "range": [164, 174],
+                            "name": "Wechsel Farbe 8"
+                        },
+                        {
+                            "range": [175, 185],
+                            "name": "Wechsel Farbe 7"
+                        },
+                        {
+                            "range": [186, 196],
+                            "name": "Wechsel Farbe 6"
+                        },
+                        {
+                            "range": [197, 207],
+                            "name": "Wechsel Farbe 5"
+                        },
+                        {
+                            "range": [208, 218],
+                            "name": "Wechsel Farbe 4"
+                        },
+                        {
+                            "range": [219, 229],
+                            "name": "Wechsel Farbe 3"
+                        },
+                        {
+                            "range": [230, 240],
+                            "name": "Wechsel Farbe 2"
+                        },
+                        {
+                            "range": [241, 255],
+                            "name": "Wechsel Farbe 1"
+                        }
+                    ]
+                },
+                "Farbe Kanal 4": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 19],
+                            "name": "Farbe 1"
+                        },
+                        {
+                            "range": [19, 38],
+                            "name": "Farbe 2"
+                        },
+                        {
+                            "range": [38, 57],
+                            "name": "Farbe 3"
+                        },
+                        {
+                            "range": [57, 76],
+                            "name": "Farbe 4"
+                        },
+                        {
+                            "range": [76, 95],
+                            "name": "Farbe 5"
+                        },
+                        {
+                            "range": [95, 114],
+                            "name": "Farbe 6"
+                        },
+                        {
+                            "range": [114, 133],
+                            "name": "Farbe 7"
+                        },
+                        {
+                            "range": [133, 152],
+                            "name": "Farbe 8"
+                        },
+                        {
+                            "range": [153, 163],
+                            "name": "Wechsel Farbe 9"
+                        },
+                        {
+                            "range": [164, 174],
+                            "name": "Wechsel Farbe 8"
+                        },
+                        {
+                            "range": [175, 185],
+                            "name": "Wechsel Farbe 7"
+                        },
+                        {
+                            "range": [186, 196],
+                            "name": "Wechsel Farbe 6"
+                        },
+                        {
+                            "range": [197, 207],
+                            "name": "Wechsel Farbe 5"
+                        },
+                        {
+                            "range": [208, 218],
+                            "name": "Wechsel Farbe 4"
+                        },
+                        {
+                            "range": [219, 229],
+                            "name": "Wechsel Farbe 3"
+                        },
+                        {
+                            "range": [230, 240],
+                            "name": "Wechsel Farbe 2"
+                        },
+                        {
+                            "range": [241, 255],
+                            "name": "Wechsel Farbe 1"
+                        }
+                    ]
+                },
+                "Farbe Kanal 5": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 19],
+                            "name": "Farbe 1"
+                        },
+                        {
+                            "range": [19, 38],
+                            "name": "Farbe 2"
+                        },
+                        {
+                            "range": [38, 57],
+                            "name": "Farbe 3"
+                        },
+                        {
+                            "range": [57, 76],
+                            "name": "Farbe 4"
+                        },
+                        {
+                            "range": [76, 95],
+                            "name": "Farbe 5"
+                        },
+                        {
+                            "range": [95, 114],
+                            "name": "Farbe 6"
+                        },
+                        {
+                            "range": [114, 133],
+                            "name": "Farbe 7"
+                        },
+                        {
+                            "range": [133, 152],
+                            "name": "Farbe 8"
+                        },
+                        {
+                            "range": [153, 163],
+                            "name": "Wechsel Farbe 9"
+                        },
+                        {
+                            "range": [164, 174],
+                            "name": "Wechsel Farbe 8"
+                        },
+                        {
+                            "range": [175, 185],
+                            "name": "Wechsel Farbe 7"
+                        },
+                        {
+                            "range": [186, 196],
+                            "name": "Wechsel Farbe 6"
+                        },
+                        {
+                            "range": [197, 207],
+                            "name": "Wechsel Farbe 5"
+                        },
+                        {
+                            "range": [208, 218],
+                            "name": "Wechsel Farbe 4"
+                        },
+                        {
+                            "range": [219, 229],
+                            "name": "Wechsel Farbe 3"
+                        },
+                        {
+                            "range": [230, 240],
+                            "name": "Wechsel Farbe 2"
+                        },
+                        {
+                            "range": [241, 255],
+                            "name": "Wechsel Farbe 1"
+                        }
+                    ]
+                },
+                "Farbe Kanal 6": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 19],
+                            "name": "Farbe 1"
+                        },
+                        {
+                            "range": [19, 38],
+                            "name": "Farbe 2"
+                        },
+                        {
+                            "range": [38, 57],
+                            "name": "Farbe 3"
+                        },
+                        {
+                            "range": [57, 76],
+                            "name": "Farbe 4"
+                        },
+                        {
+                            "range": [76, 95],
+                            "name": "Farbe 5"
+                        },
+                        {
+                            "range": [95, 114],
+                            "name": "Farbe 6"
+                        },
+                        {
+                            "range": [114, 133],
+                            "name": "Farbe 7"
+                        },
+                        {
+                            "range": [133, 152],
+                            "name": "Farbe 8"
+                        },
+                        {
+                            "range": [153, 163],
+                            "name": "Wechsel Farbe 9"
+                        },
+                        {
+                            "range": [164, 174],
+                            "name": "Wechsel Farbe 8"
+                        },
+                        {
+                            "range": [175, 185],
+                            "name": "Wechsel Farbe 7"
+                        },
+                        {
+                            "range": [186, 196],
+                            "name": "Wechsel Farbe 6"
+                        },
+                        {
+                            "range": [197, 207],
+                            "name": "Wechsel Farbe 5"
+                        },
+                        {
+                            "range": [208, 218],
+                            "name": "Wechsel Farbe 4"
+                        },
+                        {
+                            "range": [219, 229],
+                            "name": "Wechsel Farbe 3"
+                        },
+                        {
+                            "range": [230, 240],
+                            "name": "Wechsel Farbe 2"
+                        },
+                        {
+                            "range": [241, 255],
+                            "name": "Wechsel Farbe 1"
+                        }
+                    ]
+                },
+                "Speed": {
+                    "type": "Speed",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 2],
+                            "name": "tracking"
+                        },
+                        {
+                            "range": [3, 255],
+                            "name": "speed"
+                        }
+                    ]
+                },
+                "Reset": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 250],
+                            "name": "Reserviert"
+                        },
+                        {
+                            "range": [251, 255],
+                            "name": "System initiali"
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "9-channel Mode",
+                    "shortName": "9ch",
+                    "channels": [
+                        "Helligkeit",
+                        "Farbe Kanal 1",
+                        "Farbe Kanal 2",
+                        "Farbe Kanal 3",
+                        "Farbe Kanal 4",
+                        "Farbe Kanal 5",
+                        "Farbe Kanal 6",
+                        "Speed",
+                        "Reset"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Martin",
+            "name": "Alien02",
+            "shortName": "Alien02",
+            "physical": {
+                "dimensions": [200, 200, 200]
+            },
+            "availableChannels": {
+                "Control": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 207],
+                            "name": "reserved"
+                        },
+                        {
+                            "range": [208, 217],
+                            "name": "reset",
+                            "center": true
+                        },
+                        {
+                            "range": [218, 227],
+                            "name": "reserved"
+                        },
+                        {
+                            "range": [228, 237],
+                            "name": "lamp_on",
+                            "center": true
+                        },
+                        {
+                            "range": [238, 247],
+                            "name": "reserved"
+                        },
+                        {
+                            "range": [248, 255],
+                            "name": "lamp_off",
+                            "center": true
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Cyan": {
+                    "type": "SingleColor",
+                    "color": "Cyan",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Magenta": {
+                    "type": "SingleColor",
+                    "color": "Magenta",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Yellow": {
+                    "type": "SingleColor",
+                    "color": "Yellow",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "color": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 14],
+                            "name": "off"
+                        },
+                        {
+                            "range": [15, 74],
+                            "name": "CMY_rnd"
+                        },
+                        {
+                            "range": [75, 134],
+                            "name": "MY_rnd"
+                        },
+                        {
+                            "range": [135, 194],
+                            "name": "CM_rnd"
+                        },
+                        {
+                            "range": [195, 214],
+                            "name": "CY_rnd"
+                        }
+                    ]
+                },
+                "Speed": {
+                    "type": "Speed",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 2],
+                            "name": "tracking"
+                        },
+                        {
+                            "range": [3, 245],
+                            "name": "speed"
+                        },
+                        {
+                            "range": [252, 255],
+                            "name": "fast"
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "7-channel Mode",
+                    "shortName": "7ch",
+                    "channels": [
+                        "Control",
+                        "Intensity",
+                        "Cyan",
+                        "Magenta",
+                        "Yellow",
+                        "color",
+                        "Speed"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Martin",
+            "name": "Atomic 3000",
+            "shortName": "A3000",
+            "comment": "cd",
+            "physical": {
+                "dimensions": [425, 245, 240],
+                "weight": 7.5
+            },
+            "availableChannels": {
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 5],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [6, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Flash Lenght": {
+                    "type": "Beam",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "0 - 260ms"
+                        }
+                    ]
+                },
+                "Flash Rate": {
+                    "type": "Beam",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [255, 0],
+                            "name": "5 Hz - 25 Hz"
+                        }
+                    ]
+                },
+                "Effects": {
+                    "type": "Effect",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 5],
+                            "name": "idle"
+                        },
+                        {
+                            "range": [6, 42],
+                            "name": "ramp up"
+                        },
+                        {
+                            "range": [43, 85],
+                            "name": "ramp down"
+                        },
+                        {
+                            "range": [86, 128],
+                            "name": "ramp up down"
+                        },
+                        {
+                            "range": [129, 171],
+                            "name": "random"
+                        },
+                        {
+                            "range": [172, 214],
+                            "name": "electrical Stor"
+                        },
+                        {
+                            "range": [215, 255],
+                            "name": "single flash"
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "4-channel Mode",
+                    "shortName": "4ch",
+                    "channels": [
+                        "Intensity",
+                        "Flash Lenght",
+                        "Flash Rate",
+                        "Effects"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Martin",
+            "name": "CX-2",
+            "shortName": "CX-2",
+            "physical": {
+                "dimensions": [200, 200, 200]
+            },
+            "availableChannels": {
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 154,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 4],
+                            "name": "off"
+                        },
+                        {
+                            "range": [5, 154],
+                            "name": "%"
+                        },
+                        {
+                            "range": [155, 169],
+                            "name": "full"
+                        },
+                        {
+                            "range": [170, 229],
+                            "name": "strobe"
+                        },
+                        {
+                            "range": [230, 239],
+                            "name": "music"
+                        },
+                        {
+                            "range": [240, 249],
+                            "name": "auto"
+                        },
+                        {
+                            "range": [250, 255],
+                            "name": "reset"
+                        }
+                    ]
+                },
+                "Color": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 5],
+                            "name": "open"
+                        },
+                        {
+                            "range": [12, 17],
+                            "name": "light_blue",
+                            "center": true
+                        },
+                        {
+                            "range": [24, 29],
+                            "name": "fern_green",
+                            "center": true
+                        },
+                        {
+                            "range": [36, 41],
+                            "name": "red",
+                            "color": "#ff0000",
+                            "center": true
+                        },
+                        {
+                            "range": [48, 53],
+                            "name": "yellow",
+                            "color": "#ffff00",
+                            "center": true
+                        },
+                        {
+                            "range": [60, 65],
+                            "name": "magenta",
+                            "color": "#ca1f7b",
+                            "center": true
+                        },
+                        {
+                            "range": [72, 77],
+                            "name": "medium_blue",
+                            "center": true
+                        },
+                        {
+                            "range": [84, 89],
+                            "name": "deep_orange",
+                            "center": true
+                        },
+                        {
+                            "range": [96, 101],
+                            "name": "light_green",
+                            "center": true
+                        },
+                        {
+                            "range": [108, 113],
+                            "name": "cyan",
+                            "color": "#00ffff",
+                            "center": true
+                        },
+                        {
+                            "range": [120, 125],
+                            "name": "pink",
+                            "color": "#ffc0cb",
+                            "center": true
+                        },
+                        {
+                            "range": [132, 137],
+                            "name": "blue",
+                            "color": "#0000ff",
+                            "center": true
+                        },
+                        {
+                            "range": [144, 149],
+                            "name": "amber",
+                            "color": "#ffbf00",
+                            "center": true
+                        },
+                        {
+                            "range": [156, 161],
+                            "name": "primary_red",
+                            "center": true
+                        },
+                        {
+                            "range": [168, 173],
+                            "name": "primary_green",
+                            "center": true
+                        },
+                        {
+                            "range": [180, 185],
+                            "name": "orange",
+                            "color": "#ff7f00",
+                            "center": true
+                        },
+                        {
+                            "range": [192, 197],
+                            "name": "split1",
+                            "center": true
+                        },
+                        {
+                            "range": [204, 209],
+                            "name": "split2",
+                            "center": true
+                        },
+                        {
+                            "range": [210, 255],
+                            "name": "random",
+                            "center": true
+                        }
+                    ]
+                },
+                "Gobo": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 11],
+                            "name": "open"
+                        },
+                        {
+                            "range": [12, 23],
+                            "name": "frost",
+                            "color": "#edf5dd",
+                            "center": true
+                        },
+                        {
+                            "range": [24, 35],
+                            "name": "virus",
+                            "center": true
+                        },
+                        {
+                            "range": [36, 47],
+                            "name": "dot_circle",
+                            "center": true
+                        },
+                        {
+                            "range": [48, 59],
+                            "name": "spokes",
+                            "center": true
+                        },
+                        {
+                            "range": [60, 71],
+                            "name": "atomic",
+                            "center": true
+                        },
+                        {
+                            "range": [72, 83],
+                            "name": "dot_cross",
+                            "center": true
+                        },
+                        {
+                            "range": [84, 95],
+                            "name": "dot_cone",
+                            "center": true
+                        },
+                        {
+                            "range": [96, 107],
+                            "name": "holes3",
+                            "center": true
+                        },
+                        {
+                            "range": [108, 119],
+                            "name": "clouds2",
+                            "center": true
+                        },
+                        {
+                            "range": [120, 131],
+                            "name": "highway",
+                            "center": true
+                        },
+                        {
+                            "range": [132, 143],
+                            "name": "worms3",
+                            "center": true
+                        },
+                        {
+                            "range": [144, 155],
+                            "name": "XL_iris",
+                            "center": true
+                        },
+                        {
+                            "range": [156, 167],
+                            "name": "L_iris",
+                            "center": true
+                        },
+                        {
+                            "range": [168, 179],
+                            "name": "M_iris",
+                            "center": true
+                        },
+                        {
+                            "range": [180, 191],
+                            "name": "S_iris",
+                            "center": true
+                        },
+                        {
+                            "range": [192, 203],
+                            "name": "XS_iris",
+                            "center": true
+                        },
+                        {
+                            "range": [204, 215],
+                            "name": "closed",
+                            "center": true
+                        },
+                        {
+                            "range": [216, 255],
+                            "name": "random"
+                        }
+                    ]
+                },
+                "speed": {
+                    "type": "Speed",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 2],
+                            "name": "tracking"
+                        },
+                        {
+                            "range": [3, 255],
+                            "name": "speed"
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "4-channel Mode",
+                    "shortName": "4ch",
+                    "channels": [
+                        "Intensity",
+                        "Color",
+                        "Gobo",
+                        "speed"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Martin",
+            "name": "Ext600",
+            "shortName": "Exterior600",
+            "physical": {
+                "dimensions": [200, 200, 200]
+            },
+            "availableChannels": {
+                "Shutter": {
+                    "type": "Shutter",
+                    "capabilities": [
+                        {
+                            "range": [0, 19],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [20, 49],
+                            "name": "open"
+                        },
+                        {
+                            "range": [50, 112],
+                            "name": "strobe"
+                        },
+                        {
+                            "range": [113, 127],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [128, 187],
+                            "name": "random"
+                        },
+                        {
+                            "range": [188, 207],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [208, 217],
+                            "name": "reset"
+                        },
+                        {
+                            "range": [218, 227],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [228, 237],
+                            "name": "lamp_on"
+                        },
+                        {
+                            "range": [238, 247],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [248, 255],
+                            "name": "lamp_off"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Cyan": {
+                    "type": "SingleColor",
+                    "color": "Cyan",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Magenta": {
+                    "type": "SingleColor",
+                    "color": "Magenta",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Yellow": {
+                    "type": "SingleColor",
+                    "color": "Yellow",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Color": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 39],
+                            "name": "white",
+                            "color": "#ffffff"
+                        },
+                        {
+                            "range": [40, 79],
+                            "name": "color1"
+                        },
+                        {
+                            "range": [80, 119],
+                            "name": "color2"
+                        },
+                        {
+                            "range": [120, 160],
+                            "name": "color3"
+                        },
+                        {
+                            "range": [161, 165],
+                            "name": "color4"
+                        },
+                        {
+                            "range": [166, 170],
+                            "name": "color3"
+                        },
+                        {
+                            "range": [171, 175],
+                            "name": "color2"
+                        },
+                        {
+                            "range": [176, 180],
+                            "name": "color1"
+                        },
+                        {
+                            "range": [181, 185],
+                            "name": "white",
+                            "color": "#ffffff"
+                        },
+                        {
+                            "range": [186, 214],
+                            "name": "rotationcw"
+                        },
+                        {
+                            "range": [215, 243],
+                            "name": "rotationccw"
+                        },
+                        {
+                            "range": [244, 255],
+                            "name": "CMY_rnd"
+                        }
+                    ]
+                },
+                "Beam": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 2],
+                            "name": "open"
+                        },
+                        {
+                            "range": [3, 170],
+                            "name": "shaper"
+                        },
+                        {
+                            "range": [171, 255],
+                            "name": "frost",
+                            "color": "#edf5dd"
+                        }
+                    ]
+                },
+                "Zoom": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Speed": {
+                    "type": "Speed",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 2],
+                            "name": "tracking"
+                        },
+                        {
+                            "range": [3, 245],
+                            "name": "speed"
+                        },
+                        {
+                            "range": [246, 248],
+                            "name": "shortcuts_off"
+                        },
+                        {
+                            "range": [249, 251],
+                            "name": "shortcuts_on"
+                        },
+                        {
+                            "range": [252, 255],
+                            "name": "fast"
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "9-channel Mode",
+                    "shortName": "9ch",
+                    "channels": [
+                        "Shutter",
+                        "Intensity",
+                        "Cyan",
+                        "Magenta",
+                        "Yellow",
+                        "Color",
+                        "Beam",
+                        "Zoom",
+                        "Speed"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Martin",
+            "name": "Exterior 200",
+            "shortName": "Ext200",
+            "physical": {
+                "dimensions": [200, 200, 200]
+            },
+            "availableChannels": {
+                "Control": {
+                    "type": "Beam",
+                    "defaultValue": 223,
+                    "highlightValue": 223,
+                    "capabilities": [
+                        {
+                            "range": [0, 207],
+                            "name": "Reserved"
+                        },
+                        {
+                            "range": [208, 217],
+                            "name": "Reset"
+                        },
+                        {
+                            "range": [218, 227],
+                            "name": "Reserved"
+                        },
+                        {
+                            "range": [228, 237],
+                            "name": "Lamp.on",
+                            "center": true
+                        },
+                        {
+                            "range": [238, 247],
+                            "name": "Reserved"
+                        },
+                        {
+                            "range": [248, 255],
+                            "name": "Lamp.off",
+                            "center": true
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Cyan": {
+                    "type": "SingleColor",
+                    "color": "Cyan",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Magenta": {
+                    "type": "SingleColor",
+                    "color": "Magenta",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Yellow": {
+                    "type": "SingleColor",
+                    "color": "Yellow",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Colormix": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 14],
+                            "name": "off"
+                        },
+                        {
+                            "range": [15, 74],
+                            "name": "CMY"
+                        },
+                        {
+                            "range": [75, 134],
+                            "name": "MY"
+                        },
+                        {
+                            "range": [135, 194],
+                            "name": "CM"
+                        },
+                        {
+                            "range": [195, 255],
+                            "name": "CY"
+                        }
+                    ]
+                },
+                "Speed": {
+                    "type": "Speed",
+                    "capabilities": [
+                        {
+                            "range": [0, 2],
+                            "name": "tracking"
+                        },
+                        {
+                            "range": [3, 245],
+                            "name": "speed"
+                        },
+                        {
+                            "range": [246, 251],
+                            "name": "reserved"
+                        },
+                        {
+                            "range": [252, 255],
+                            "name": "fast"
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "7-channel Mode",
+                    "shortName": "7ch",
+                    "channels": [
+                        "Control",
+                        "Intensity",
+                        "Cyan",
+                        "Magenta",
+                        "Yellow",
+                        "Colormix",
+                        "Speed"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Martin",
+            "name": "Exterior 600 Compact",
+            "shortName": "Ext600C",
+            "comment": "Compact Version",
+            "physical": {
+                "dimensions": [200, 200, 200]
+            },
+            "availableChannels": {
+                "Light": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 19],
+                            "name": "Blackout"
+                        },
+                        {
+                            "range": [20, 49],
+                            "name": "Light"
+                        },
+                        {
+                            "range": [50, 127],
+                            "name": "white",
+                            "color": "#ffffff"
+                        },
+                        {
+                            "range": [128, 187],
+                            "name": "color_rnd"
+                        },
+                        {
+                            "range": [188, 207],
+                            "name": "white",
+                            "color": "#ffffff"
+                        },
+                        {
+                            "range": [208, 217],
+                            "name": "reset"
+                        },
+                        {
+                            "range": [218, 227],
+                            "name": "white",
+                            "color": "#ffffff"
+                        },
+                        {
+                            "range": [228, 237],
+                            "name": "lamp_on"
+                        },
+                        {
+                            "range": [238, 247],
+                            "name": "white",
+                            "color": "#ffffff"
+                        },
+                        {
+                            "range": [248, 255],
+                            "name": "lamp_off"
+                        }
+                    ]
+                },
+                "Cyan": {
+                    "type": "SingleColor",
+                    "color": "Cyan",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Magenta": {
+                    "type": "SingleColor",
+                    "color": "Magenta",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Yellow": {
+                    "type": "SingleColor",
+                    "color": "Yellow",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Speed": {
+                    "type": "Speed",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 2],
+                            "name": "tracking"
+                        },
+                        {
+                            "range": [3, 245],
+                            "name": "speed"
+                        },
+                        {
+                            "range": [246, 248],
+                            "name": "shortcuts_off"
+                        },
+                        {
+                            "range": [249, 251],
+                            "name": "shortcuts_on"
+                        },
+                        {
+                            "range": [252, 255],
+                            "name": "fast"
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "5-channel Mode",
+                    "shortName": "5ch",
+                    "channels": [
+                        "Light",
+                        "Cyan",
+                        "Magenta",
+                        "Yellow",
+                        "Speed"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Martin",
+            "name": "FiberSource CMY150",
+            "shortName": "FS150",
+            "physical": {
+                "dimensions": [200, 200, 200]
+            },
+            "availableChannels": {
+                "Control": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 207],
+                            "name": "nofunction"
+                        },
+                        {
+                            "range": [208, 217],
+                            "name": "reset"
+                        },
+                        {
+                            "range": [218, 227],
+                            "name": "reserved"
+                        },
+                        {
+                            "range": [228, 237],
+                            "name": "lamp on"
+                        },
+                        {
+                            "range": [238, 247],
+                            "name": "reserved"
+                        },
+                        {
+                            "range": [248, 255],
+                            "name": "lamp off"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Cyan": {
+                    "type": "SingleColor",
+                    "color": "Cyan",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Magenta": {
+                    "type": "SingleColor",
+                    "color": "Magenta",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Yellow": {
+                    "type": "SingleColor",
+                    "color": "Yellow",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Random": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 14],
+                            "name": "off"
+                        },
+                        {
+                            "range": [15, 34],
+                            "name": "CMY slow"
+                        },
+                        {
+                            "range": [35, 54],
+                            "name": "CMY medium"
+                        },
+                        {
+                            "range": [55, 74],
+                            "name": "CMY fast"
+                        },
+                        {
+                            "range": [75, 94],
+                            "name": "MY slow"
+                        },
+                        {
+                            "range": [95, 114],
+                            "name": "MY medium"
+                        },
+                        {
+                            "range": [115, 134],
+                            "name": "MY fast"
+                        },
+                        {
+                            "range": [135, 154],
+                            "name": "CM slow"
+                        },
+                        {
+                            "range": [155, 174],
+                            "name": "CM medium"
+                        },
+                        {
+                            "range": [175, 194],
+                            "name": "CM fast"
+                        },
+                        {
+                            "range": [195, 214],
+                            "name": "CY slow"
+                        },
+                        {
+                            "range": [215, 234],
+                            "name": "CY medium"
+                        },
+                        {
+                            "range": [235, 255],
+                            "name": "CY fast"
+                        }
+                    ]
+                },
+                "Speed": {
+                    "type": "Speed",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 2],
+                            "name": "Tracking"
+                        },
+                        {
+                            "range": [3, 245],
+                            "name": "Speed"
+                        },
+                        {
+                            "range": [246, 251],
+                            "name": "reserved"
+                        },
+                        {
+                            "range": [252, 255],
+                            "name": "Fast"
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "7-channel Mode",
+                    "shortName": "7ch",
+                    "channels": [
+                        "Control",
+                        "Intensity",
+                        "Cyan",
+                        "Magenta",
+                        "Yellow",
+                        "Random",
+                        "Speed"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Martin",
+            "name": "Imagescan",
+            "shortName": "ImageSc",
+            "comment": "Mode 0",
+            "physical": {
+                "dimensions": [200, 200, 200]
+            },
+            "availableChannels": {
+                "Shutter": {
+                    "type": "Shutter",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 9],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [10, 139],
+                            "name": "open"
+                        },
+                        {
+                            "range": [203, 235],
+                            "name": "reset"
+                        },
+                        {
+                            "range": [236, 252],
+                            "name": "lamp.on"
+                        },
+                        {
+                            "range": [253, 255],
+                            "name": "lamp.off"
+                        }
+                    ]
+                },
+                "Focus": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Rotation": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 85],
+                            "name": "CW"
+                        },
+                        {
+                            "range": [86, 90],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [91, 177],
+                            "name": "CCW"
+                        },
+                        {
+                            "range": [178, 199],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [200, 249],
+                            "name": "orientation"
+                        },
+                        {
+                            "range": [250, 255],
+                            "name": "nofunction"
+                        },
+                        {
+                            "range": [0, 0],
+                            "name": "New Range"
+                        }
+                    ]
+                },
+                "Position fine": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 244,
+                    "highlightValue": 244,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "speed": {
+                    "type": "Speed",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 4],
+                            "name": "tracking"
+                        },
+                        {
+                            "range": [5, 255],
+                            "name": "speed"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "9-channel Mode",
+                    "shortName": "9ch",
+                    "channels": [
+                        "Shutter",
+                        "Focus",
+                        "Rotation",
+                        "Position fine",
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "speed"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Martin",
+            "name": "Inground 200 6 Color",
+            "shortName": "Inground 200 6 Color",
+            "physical": {
+                "dimensions": [200, 200, 200]
+            },
+            "availableChannels": {
+                "Control": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 207],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [208, 217],
+                            "name": "Reset"
+                        },
+                        {
+                            "range": [218, 227],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [228, 237],
+                            "name": "Lamp on",
+                            "center": true
+                        },
+                        {
+                            "range": [238, 247],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [248, 255],
+                            "name": "Lamp off"
+                        }
+                    ]
+                },
+                "Dimmer": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Color": {
+                    "type": "MultiColor",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 22],
+                            "name": "Color 1"
+                        },
+                        {
+                            "range": [23, 45],
+                            "name": "Color 1"
+                        },
+                        {
+                            "range": [46, 68],
+                            "name": "Color 2"
+                        },
+                        {
+                            "range": [69, 92],
+                            "name": "Color 2"
+                        },
+                        {
+                            "range": [93, 115],
+                            "name": "Color 3"
+                        },
+                        {
+                            "range": [116, 138],
+                            "name": "Color 3"
+                        },
+                        {
+                            "range": [139, 161],
+                            "name": "Color 4"
+                        },
+                        {
+                            "range": [162, 185],
+                            "name": "Color 4"
+                        },
+                        {
+                            "range": [186, 208],
+                            "name": "Color 5"
+                        },
+                        {
+                            "range": [209, 231],
+                            "name": "Color 5"
+                        },
+                        {
+                            "range": [232, 255],
+                            "name": "Open"
+                        }
+                    ]
+                },
+                "Speed": {
+                    "type": "Speed",
+                    "capabilities": [
+                        {
+                            "range": [0, 2],
+                            "name": "Tracking"
+                        },
+                        {
+                            "range": [3, 245],
+                            "name": "Fast->slow"
+                        },
+                        {
+                            "range": [246, 255],
+                            "name": "Fast",
+                            "center": true
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "4-channel Mode",
+                    "shortName": "4ch",
+                    "channels": [
+                        "Control",
+                        "Dimmer",
+                        "Color",
+                        "Speed"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Martin",
+            "name": "Inground 200 CMY",
+            "shortName": "Inground 200 CMY",
+            "physical": {
+                "dimensions": [200, 200, 200]
+            },
+            "availableChannels": {
+                "Control": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 207],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [208, 217],
+                            "name": "Reset"
+                        },
+                        {
+                            "range": [218, 227],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [228, 237],
+                            "name": "Lamp on",
+                            "center": true
+                        },
+                        {
+                            "range": [238, 247],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [248, 255],
+                            "name": "Lamp off"
+                        }
+                    ]
+                },
+                "Dimmer": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Cyan": {
+                    "type": "SingleColor",
+                    "color": "Cyan",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Magenta": {
+                    "type": "SingleColor",
+                    "color": "Magenta",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Yellow": {
+                    "type": "SingleColor",
+                    "color": "Yellow",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Speed": {
+                    "type": "Speed",
+                    "capabilities": [
+                        {
+                            "range": [0, 2],
+                            "name": "Tracking"
+                        },
+                        {
+                            "range": [3, 245],
+                            "name": "Fast->slow"
+                        },
+                        {
+                            "range": [246, 255],
+                            "name": "Fast",
+                            "center": true
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "6-channel Mode",
+                    "shortName": "6ch",
+                    "channels": [
+                        "Control",
+                        "Dimmer",
+                        "Cyan",
+                        "Magenta",
+                        "Yellow",
+                        "Speed"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Martin",
+            "name": "Mac 101 Basic",
+            "shortName": "Mac101Basic",
+            "comment": "LED Movinghead",
+            "physical": {
+                "dimensions": [241, 241, 304],
+                "weight": 3.7,
+                "power": 123
+            },
+            "availableChannels": {
+                "Shutter Effect": {
+                    "type": "Effect",
+                    "defaultValue": 30,
+                    "highlightValue": 30,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 19],
+                            "name": "Closed",
+                            "center": true
+                        },
+                        {
+                            "range": [20, 49],
+                            "name": "Open",
+                            "center": true
+                        },
+                        {
+                            "range": [50, 64],
+                            "name": "Strobe F-S"
+                        },
+                        {
+                            "range": [65, 69],
+                            "name": "Open",
+                            "center": true
+                        },
+                        {
+                            "range": [70, 84],
+                            "name": "Pulse Open F-S"
+                        },
+                        {
+                            "range": [85, 89],
+                            "name": "Open",
+                            "center": true
+                        },
+                        {
+                            "range": [90, 104],
+                            "name": "Pulse Close F-S"
+                        },
+                        {
+                            "range": [105, 109],
+                            "name": "Open",
+                            "center": true
+                        },
+                        {
+                            "range": [110, 124],
+                            "name": "RND strobe F-S"
+                        },
+                        {
+                            "range": [125, 129],
+                            "name": "Closed",
+                            "center": true
+                        },
+                        {
+                            "range": [130, 144],
+                            "name": "RNDPulse Op F-S"
+                        },
+                        {
+                            "range": [145, 149],
+                            "name": "Open",
+                            "center": true
+                        },
+                        {
+                            "range": [150, 164],
+                            "name": "RNDPulse Cl F-S"
+                        },
+                        {
+                            "range": [165, 169],
+                            "name": "Closed",
+                            "center": true
+                        },
+                        {
+                            "range": [170, 184],
+                            "name": "Burst pulse F-S"
+                        },
+                        {
+                            "range": [185, 189],
+                            "name": "Open",
+                            "center": true
+                        },
+                        {
+                            "range": [190, 204],
+                            "name": "RND Burst F-S"
+                        },
+                        {
+                            "range": [205, 209],
+                            "name": "Closed",
+                            "center": true
+                        },
+                        {
+                            "range": [210, 224],
+                            "name": "Sinuswave F-S"
+                        },
+                        {
+                            "range": [225, 229],
+                            "name": "Open",
+                            "center": true
+                        },
+                        {
+                            "range": [230, 244],
+                            "name": "Burst F-S"
+                        },
+                        {
+                            "range": [245, 255],
+                            "name": "Open",
+                            "center": true
+                        }
+                    ]
+                },
+                "Dimmer": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 100,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Fix Control Set": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 9],
+                            "name": "No Function ",
+                            "center": true
+                        },
+                        {
+                            "range": [10, 14],
+                            "name": "Reset All",
+                            "center": true
+                        },
+                        {
+                            "range": [15, 39],
+                            "name": "No Function ",
+                            "center": true
+                        },
+                        {
+                            "range": [40, 44],
+                            "name": "PTSP Norm",
+                            "center": true
+                        },
+                        {
+                            "range": [45, 49],
+                            "name": "PTSP Fast",
+                            "center": true
+                        },
+                        {
+                            "range": [50, 54],
+                            "name": "No Function ",
+                            "center": true
+                        },
+                        {
+                            "range": [55, 59],
+                            "name": "No Function",
+                            "center": true
+                        },
+                        {
+                            "range": [60, 64],
+                            "name": "Fan Mode Full",
+                            "center": true
+                        },
+                        {
+                            "range": [65, 69],
+                            "name": "No Function",
+                            "center": true
+                        },
+                        {
+                            "range": [70, 74],
+                            "name": "Fan Mode Regul",
+                            "center": true
+                        },
+                        {
+                            "range": [75, 89],
+                            "name": "No Function ",
+                            "center": true
+                        },
+                        {
+                            "range": [90, 94],
+                            "name": "RGB Control Mod",
+                            "center": true
+                        },
+                        {
+                            "range": [95, 99],
+                            "name": "No Function ",
+                            "center": true
+                        },
+                        {
+                            "range": [100, 104],
+                            "name": "Raw Control Mod",
+                            "center": true
+                        },
+                        {
+                            "range": [105, 109],
+                            "name": "No Function ",
+                            "center": true
+                        },
+                        {
+                            "range": [110, 114],
+                            "name": "Fast Dimming",
+                            "center": true
+                        },
+                        {
+                            "range": [115, 119],
+                            "name": "No Function ",
+                            "center": true
+                        },
+                        {
+                            "range": [120, 124],
+                            "name": "Smooth Dimming",
+                            "center": true
+                        },
+                        {
+                            "range": [125, 249],
+                            "name": "Illuminate Disp"
+                        },
+                        {
+                            "range": [250, 255],
+                            "name": "Function",
+                            "center": true
+                        }
+                    ]
+                },
+                "Color Wheel": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 9],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [10, 14],
+                            "name": "LEE 790",
+                            "center": true
+                        },
+                        {
+                            "range": [15, 19],
+                            "name": "LEE 157",
+                            "center": true
+                        },
+                        {
+                            "range": [20, 24],
+                            "name": "LEE 332",
+                            "center": true
+                        },
+                        {
+                            "range": [25, 29],
+                            "name": "LEE 328",
+                            "center": true
+                        },
+                        {
+                            "range": [30, 34],
+                            "name": "LEE 345",
+                            "center": true
+                        },
+                        {
+                            "range": [35, 39],
+                            "name": "LEE 194",
+                            "center": true
+                        },
+                        {
+                            "range": [40, 44],
+                            "name": "LEE  181",
+                            "center": true
+                        },
+                        {
+                            "range": [45, 49],
+                            "name": "LEE 071",
+                            "center": true
+                        },
+                        {
+                            "range": [50, 54],
+                            "name": "LEE 120",
+                            "center": true
+                        },
+                        {
+                            "range": [55, 59],
+                            "name": "LEE 079",
+                            "center": true
+                        },
+                        {
+                            "range": [60, 64],
+                            "name": "LEE 132",
+                            "center": true
+                        },
+                        {
+                            "range": [65, 69],
+                            "name": "LEE 200",
+                            "center": true
+                        },
+                        {
+                            "range": [70, 74],
+                            "name": "LEE 161",
+                            "center": true
+                        },
+                        {
+                            "range": [75, 79],
+                            "name": "LEE 201",
+                            "center": true
+                        },
+                        {
+                            "range": [80, 84],
+                            "name": "LEE 202",
+                            "center": true
+                        },
+                        {
+                            "range": [85, 89],
+                            "name": "LEE 117",
+                            "center": true
+                        },
+                        {
+                            "range": [90, 94],
+                            "name": "LEE 353",
+                            "center": true
+                        },
+                        {
+                            "range": [95, 99],
+                            "name": "LEE 118",
+                            "center": true
+                        },
+                        {
+                            "range": [100, 104],
+                            "name": "LEE 116",
+                            "center": true
+                        },
+                        {
+                            "range": [105, 109],
+                            "name": "LEE 124",
+                            "center": true
+                        },
+                        {
+                            "range": [110, 114],
+                            "name": "LEE 139",
+                            "center": true
+                        },
+                        {
+                            "range": [115, 119],
+                            "name": "LEE 089",
+                            "center": true
+                        },
+                        {
+                            "range": [120, 124],
+                            "name": "LEE 122",
+                            "center": true
+                        },
+                        {
+                            "range": [125, 129],
+                            "name": "LEE 738",
+                            "center": true
+                        },
+                        {
+                            "range": [130, 134],
+                            "name": "LEE 088",
+                            "center": true
+                        },
+                        {
+                            "range": [135, 139],
+                            "name": "LEE 100",
+                            "center": true
+                        },
+                        {
+                            "range": [140, 144],
+                            "name": "LEE 104",
+                            "center": true
+                        },
+                        {
+                            "range": [145, 149],
+                            "name": "LEE 179",
+                            "center": true
+                        },
+                        {
+                            "range": [150, 154],
+                            "name": "LEE 105",
+                            "center": true
+                        },
+                        {
+                            "range": [155, 159],
+                            "name": "LEE 021",
+                            "center": true
+                        },
+                        {
+                            "range": [160, 164],
+                            "name": "LEE 778",
+                            "center": true
+                        },
+                        {
+                            "range": [165, 169],
+                            "name": "LEE 135",
+                            "center": true
+                        },
+                        {
+                            "range": [170, 174],
+                            "name": "LEE 164",
+                            "center": true
+                        },
+                        {
+                            "range": [175, 179],
+                            "name": "Open",
+                            "center": true
+                        },
+                        {
+                            "range": [180, 201],
+                            "name": "F-S Right"
+                        },
+                        {
+                            "range": [202, 207],
+                            "name": "No Rotation",
+                            "center": true
+                        },
+                        {
+                            "range": [208, 229],
+                            "name": "S-F Left"
+                        },
+                        {
+                            "range": [230, 234],
+                            "name": "Open",
+                            "center": true
+                        },
+                        {
+                            "range": [235, 239],
+                            "name": "RND Col Fast",
+                            "center": true
+                        },
+                        {
+                            "range": [240, 244],
+                            "name": "RND Col Med",
+                            "center": true
+                        },
+                        {
+                            "range": [245, 249],
+                            "name": "RND Col Slow",
+                            "center": true
+                        },
+                        {
+                            "range": [250, 255],
+                            "name": "Open",
+                            "center": true
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "8-channel Mode",
+                    "shortName": "8ch",
+                    "channels": [
+                        "Shutter Effect",
+                        "Dimmer",
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "Fix Control Set",
+                        "Color Wheel"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Martin",
+            "name": "Mac 101 Raw RGB",
+            "shortName": "Mac101RRGB",
+            "comment": "LED Movinghead",
+            "physical": {
+                "dimensions": [241, 241, 304],
+                "weight": 3.7,
+                "power": 123
+            },
+            "availableChannels": {
+                "Shutter Effect": {
+                    "type": "Effect",
+                    "defaultValue": 30,
+                    "highlightValue": 30,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 19],
+                            "name": "Closed",
+                            "center": true
+                        },
+                        {
+                            "range": [20, 49],
+                            "name": "Open",
+                            "center": true
+                        },
+                        {
+                            "range": [50, 64],
+                            "name": "Strobe F-S"
+                        },
+                        {
+                            "range": [65, 69],
+                            "name": "Open",
+                            "center": true
+                        },
+                        {
+                            "range": [70, 84],
+                            "name": "Pulse Open F-S"
+                        },
+                        {
+                            "range": [85, 89],
+                            "name": "Open",
+                            "center": true
+                        },
+                        {
+                            "range": [90, 104],
+                            "name": "Pulse Close F-S"
+                        },
+                        {
+                            "range": [105, 109],
+                            "name": "Open",
+                            "center": true
+                        },
+                        {
+                            "range": [110, 124],
+                            "name": "RND strobe F-S"
+                        },
+                        {
+                            "range": [125, 129],
+                            "name": "Closed",
+                            "center": true
+                        },
+                        {
+                            "range": [130, 144],
+                            "name": "RNDPulse Op F-S"
+                        },
+                        {
+                            "range": [145, 149],
+                            "name": "Open",
+                            "center": true
+                        },
+                        {
+                            "range": [150, 164],
+                            "name": "RNDPulse Cl F-S"
+                        },
+                        {
+                            "range": [165, 169],
+                            "name": "Closed",
+                            "center": true
+                        },
+                        {
+                            "range": [170, 184],
+                            "name": "Burst pulse F-S"
+                        },
+                        {
+                            "range": [185, 189],
+                            "name": "Open",
+                            "center": true
+                        },
+                        {
+                            "range": [190, 204],
+                            "name": "RND Burst F-S"
+                        },
+                        {
+                            "range": [205, 209],
+                            "name": "Closed",
+                            "center": true
+                        },
+                        {
+                            "range": [210, 224],
+                            "name": "Sinuswave F-S"
+                        },
+                        {
+                            "range": [225, 229],
+                            "name": "Open",
+                            "center": true
+                        },
+                        {
+                            "range": [230, 244],
+                            "name": "Burst F-S"
+                        },
+                        {
+                            "range": [245, 255],
+                            "name": "Open",
+                            "center": true
+                        }
+                    ]
+                },
+                "Dimmer": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 100,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Fix Control Set": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 9],
+                            "name": "No Function ",
+                            "center": true
+                        },
+                        {
+                            "range": [10, 14],
+                            "name": "Reset All",
+                            "center": true
+                        },
+                        {
+                            "range": [15, 39],
+                            "name": "No Function ",
+                            "center": true
+                        },
+                        {
+                            "range": [40, 44],
+                            "name": "PTSP Norm",
+                            "center": true
+                        },
+                        {
+                            "range": [45, 49],
+                            "name": "PTSP Fast",
+                            "center": true
+                        },
+                        {
+                            "range": [50, 54],
+                            "name": "No Function ",
+                            "center": true
+                        },
+                        {
+                            "range": [55, 59],
+                            "name": "No Function",
+                            "center": true
+                        },
+                        {
+                            "range": [60, 64],
+                            "name": "Fan Mode Full",
+                            "center": true
+                        },
+                        {
+                            "range": [65, 69],
+                            "name": "No Function",
+                            "center": true
+                        },
+                        {
+                            "range": [70, 74],
+                            "name": "Fan Mode Regul",
+                            "center": true
+                        },
+                        {
+                            "range": [75, 89],
+                            "name": "No Function ",
+                            "center": true
+                        },
+                        {
+                            "range": [90, 94],
+                            "name": "RGB Control Mod",
+                            "center": true
+                        },
+                        {
+                            "range": [95, 99],
+                            "name": "No Function ",
+                            "center": true
+                        },
+                        {
+                            "range": [100, 104],
+                            "name": "Raw Control Mod",
+                            "center": true
+                        },
+                        {
+                            "range": [105, 109],
+                            "name": "No Function ",
+                            "center": true
+                        },
+                        {
+                            "range": [110, 114],
+                            "name": "Fast Dimming",
+                            "center": true
+                        },
+                        {
+                            "range": [115, 119],
+                            "name": "No Function ",
+                            "center": true
+                        },
+                        {
+                            "range": [120, 124],
+                            "name": "Smooth Dimming",
+                            "center": true
+                        },
+                        {
+                            "range": [125, 249],
+                            "name": "Illuminate Disp"
+                        },
+                        {
+                            "range": [250, 255],
+                            "name": "Function",
+                            "center": true
+                        }
+                    ]
+                },
+                "Color Wheel": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 9],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [10, 14],
+                            "name": "LEE 790",
+                            "center": true
+                        },
+                        {
+                            "range": [15, 19],
+                            "name": "LEE 157",
+                            "center": true
+                        },
+                        {
+                            "range": [20, 24],
+                            "name": "LEE 332",
+                            "center": true
+                        },
+                        {
+                            "range": [25, 29],
+                            "name": "LEE 328",
+                            "center": true
+                        },
+                        {
+                            "range": [30, 34],
+                            "name": "LEE 345",
+                            "center": true
+                        },
+                        {
+                            "range": [35, 39],
+                            "name": "LEE 194",
+                            "center": true
+                        },
+                        {
+                            "range": [40, 44],
+                            "name": "LEE  181",
+                            "center": true
+                        },
+                        {
+                            "range": [45, 49],
+                            "name": "LEE 071",
+                            "center": true
+                        },
+                        {
+                            "range": [50, 54],
+                            "name": "LEE 120",
+                            "center": true
+                        },
+                        {
+                            "range": [55, 59],
+                            "name": "LEE 079",
+                            "center": true
+                        },
+                        {
+                            "range": [60, 64],
+                            "name": "LEE 132",
+                            "center": true
+                        },
+                        {
+                            "range": [65, 69],
+                            "name": "LEE 200",
+                            "center": true
+                        },
+                        {
+                            "range": [70, 74],
+                            "name": "LEE 161",
+                            "center": true
+                        },
+                        {
+                            "range": [75, 79],
+                            "name": "LEE 201",
+                            "center": true
+                        },
+                        {
+                            "range": [80, 84],
+                            "name": "LEE 202",
+                            "center": true
+                        },
+                        {
+                            "range": [85, 89],
+                            "name": "LEE 117",
+                            "center": true
+                        },
+                        {
+                            "range": [90, 94],
+                            "name": "LEE 353",
+                            "center": true
+                        },
+                        {
+                            "range": [95, 99],
+                            "name": "LEE 118",
+                            "center": true
+                        },
+                        {
+                            "range": [100, 104],
+                            "name": "LEE 116",
+                            "center": true
+                        },
+                        {
+                            "range": [105, 109],
+                            "name": "LEE 124",
+                            "center": true
+                        },
+                        {
+                            "range": [110, 114],
+                            "name": "LEE 139",
+                            "center": true
+                        },
+                        {
+                            "range": [115, 119],
+                            "name": "LEE 089",
+                            "center": true
+                        },
+                        {
+                            "range": [120, 124],
+                            "name": "LEE 122",
+                            "center": true
+                        },
+                        {
+                            "range": [125, 129],
+                            "name": "LEE 738",
+                            "center": true
+                        },
+                        {
+                            "range": [130, 134],
+                            "name": "LEE 088",
+                            "center": true
+                        },
+                        {
+                            "range": [135, 139],
+                            "name": "LEE 100",
+                            "center": true
+                        },
+                        {
+                            "range": [140, 144],
+                            "name": "LEE 104",
+                            "center": true
+                        },
+                        {
+                            "range": [145, 149],
+                            "name": "LEE 179",
+                            "center": true
+                        },
+                        {
+                            "range": [150, 154],
+                            "name": "LEE 105",
+                            "center": true
+                        },
+                        {
+                            "range": [155, 159],
+                            "name": "LEE 021",
+                            "center": true
+                        },
+                        {
+                            "range": [160, 164],
+                            "name": "LEE 778",
+                            "center": true
+                        },
+                        {
+                            "range": [165, 169],
+                            "name": "LEE 135",
+                            "center": true
+                        },
+                        {
+                            "range": [170, 174],
+                            "name": "LEE 164",
+                            "center": true
+                        },
+                        {
+                            "range": [175, 179],
+                            "name": "Open",
+                            "center": true
+                        },
+                        {
+                            "range": [180, 201],
+                            "name": "F-S Right"
+                        },
+                        {
+                            "range": [202, 207],
+                            "name": "No Rotation",
+                            "center": true
+                        },
+                        {
+                            "range": [208, 229],
+                            "name": "S-F Left"
+                        },
+                        {
+                            "range": [230, 234],
+                            "name": "Open",
+                            "center": true
+                        },
+                        {
+                            "range": [235, 239],
+                            "name": "RND Col Fast",
+                            "center": true
+                        },
+                        {
+                            "range": [240, 244],
+                            "name": "RND Col Med",
+                            "center": true
+                        },
+                        {
+                            "range": [245, 249],
+                            "name": "RND Col Slow",
+                            "center": true
+                        },
+                        {
+                            "range": [250, 255],
+                            "name": "Open",
+                            "center": true
+                        }
+                    ]
+                },
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "CTC": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 19],
+                            "name": "No Function"
+                        },
+                        {
+                            "range": [20, 255],
+                            "name": "10000K to 2000K"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "12-channel Mode",
+                    "shortName": "12ch",
+                    "channels": [
+                        "Shutter Effect",
+                        "Dimmer",
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "Fix Control Set",
+                        "Color Wheel",
+                        "Red",
+                        "Green",
+                        "Blue",
+                        "CTC"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Martin",
+            "name": "Mac 1200 Mode 4",
+            "shortName": "Mac 1200m4",
+            "physical": {
+                "dimensions": [500, 500, 750]
+            },
+            "availableChannels": {
+                "Control": {
+                    "type": "Beam",
+                    "defaultValue": 25,
+                    "highlightValue": 25,
+                    "capabilities": [
+                        {
+                            "range": [0, 9],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [10, 49],
+                            "name": "nofunction"
+                        },
+                        {
+                            "range": [50, 177],
+                            "name": "strobe"
+                        },
+                        {
+                            "range": [178, 207],
+                            "name": "nofunction"
+                        },
+                        {
+                            "range": [208, 217],
+                            "name": "reset"
+                        },
+                        {
+                            "range": [218, 227],
+                            "name": "nofunction"
+                        },
+                        {
+                            "range": [228, 237],
+                            "name": "lamp_on"
+                        },
+                        {
+                            "range": [238, 247],
+                            "name": "nofunction"
+                        },
+                        {
+                            "range": [248, 255],
+                            "name": "lamp_off"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Cyan": {
+                    "type": "SingleColor",
+                    "color": "Cyan",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Magenta": {
+                    "type": "SingleColor",
+                    "color": "Magenta",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Yellow": {
+                    "type": "SingleColor",
+                    "color": "Yellow",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Color": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 39],
+                            "name": "white",
+                            "color": "#ffffff"
+                        },
+                        {
+                            "range": [40, 79],
+                            "name": "color1"
+                        },
+                        {
+                            "range": [80, 119],
+                            "name": "color2"
+                        },
+                        {
+                            "range": [120, 159],
+                            "name": "color3"
+                        },
+                        {
+                            "range": [160, 166],
+                            "name": "color4"
+                        },
+                        {
+                            "range": [167, 172],
+                            "name": "color5"
+                        },
+                        {
+                            "range": [173, 178],
+                            "name": "color6"
+                        },
+                        {
+                            "range": [179, 184],
+                            "name": "color7"
+                        },
+                        {
+                            "range": [185, 191],
+                            "name": "white",
+                            "color": "#ffffff"
+                        },
+                        {
+                            "range": [192, 255],
+                            "name": "rainbow"
+                        }
+                    ]
+                },
+                "Gobo": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 30],
+                            "name": "open"
+                        },
+                        {
+                            "range": [31, 57],
+                            "name": "gobo1"
+                        },
+                        {
+                            "range": [58, 82],
+                            "name": "gobo2"
+                        },
+                        {
+                            "range": [83, 105],
+                            "name": "gobo3"
+                        },
+                        {
+                            "range": [106, 125],
+                            "name": "gobo4"
+                        },
+                        {
+                            "range": [126, 161],
+                            "name": "gobo5"
+                        },
+                        {
+                            "range": [162, 166],
+                            "name": "gobo6"
+                        },
+                        {
+                            "range": [167, 170],
+                            "name": "gobo5"
+                        },
+                        {
+                            "range": [171, 174],
+                            "name": "gobo4"
+                        },
+                        {
+                            "range": [175, 182],
+                            "name": "gobo3"
+                        },
+                        {
+                            "range": [179, 182],
+                            "name": "gobo2"
+                        },
+                        {
+                            "range": [183, 186],
+                            "name": "gobo1"
+                        },
+                        {
+                            "range": [187, 191],
+                            "name": "open"
+                        },
+                        {
+                            "range": [192, 255],
+                            "name": "rotation"
+                        }
+                    ]
+                },
+                "Frost": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Speed": {
+                    "type": "Speed",
+                    "capabilities": [
+                        {
+                            "range": [0, 245],
+                            "name": "tracking"
+                        },
+                        {
+                            "range": [246, 251],
+                            "name": "tr_fast"
+                        },
+                        {
+                            "range": [252, 255],
+                            "name": "black_move"
+                        }
+                    ]
+                },
+                "C_Speed": {
+                    "type": "Speed",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 251],
+                            "name": "tracking"
+                        },
+                        {
+                            "range": [252, 255],
+                            "name": "black_move"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "14-channel Mode",
+                    "shortName": "14ch",
+                    "channels": [
+                        "Control",
+                        "Intensity",
+                        "Cyan",
+                        "Magenta",
+                        "Yellow",
+                        "Color",
+                        "Gobo",
+                        "Frost",
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "Speed",
+                        "C_Speed"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Martin",
+            "name": "Mac 2000",
+            "shortName": "Mac2000",
+            "physical": {
+                "dimensions": [500, 500, 750]
+            },
+            "availableChannels": {
+                "Strobe": {
+                    "type": "Strobe",
+                    "defaultValue": 20,
+                    "highlightValue": 20,
+                    "capabilities": [
+                        {
+                            "range": [0, 19],
+                            "name": "Closed"
+                        },
+                        {
+                            "range": [20, 49],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [50, 72],
+                            "name": "Strobe"
+                        },
+                        {
+                            "range": [80, 99],
+                            "name": "Open Pulse"
+                        },
+                        {
+                            "range": [100, 119],
+                            "name": "Close Pulse"
+                        },
+                        {
+                            "range": [128, 187],
+                            "name": "Random",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [191, 196],
+                            "name": "Rand Open Pulse",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [197, 202],
+                            "name": "Rand Cl Pulse",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [208, 217],
+                            "name": "Reset",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [228, 247],
+                            "name": "Lamp On",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [248, 255],
+                            "name": "Lamp Off",
+                            "showInMenu": false
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Cyan": {
+                    "type": "SingleColor",
+                    "color": "Cyan",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Magenta": {
+                    "type": "SingleColor",
+                    "color": "Magenta",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Yellow": {
+                    "type": "SingleColor",
+                    "color": "Yellow",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "CTC": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Col/Gobo": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 19],
+                            "name": "White",
+                            "color": "#ffffff",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [20, 39],
+                            "name": "Pos1->Pos2",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [40, 59],
+                            "name": "Pos2->Pos3",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [60, 79],
+                            "name": "Pos3->Pos4",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [80, 99],
+                            "name": "Pos4->Pos5",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [100, 119],
+                            "name": "Pos5->Pos6",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [120, 139],
+                            "name": "Pos6->Pos7",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [140, 159],
+                            "name": "Pos7->Open",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [160, 163],
+                            "name": "Dots",
+                            "center": true
+                        },
+                        {
+                            "range": [164, 167],
+                            "name": "Highways",
+                            "center": true
+                        },
+                        {
+                            "range": [168, 171],
+                            "name": "Triple Cone",
+                            "center": true
+                        },
+                        {
+                            "range": [172, 175],
+                            "name": "UV",
+                            "center": true
+                        },
+                        {
+                            "range": [176, 179],
+                            "name": "Blue",
+                            "color": "#0000ff",
+                            "center": true
+                        },
+                        {
+                            "range": [180, 183],
+                            "name": "Green",
+                            "color": "#00ff00",
+                            "center": true
+                        },
+                        {
+                            "range": [184, 187],
+                            "name": "Red",
+                            "color": "#ff0000",
+                            "center": true
+                        },
+                        {
+                            "range": [188, 191],
+                            "name": "Open",
+                            "center": true
+                        },
+                        {
+                            "range": [192, 217],
+                            "name": "Rot Right",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [218, 243],
+                            "name": "Rot Left",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [244, 255],
+                            "name": "Random Colour",
+                            "showInMenu": false
+                        }
+                    ]
+                },
+                "Gobo 1": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 9],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [10, 14],
+                            "name": "Gobo 1"
+                        },
+                        {
+                            "range": [15, 19],
+                            "name": "Gobo 2"
+                        },
+                        {
+                            "range": [20, 24],
+                            "name": "Gobo 3"
+                        },
+                        {
+                            "range": [25, 29],
+                            "name": "Gobo 4"
+                        },
+                        {
+                            "range": [30, 34],
+                            "name": "Gobo 5"
+                        },
+                        {
+                            "range": [35, 39],
+                            "name": "Rot Gobo 1"
+                        },
+                        {
+                            "range": [40, 44],
+                            "name": "Rot Gobo 2"
+                        },
+                        {
+                            "range": [45, 49],
+                            "name": "Rot Gobo 3"
+                        },
+                        {
+                            "range": [50, 54],
+                            "name": "Rot Gobo 4"
+                        },
+                        {
+                            "range": [55, 59],
+                            "name": "Rot Gobo 5"
+                        },
+                        {
+                            "range": [60, 74],
+                            "name": "Ind Shake Gob 1"
+                        },
+                        {
+                            "range": [75, 89],
+                            "name": "Ind Shake Gob 2"
+                        },
+                        {
+                            "range": [90, 104],
+                            "name": "Ind Shake Gob 3"
+                        },
+                        {
+                            "range": [105, 119],
+                            "name": "Ind Shake Gob 4"
+                        },
+                        {
+                            "range": [120, 134],
+                            "name": "Ind Shake Gob 5"
+                        },
+                        {
+                            "range": [135, 149],
+                            "name": "Rot Shake Gob 1"
+                        },
+                        {
+                            "range": [150, 164],
+                            "name": "Rot Shake Gob 2"
+                        },
+                        {
+                            "range": [165, 179],
+                            "name": "Rot Shake Gob 3"
+                        },
+                        {
+                            "range": [180, 194],
+                            "name": "Rot Shake Gob 4"
+                        },
+                        {
+                            "range": [195, 209],
+                            "name": "Rot Shake Gob 5"
+                        },
+                        {
+                            "range": [210, 234],
+                            "name": "Rot Right",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [235, 255],
+                            "name": "Rot Left",
+                            "showInMenu": false,
+                            "center": true
+                        }
+                    ]
+                },
+                "Gobo 1 Rot": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ],
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "Gobo 1 Rot fine": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ],
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "Gobo 2": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 9],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [10, 14],
+                            "name": "Gobo 2.1"
+                        },
+                        {
+                            "range": [15, 19],
+                            "name": "Gobo 2.2"
+                        },
+                        {
+                            "range": [20, 24],
+                            "name": "Gobo 2.3"
+                        },
+                        {
+                            "range": [25, 29],
+                            "name": "Gobo 2.4"
+                        },
+                        {
+                            "range": [30, 34],
+                            "name": "Gobo 2.5"
+                        },
+                        {
+                            "range": [35, 39],
+                            "name": "Rot Gobo 1"
+                        },
+                        {
+                            "range": [40, 44],
+                            "name": "Rot Gobo 2"
+                        },
+                        {
+                            "range": [45, 49],
+                            "name": "Rot Gobo 3"
+                        },
+                        {
+                            "range": [50, 54],
+                            "name": "Rot Gobo 4"
+                        },
+                        {
+                            "range": [55, 59],
+                            "name": "Rot Gobo 5"
+                        },
+                        {
+                            "range": [60, 74],
+                            "name": "Ind Shake Gob 1"
+                        },
+                        {
+                            "range": [75, 89],
+                            "name": "Ind Shake Gob 2"
+                        },
+                        {
+                            "range": [90, 104],
+                            "name": "Ind Shake Gob 3"
+                        },
+                        {
+                            "range": [105, 119],
+                            "name": "Ind Shake Gob 4"
+                        },
+                        {
+                            "range": [120, 134],
+                            "name": "Ind Shake Gob 5"
+                        },
+                        {
+                            "range": [135, 149],
+                            "name": "Rot Shake Gob 1"
+                        },
+                        {
+                            "range": [150, 164],
+                            "name": "Rot Shake Gob 2"
+                        },
+                        {
+                            "range": [165, 179],
+                            "name": "Rot Shake Gob 3"
+                        },
+                        {
+                            "range": [180, 194],
+                            "name": "Rot Shake Gob 4"
+                        },
+                        {
+                            "range": [195, 209],
+                            "name": "Rot Shake Gob 5"
+                        },
+                        {
+                            "range": [210, 234],
+                            "name": "Rot Right",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [235, 255],
+                            "name": "Rot Left",
+                            "showInMenu": false,
+                            "center": true
+                        }
+                    ]
+                },
+                "Gobo 2 Rot": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ],
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "Gobo 2 Rot fine": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ],
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "FX": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [1, 175],
+                            "name": "Frost",
+                            "color": "#edf5dd"
+                        },
+                        {
+                            "range": [176, 183],
+                            "name": "FX 1 - Ind Rot"
+                        },
+                        {
+                            "range": [184, 191],
+                            "name": "FX 2 - Ind Rot"
+                        },
+                        {
+                            "range": [192, 191],
+                            "name": "FX 1 - Cont Rot"
+                        },
+                        {
+                            "range": [192, 207],
+                            "name": "FX 2 - Cont Rot"
+                        },
+                        {
+                            "range": [208, 215],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [216, 220],
+                            "name": "Macro 1"
+                        },
+                        {
+                            "range": [221, 225],
+                            "name": "Macro 2"
+                        },
+                        {
+                            "range": [226, 230],
+                            "name": "Macro 3"
+                        },
+                        {
+                            "range": [231, 235],
+                            "name": "Macro 4"
+                        },
+                        {
+                            "range": [236, 240],
+                            "name": "Macro 5"
+                        },
+                        {
+                            "range": [241, 245],
+                            "name": "Macro 6"
+                        },
+                        {
+                            "range": [246, 250],
+                            "name": "Macro 7"
+                        },
+                        {
+                            "range": [251, 255],
+                            "name": "Macro 8"
+                        }
+                    ]
+                },
+                "FX Rot": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Iris": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 199],
+                            "name": "Open->Closed"
+                        },
+                        {
+                            "range": [200, 215],
+                            "name": "Closed"
+                        },
+                        {
+                            "range": [216, 255],
+                            "name": "Pulse",
+                            "showInMenu": false
+                        }
+                    ]
+                },
+                "Focus": {
+                    "type": "Beam",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "Distance"
+                        }
+                    ]
+                },
+                "Zoom": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "Beam"
+                        }
+                    ]
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "*Pan Speed": {
+                    "type": "Speed",
+                    "capabilities": [
+                        {
+                            "range": [0, 2],
+                            "name": "Tracking",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [3, 245],
+                            "name": "Speed",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [246, 248],
+                            "name": "PTSPnorm",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [249, 251],
+                            "name": "PTSPfast",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [252, 255],
+                            "name": "Blackout",
+                            "showInMenu": false
+                        }
+                    ]
+                },
+                "FX Speed": {
+                    "type": "Speed",
+                    "capabilities": [
+                        {
+                            "range": [0, 2],
+                            "name": "Tracking",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [3, 239],
+                            "name": "Speed",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [240, 242],
+                            "name": "Studio mode off",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [243, 245],
+                            "name": "Studio mode on",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [246, 248],
+                            "name": "Shortcuts off",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [249, 251],
+                            "name": "Shortcuts on",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [252, 255],
+                            "name": "Blackout",
+                            "showInMenu": false
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Gobo 1 Rot",
+                    "Gobo 1 Rot fine"
+                ],
+                [
+                    "Gobo 2 Rot",
+                    "Gobo 2 Rot fine"
+                ],
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "24-channel Mode",
+                    "shortName": "24ch",
+                    "channels": [
+                        "Strobe",
+                        "Intensity",
+                        "Cyan",
+                        "Magenta",
+                        "Yellow",
+                        "CTC",
+                        "Col/Gobo",
+                        "Gobo 1",
+                        "Gobo 1 Rot",
+                        "Gobo 1 Rot fine",
+                        "Gobo 2",
+                        "Gobo 2 Rot",
+                        "Gobo 2 Rot fine",
+                        "FX",
+                        "FX Rot",
+                        "Iris",
+                        "Focus",
+                        "Zoom",
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "*Pan Speed",
+                        "FX Speed"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Martin",
+            "name": "MAC 2000 Performens 16bit",
+            "shortName": "MAC2k16",
+            "comment": "16bit",
+            "physical": {
+                "dimensions": [500, 500, 750]
+            },
+            "availableChannels": {
+                "Shutter": {
+                    "type": "Shutter",
+                    "highlightValue": 25,
+                    "capabilities": [
+                        {
+                            "range": [0, 19],
+                            "name": "Close",
+                            "center": true
+                        },
+                        {
+                            "range": [20, 49],
+                            "name": "Open",
+                            "center": true
+                        },
+                        {
+                            "range": [50, 57],
+                            "name": "Strobe fast"
+                        },
+                        {
+                            "range": [58, 65],
+                            "name": "Strobe middle"
+                        },
+                        {
+                            "range": [66, 72],
+                            "name": "Strobe slow"
+                        },
+                        {
+                            "range": [80, 99],
+                            "name": "Puls open"
+                        },
+                        {
+                            "range": [100, 119],
+                            "name": "Puls close"
+                        },
+                        {
+                            "range": [120, 127],
+                            "name": "Open",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 147],
+                            "name": "Random strobe f",
+                            "center": true
+                        },
+                        {
+                            "range": [148, 167],
+                            "name": "Random strobe m",
+                            "center": true
+                        },
+                        {
+                            "range": [168, 187],
+                            "name": "Random strobe s",
+                            "center": true
+                        },
+                        {
+                            "range": [188, 190],
+                            "name": "Open",
+                            "center": true
+                        },
+                        {
+                            "range": [191, 196],
+                            "name": "Random  puls op"
+                        },
+                        {
+                            "range": [197, 202],
+                            "name": "Random puls clo"
+                        },
+                        {
+                            "range": [203, 207],
+                            "name": "Open",
+                            "center": true
+                        },
+                        {
+                            "range": [208, 217],
+                            "name": "Reset",
+                            "center": true
+                        },
+                        {
+                            "range": [218, 227],
+                            "name": "Open",
+                            "center": true
+                        },
+                        {
+                            "range": [228, 237],
+                            "name": "Lamp on",
+                            "center": true
+                        },
+                        {
+                            "range": [238, 247],
+                            "name": "Open",
+                            "center": true
+                        },
+                        {
+                            "range": [248, 255],
+                            "name": "Lamp off",
+                            "center": true
+                        }
+                    ]
+                },
+                "Dimmer": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "Close"
+                        },
+                        {
+                            "range": [1, 254],
+                            "name": "%"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "Open"
+                        }
+                    ]
+                },
+                "Cyan": {
+                    "type": "SingleColor",
+                    "color": "Cyan",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Magenta": {
+                    "type": "SingleColor",
+                    "color": "Magenta",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Yellow": {
+                    "type": "SingleColor",
+                    "color": "Yellow",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "CTO": {
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Gobo1": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 9],
+                            "name": "Open",
+                            "center": true
+                        },
+                        {
+                            "range": [10, 14],
+                            "name": "Slot 1 ind.",
+                            "center": true
+                        },
+                        {
+                            "range": [15, 19],
+                            "name": "Slot 2 ind.",
+                            "center": true
+                        },
+                        {
+                            "range": [20, 24],
+                            "name": "Slot 3 ind.",
+                            "center": true
+                        },
+                        {
+                            "range": [25, 29],
+                            "name": "Slot 4 ind.",
+                            "center": true
+                        },
+                        {
+                            "range": [30, 34],
+                            "name": "Slot 5 ind.",
+                            "center": true
+                        },
+                        {
+                            "range": [35, 39],
+                            "name": "Slot 1 rot.",
+                            "center": true
+                        },
+                        {
+                            "range": [40, 44],
+                            "name": "Slot 2 rot.",
+                            "center": true
+                        },
+                        {
+                            "range": [45, 49],
+                            "name": "Slot 3 rot.",
+                            "center": true
+                        },
+                        {
+                            "range": [50, 54],
+                            "name": "Slot 4 rot.",
+                            "center": true
+                        },
+                        {
+                            "range": [55, 59],
+                            "name": "Slot 5 rot.",
+                            "center": true
+                        },
+                        {
+                            "range": [60, 74],
+                            "name": "Slot 1 ind. sh."
+                        },
+                        {
+                            "range": [75, 89],
+                            "name": "Slot 2 ind. sh."
+                        },
+                        {
+                            "range": [90, 104],
+                            "name": "Slot 3 ind. sh."
+                        },
+                        {
+                            "range": [105, 119],
+                            "name": "Slot 4 ind. sh."
+                        },
+                        {
+                            "range": [120, 134],
+                            "name": "Slot 5 ind. sh."
+                        },
+                        {
+                            "range": [135, 149],
+                            "name": "Slot 1 rot. sh."
+                        },
+                        {
+                            "range": [150, 164],
+                            "name": "Slot 2 rot. sh."
+                        },
+                        {
+                            "range": [165, 179],
+                            "name": "Slot 3 rot. sh."
+                        },
+                        {
+                            "range": [180, 194],
+                            "name": "Slot 4 rot. sh."
+                        },
+                        {
+                            "range": [195, 209],
+                            "name": "Slot 5 rot. sh."
+                        },
+                        {
+                            "range": [210, 232],
+                            "name": ">>"
+                        },
+                        {
+                            "range": [233, 255],
+                            "name": "<<"
+                        }
+                    ]
+                },
+                "Gobo1 Rot": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "Index",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "Gobo1 Rot fine": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "Index",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "Gobo anim. func": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 9],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [10, 19],
+                            "name": "Vert. ind. po"
+                        },
+                        {
+                            "range": [20, 29],
+                            "name": "Hori. ind. pos."
+                        },
+                        {
+                            "range": [30, 39],
+                            "name": "Vert. cont. rot"
+                        },
+                        {
+                            "range": [40, 49],
+                            "name": "Hori. cont. rot"
+                        },
+                        {
+                            "range": [50, 139],
+                            "name": "Angled ind. pos"
+                        },
+                        {
+                            "range": [140, 229],
+                            "name": "Angled cont. ro"
+                        },
+                        {
+                            "range": [230, 235],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [236, 239],
+                            "name": "Macro1"
+                        },
+                        {
+                            "range": [240, 243],
+                            "name": "Macro2"
+                        },
+                        {
+                            "range": [244, 247],
+                            "name": "Macro3"
+                        },
+                        {
+                            "range": [248, 251],
+                            "name": "Macro4"
+                        },
+                        {
+                            "range": [252, 255],
+                            "name": "Macro5"
+                        }
+                    ]
+                },
+                "Gobo anim. spee": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 2],
+                            "name": "no rot."
+                        },
+                        {
+                            "range": [3, 127],
+                            "name": ">>"
+                        },
+                        {
+                            "range": [128, 252],
+                            "name": "<<"
+                        },
+                        {
+                            "range": [253, 255],
+                            "name": "no rot."
+                        }
+                    ]
+                },
+                "Frost (Effect)": {
+                    "type": "Effect",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "Open",
+                            "center": true
+                        },
+                        {
+                            "range": [1, 234],
+                            "name": "Frost",
+                            "color": "#edf5dd"
+                        },
+                        {
+                            "range": [235, 242],
+                            "name": "Effect 1",
+                            "center": true
+                        },
+                        {
+                            "range": [243, 250],
+                            "name": "Effect 2",
+                            "center": true
+                        },
+                        {
+                            "range": [251, 255],
+                            "name": "Open",
+                            "center": true
+                        }
+                    ]
+                },
+                "Iris": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [1, 199],
+                            "name": "%"
+                        },
+                        {
+                            "range": [200, 215],
+                            "name": "Close"
+                        },
+                        {
+                            "range": [216, 229],
+                            "name": "Opening pulse"
+                        },
+                        {
+                            "range": [230, 243],
+                            "name": "Closing pulse"
+                        },
+                        {
+                            "range": [244, 246],
+                            "name": "Random fast ope"
+                        },
+                        {
+                            "range": [247, 249],
+                            "name": "Random slow ope"
+                        },
+                        {
+                            "range": [250, 252],
+                            "name": "Random fast clo"
+                        },
+                        {
+                            "range": [253, 255],
+                            "name": "Random slow clo"
+                        }
+                    ]
+                },
+                "Framing Macro": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "No Macros",
+                            "center": true
+                        }
+                    ]
+                },
+                "Focus": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "Infinity"
+                        },
+                        {
+                            "range": [1, 254],
+                            "name": "%"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "Near"
+                        }
+                    ]
+                },
+                "Zoom": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "Flood"
+                        },
+                        {
+                            "range": [1, 254],
+                            "name": "%"
+                        },
+                        {
+                            "range": [0, 0],
+                            "name": "New Range"
+                        }
+                    ]
+                },
+                "Barn door 1": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "Out"
+                        },
+                        {
+                            "range": [1, 254],
+                            "name": "%"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "In"
+                        }
+                    ]
+                },
+                "Barn door 1 ang": {
+                    "type": "Beam",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 126],
+                            "name": "Angle -"
+                        },
+                        {
+                            "range": [127, 128],
+                            "name": "Parallel"
+                        },
+                        {
+                            "range": [129, 255],
+                            "name": "Angle +"
+                        }
+                    ]
+                },
+                "Barn door 2": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "Out"
+                        },
+                        {
+                            "range": [1, 254],
+                            "name": "%"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "In"
+                        }
+                    ]
+                },
+                "Barn door 2 ang": {
+                    "type": "Beam",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 126],
+                            "name": "Angle -"
+                        },
+                        {
+                            "range": [127, 128],
+                            "name": "Parallel"
+                        },
+                        {
+                            "range": [129, 255],
+                            "name": "Angle +"
+                        }
+                    ]
+                },
+                "Barn door 3": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "Out"
+                        },
+                        {
+                            "range": [1, 254],
+                            "name": "%"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "In"
+                        }
+                    ]
+                },
+                "Barn door 3 ang": {
+                    "type": "Beam",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 126],
+                            "name": "Angle -"
+                        },
+                        {
+                            "range": [127, 128],
+                            "name": "Parallel"
+                        },
+                        {
+                            "range": [129, 255],
+                            "name": "Angle +"
+                        }
+                    ]
+                },
+                "Barn door 4": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "Out"
+                        },
+                        {
+                            "range": [1, 254],
+                            "name": "%"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "In"
+                        }
+                    ]
+                },
+                "Barn door 4 ang": {
+                    "type": "Beam",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 126],
+                            "name": "Angle -"
+                        },
+                        {
+                            "range": [127, 128],
+                            "name": "Parallel"
+                        },
+                        {
+                            "range": [129, 255],
+                            "name": "Angle +"
+                        }
+                    ]
+                },
+                "Barn door rot.": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "Right"
+                        },
+                        {
+                            "range": [128, 128],
+                            "name": "128",
+                            "center": true
+                        },
+                        {
+                            "range": [129, 255],
+                            "name": "Left"
+                        }
+                    ]
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 0,
+                    "highlightValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 0,
+                    "highlightValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Pan/Tilt speed": {
+                    "type": "Speed",
+                    "capabilities": [
+                        {
+                            "range": [0, 2],
+                            "name": "Tracking"
+                        },
+                        {
+                            "range": [3, 242],
+                            "name": "Fast->slow"
+                        },
+                        {
+                            "range": [243, 245],
+                            "name": "Tracking PTSP s",
+                            "center": true
+                        },
+                        {
+                            "range": [246, 248],
+                            "name": "Tracking PTSP n",
+                            "center": true
+                        },
+                        {
+                            "range": [249, 251],
+                            "name": "Tracking PTSP f",
+                            "center": true
+                        },
+                        {
+                            "range": [252, 255],
+                            "name": "Move blackout",
+                            "center": true
+                        }
+                    ]
+                },
+                "Effects speed": {
+                    "type": "Speed",
+                    "capabilities": [
+                        {
+                            "range": [0, 2],
+                            "name": "Tracking",
+                            "center": true
+                        },
+                        {
+                            "range": [3, 245],
+                            "name": "fast->slow"
+                        },
+                        {
+                            "range": [246, 251],
+                            "name": "Special"
+                        },
+                        {
+                            "range": [252, 255],
+                            "name": "Move blackout",
+                            "center": true
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Gobo1 Rot",
+                    "Gobo1 Rot fine"
+                ],
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "31-channel Mode",
+                    "shortName": "31ch",
+                    "channels": [
+                        "Shutter",
+                        "Dimmer",
+                        "Cyan",
+                        "Magenta",
+                        "Yellow",
+                        "CTO",
+                        "Gobo1",
+                        "Gobo1 Rot",
+                        "Gobo1 Rot fine",
+                        "Gobo anim. func",
+                        "Gobo anim. spee",
+                        "Frost (Effect)",
+                        "Iris",
+                        "Framing Macro",
+                        "Focus",
+                        "Zoom",
+                        "Barn door 1",
+                        "Barn door 1 ang",
+                        "Barn door 2",
+                        "Barn door 2 ang",
+                        "Barn door 3",
+                        "Barn door 3 ang",
+                        "Barn door 4",
+                        "Barn door 4 ang",
+                        "Barn door rot.",
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "Pan/Tilt speed",
+                        "Effects speed"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Martin",
+            "name": "MAC 2000 Performens 8bit",
+            "shortName": "MAC2k8",
+            "comment": "8bit",
+            "physical": {
+                "dimensions": [500, 500, 750]
+            },
+            "availableChannels": {
+                "Shutter": {
+                    "type": "Shutter",
+                    "highlightValue": 25,
+                    "capabilities": [
+                        {
+                            "range": [0, 19],
+                            "name": "closed",
+                            "center": true
+                        },
+                        {
+                            "range": [20, 49],
+                            "name": "open",
+                            "center": true
+                        },
+                        {
+                            "range": [50, 72],
+                            "name": "strobe"
+                        },
+                        {
+                            "range": [80, 99],
+                            "name": "puls open"
+                        },
+                        {
+                            "range": [100, 119],
+                            "name": "puls close"
+                        },
+                        {
+                            "range": [120, 127],
+                            "name": "open",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 187],
+                            "name": "random strobe",
+                            "center": true
+                        },
+                        {
+                            "range": [188, 190],
+                            "name": "open",
+                            "center": true
+                        },
+                        {
+                            "range": [191, 196],
+                            "name": "random  puls op"
+                        },
+                        {
+                            "range": [197, 202],
+                            "name": "Random puls clo"
+                        },
+                        {
+                            "range": [203, 207],
+                            "name": "open",
+                            "center": true
+                        },
+                        {
+                            "range": [208, 217],
+                            "name": "reset",
+                            "center": true
+                        },
+                        {
+                            "range": [218, 227],
+                            "name": "open",
+                            "center": true
+                        },
+                        {
+                            "range": [228, 237],
+                            "name": "lamp on",
+                            "center": true
+                        },
+                        {
+                            "range": [238, 247],
+                            "name": "open",
+                            "center": true
+                        },
+                        {
+                            "range": [248, 255],
+                            "name": "lamp off",
+                            "center": true
+                        }
+                    ]
+                },
+                "Dimmer": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "Close"
+                        },
+                        {
+                            "range": [1, 254],
+                            "name": "%"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "Open"
+                        }
+                    ]
+                },
+                "Cyan": {
+                    "type": "SingleColor",
+                    "color": "Cyan",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Magenta": {
+                    "type": "SingleColor",
+                    "color": "Magenta",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Yellow": {
+                    "type": "SingleColor",
+                    "color": "Yellow",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "CTO": {
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Gobo1": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 9],
+                            "name": "Open",
+                            "center": true
+                        },
+                        {
+                            "range": [10, 14],
+                            "name": "Slot 1 ind.",
+                            "center": true
+                        },
+                        {
+                            "range": [15, 19],
+                            "name": "Slot 2 ind.",
+                            "center": true
+                        },
+                        {
+                            "range": [20, 24],
+                            "name": "Slot 3 ind.",
+                            "center": true
+                        },
+                        {
+                            "range": [25, 29],
+                            "name": "Slot 4 ind.",
+                            "center": true
+                        },
+                        {
+                            "range": [30, 34],
+                            "name": "Slot 5 ind.",
+                            "center": true
+                        },
+                        {
+                            "range": [35, 39],
+                            "name": "Slot 1 rot.",
+                            "center": true
+                        },
+                        {
+                            "range": [40, 44],
+                            "name": "Slot 2 rot.",
+                            "center": true
+                        },
+                        {
+                            "range": [45, 49],
+                            "name": "Slot 3 rot.",
+                            "center": true
+                        },
+                        {
+                            "range": [50, 54],
+                            "name": "Slot 4 rot.",
+                            "center": true
+                        },
+                        {
+                            "range": [55, 59],
+                            "name": "Slot 5 rot.",
+                            "center": true
+                        },
+                        {
+                            "range": [60, 74],
+                            "name": "Slot 1 ind. sh."
+                        },
+                        {
+                            "range": [75, 89],
+                            "name": "Slot 2 ind. sh."
+                        },
+                        {
+                            "range": [90, 104],
+                            "name": "Slot 3 ind. sh."
+                        },
+                        {
+                            "range": [105, 119],
+                            "name": "Slot 4 ind. sh."
+                        },
+                        {
+                            "range": [120, 134],
+                            "name": "Slot 5 ind. sh."
+                        },
+                        {
+                            "range": [135, 149],
+                            "name": "Slot 1 rot. sh."
+                        },
+                        {
+                            "range": [150, 164],
+                            "name": "Slot 2 rot. sh."
+                        },
+                        {
+                            "range": [165, 179],
+                            "name": "Slot 3 rot. sh."
+                        },
+                        {
+                            "range": [180, 194],
+                            "name": "Slot 4 rot. sh."
+                        },
+                        {
+                            "range": [195, 209],
+                            "name": "Slot 5 rot. sh."
+                        },
+                        {
+                            "range": [210, 232],
+                            "name": ">>"
+                        },
+                        {
+                            "range": [233, 255],
+                            "name": "<<"
+                        }
+                    ]
+                },
+                "Gobo1 Rot": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "Index",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Gobo anim. func": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 9],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [10, 19],
+                            "name": "Vert. ind. po"
+                        },
+                        {
+                            "range": [20, 29],
+                            "name": "Hori. ind. pos."
+                        },
+                        {
+                            "range": [30, 39],
+                            "name": "Vert. cont. rot"
+                        },
+                        {
+                            "range": [40, 49],
+                            "name": "Hori. cont. rot"
+                        },
+                        {
+                            "range": [50, 139],
+                            "name": "Angled ind. pos"
+                        },
+                        {
+                            "range": [140, 229],
+                            "name": "Angled cont. ro"
+                        },
+                        {
+                            "range": [230, 235],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [236, 239],
+                            "name": "Macro1"
+                        },
+                        {
+                            "range": [240, 243],
+                            "name": "Macro2"
+                        },
+                        {
+                            "range": [244, 247],
+                            "name": "Macro3"
+                        },
+                        {
+                            "range": [248, 251],
+                            "name": "Macro4"
+                        },
+                        {
+                            "range": [252, 255],
+                            "name": "Macro5"
+                        }
+                    ]
+                },
+                "Gobo anim. spee": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 2],
+                            "name": "no rot."
+                        },
+                        {
+                            "range": [3, 127],
+                            "name": ">>"
+                        },
+                        {
+                            "range": [128, 252],
+                            "name": "<<"
+                        },
+                        {
+                            "range": [253, 255],
+                            "name": "no rot."
+                        }
+                    ]
+                },
+                "Frost (Effect)": {
+                    "type": "Effect",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "Open",
+                            "center": true
+                        },
+                        {
+                            "range": [1, 234],
+                            "name": "Frost",
+                            "color": "#edf5dd"
+                        },
+                        {
+                            "range": [235, 242],
+                            "name": "Effect 1",
+                            "center": true
+                        },
+                        {
+                            "range": [243, 250],
+                            "name": "Effect 2",
+                            "center": true
+                        },
+                        {
+                            "range": [251, 255],
+                            "name": "Open",
+                            "center": true
+                        }
+                    ]
+                },
+                "Iris": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [1, 199],
+                            "name": "%"
+                        },
+                        {
+                            "range": [200, 215],
+                            "name": "Close"
+                        },
+                        {
+                            "range": [216, 229],
+                            "name": "Opening pulse"
+                        },
+                        {
+                            "range": [230, 243],
+                            "name": "Closing pulse"
+                        },
+                        {
+                            "range": [244, 246],
+                            "name": "Random fast ope"
+                        },
+                        {
+                            "range": [247, 249],
+                            "name": "Random slow ope"
+                        },
+                        {
+                            "range": [250, 252],
+                            "name": "Random fast clo"
+                        },
+                        {
+                            "range": [253, 255],
+                            "name": "Random slow clo"
+                        }
+                    ]
+                },
+                "Framing Macro": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "No Macros",
+                            "center": true
+                        }
+                    ]
+                },
+                "Focus": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "Infinity"
+                        },
+                        {
+                            "range": [1, 254],
+                            "name": "%"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "Near"
+                        }
+                    ]
+                },
+                "Zoom": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "Flood"
+                        },
+                        {
+                            "range": [1, 254],
+                            "name": "%"
+                        },
+                        {
+                            "range": [0, 0],
+                            "name": "New Range"
+                        }
+                    ]
+                },
+                "Barn door 1": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "Out"
+                        },
+                        {
+                            "range": [1, 254],
+                            "name": "%"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "In"
+                        }
+                    ]
+                },
+                "Barn door 1 ang": {
+                    "type": "Beam",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 126],
+                            "name": "Angle -"
+                        },
+                        {
+                            "range": [127, 128],
+                            "name": "Parallel"
+                        },
+                        {
+                            "range": [129, 255],
+                            "name": "Angle +"
+                        }
+                    ]
+                },
+                "Barn door 2": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "Out"
+                        },
+                        {
+                            "range": [1, 254],
+                            "name": "%"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "In"
+                        }
+                    ]
+                },
+                "Barn door 2 ang": {
+                    "type": "Beam",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 126],
+                            "name": "Angle -"
+                        },
+                        {
+                            "range": [127, 128],
+                            "name": "Parallel"
+                        },
+                        {
+                            "range": [129, 255],
+                            "name": "Angle +"
+                        }
+                    ]
+                },
+                "Barn door 3": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "Out"
+                        },
+                        {
+                            "range": [1, 254],
+                            "name": "%"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "In"
+                        }
+                    ]
+                },
+                "Barn door 3 ang": {
+                    "type": "Beam",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 126],
+                            "name": "Angle -"
+                        },
+                        {
+                            "range": [127, 128],
+                            "name": "Parallel"
+                        },
+                        {
+                            "range": [129, 255],
+                            "name": "Angle +"
+                        }
+                    ]
+                },
+                "Barn door 4": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "Out"
+                        },
+                        {
+                            "range": [1, 254],
+                            "name": "%"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "In"
+                        }
+                    ]
+                },
+                "Barn door 4 ang": {
+                    "type": "Beam",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 126],
+                            "name": "Angle -"
+                        },
+                        {
+                            "range": [127, 128],
+                            "name": "Parallel"
+                        },
+                        {
+                            "range": [129, 255],
+                            "name": "Angle +"
+                        }
+                    ]
+                },
+                "Barn door rot.": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "Right"
+                        },
+                        {
+                            "range": [128, 128],
+                            "name": "128",
+                            "center": true
+                        },
+                        {
+                            "range": [129, 255],
+                            "name": "Left"
+                        }
+                    ]
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Pan/Tilt speed": {
+                    "type": "Speed",
+                    "capabilities": [
+                        {
+                            "range": [0, 2],
+                            "name": "Tracking"
+                        },
+                        {
+                            "range": [3, 242],
+                            "name": "Fast->slow"
+                        },
+                        {
+                            "range": [243, 245],
+                            "name": "Tracking PTSP s",
+                            "center": true
+                        },
+                        {
+                            "range": [246, 248],
+                            "name": "Tracking PTSP n",
+                            "center": true
+                        },
+                        {
+                            "range": [249, 251],
+                            "name": "Tracking PTSP f",
+                            "center": true
+                        },
+                        {
+                            "range": [252, 255],
+                            "name": "Move blackout",
+                            "center": true
+                        }
+                    ]
+                },
+                "Effects speed": {
+                    "type": "Speed",
+                    "capabilities": [
+                        {
+                            "range": [0, 2],
+                            "name": "Tracking",
+                            "center": true
+                        },
+                        {
+                            "range": [3, 245],
+                            "name": "fast->slow"
+                        },
+                        {
+                            "range": [246, 251],
+                            "name": "Special"
+                        },
+                        {
+                            "range": [252, 255],
+                            "name": "Move blackout",
+                            "center": true
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "28-channel Mode",
+                    "shortName": "28ch",
+                    "channels": [
+                        "Shutter",
+                        "Dimmer",
+                        "Cyan",
+                        "Magenta",
+                        "Yellow",
+                        "CTO",
+                        "Gobo1",
+                        "Gobo1 Rot",
+                        "Gobo anim. func",
+                        "Gobo anim. spee",
+                        "Frost (Effect)",
+                        "Iris",
+                        "Framing Macro",
+                        "Focus",
+                        "Zoom",
+                        "Barn door 1",
+                        "Barn door 1 ang",
+                        "Barn door 2",
+                        "Barn door 2 ang",
+                        "Barn door 3",
+                        "Barn door 3 ang",
+                        "Barn door 4",
+                        "Barn door 4 ang",
+                        "Barn door rot.",
+                        "Pan",
+                        "Tilt",
+                        "Pan/Tilt speed",
+                        "Effects speed"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Martin",
+            "name": "Mac 2000 Wash",
+            "shortName": "2000Wash",
+            "physical": {
+                "dimensions": [500, 500, 750],
+                "weight": 34
+            },
+            "availableChannels": {
+                "Shutter": {
+                    "type": "Shutter",
+                    "defaultValue": 35,
+                    "crossfade": true
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Cyan": {
+                    "type": "SingleColor",
+                    "color": "Cyan",
+                    "crossfade": true
+                },
+                "Magenta": {
+                    "type": "SingleColor",
+                    "color": "Magenta",
+                    "crossfade": true
+                },
+                "Yellow": {
+                    "type": "SingleColor",
+                    "color": "Yellow",
+                    "crossfade": true
+                },
+                "CTC": {
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "crossfade": true
+                },
+                "CW 1": {
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "crossfade": true
+                },
+                "CW 2": {
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "crossfade": true
+                },
+                "Zoom": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Barndoor1": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Barndoor2": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Barndoor3": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Barndoor4": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "BarnRot": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Reserve": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "highlightValue": null
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 0,
+                    "crossfade": true,
+                    "highlightValue": null
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "highlightValue": null
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 0,
+                    "crossfade": true,
+                    "highlightValue": null
+                },
+                "SpeedMov": {
+                    "type": "Speed",
+                    "crossfade": true
+                },
+                "SpeedCol": {
+                    "type": "Speed",
+                    "crossfade": true
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "21-channel Mode",
+                    "shortName": "21ch",
+                    "channels": [
+                        "Shutter",
+                        "Intensity",
+                        "Cyan",
+                        "Magenta",
+                        "Yellow",
+                        "CTC",
+                        "CW 1",
+                        "CW 2",
+                        "Zoom",
+                        "Barndoor1",
+                        "Barndoor2",
+                        "Barndoor3",
+                        "Barndoor4",
+                        "BarnRot",
+                        "Reserve",
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "SpeedMov",
+                        "SpeedCol"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Martin",
+            "name": "Mac 250",
+            "shortName": "Mac250v1",
+            "comment": "New alternative definition",
+            "physical": {
+                "dimensions": [384, 384, 557],
+                "weight": 22
+            },
+            "availableChannels": {
+                "Strobe": {
+                    "type": "Strobe",
+                    "defaultValue": 20,
+                    "highlightValue": 20,
+                    "capabilities": [
+                        {
+                            "range": [0, 19],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [20, 49],
+                            "name": "open"
+                        },
+                        {
+                            "range": [50, 72],
+                            "name": "strobe"
+                        },
+                        {
+                            "range": [80, 119],
+                            "name": "pulse"
+                        },
+                        {
+                            "range": [128, 202],
+                            "name": "random",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [212, 231],
+                            "name": "reset",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [232, 217],
+                            "name": "lamp on",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [218, 227],
+                            "name": "shutter open",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [228, 237],
+                            "name": "lamp on",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [238, 247],
+                            "name": "shutter open",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [248, 255],
+                            "name": "lamp off",
+                            "showInMenu": false
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Colour": {
+                    "type": "MultiColor",
+                    "capabilities": [
+                        {
+                            "range": [0, 11],
+                            "name": "white",
+                            "color": "#ffffff"
+                        },
+                        {
+                            "range": [12, 23],
+                            "name": "ctc"
+                        },
+                        {
+                            "range": [24, 35],
+                            "name": "yellow",
+                            "color": "#ffff00"
+                        },
+                        {
+                            "range": [36, 47],
+                            "name": "blue104"
+                        },
+                        {
+                            "range": [48, 59],
+                            "name": "pink",
+                            "color": "#ffc0cb"
+                        },
+                        {
+                            "range": [60, 71],
+                            "name": "green206"
+                        },
+                        {
+                            "range": [72, 83],
+                            "name": "blue108"
+                        },
+                        {
+                            "range": [84, 95],
+                            "name": "red",
+                            "color": "#ff0000"
+                        },
+                        {
+                            "range": [96, 107],
+                            "name": "magenta",
+                            "color": "#ca1f7b"
+                        },
+                        {
+                            "range": [108, 119],
+                            "name": "blue101"
+                        },
+                        {
+                            "range": [120, 131],
+                            "name": "o    range",
+                            "color": "#ff7f00"
+                        },
+                        {
+                            "range": [132, 143],
+                            "name": "green202"
+                        },
+                        {
+                            "range": [144, 155],
+                            "name": "lavender",
+                            "color": "#b57edc"
+                        },
+                        {
+                            "range": [156, 159],
+                            "name": "lavender",
+                            "color": "#b57edc",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [160, 163],
+                            "name": "green202",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [164, 167],
+                            "name": "o    range",
+                            "color": "#ff7f00",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [168, 171],
+                            "name": "blue101",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [172, 175],
+                            "name": "magenta",
+                            "color": "#ca1f7b",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [176, 179],
+                            "name": "red",
+                            "color": "#ff0000",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [180, 183],
+                            "name": "blue108",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [184, 187],
+                            "name": "green206",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [188, 191],
+                            "name": "pink",
+                            "color": "#ffc0cb",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [192, 195],
+                            "name": "blue104",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [196, 199],
+                            "name": "yellow",
+                            "color": "#ffff00",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [200, 203],
+                            "name": "ctc",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [204, 207],
+                            "name": "white",
+                            "color": "#ffffff",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [208, 226],
+                            "name": ">>",
+                            "center": true
+                        },
+                        {
+                            "range": [227, 245],
+                            "name": "<<",
+                            "center": true
+                        },
+                        {
+                            "range": [246, 255],
+                            "name": "random",
+                            "showInMenu": false
+                        }
+                    ]
+                },
+                "Gobo": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 9],
+                            "name": "open"
+                        },
+                        {
+                            "range": [10, 19],
+                            "name": "gobo1",
+                            "center": true
+                        },
+                        {
+                            "range": [20, 29],
+                            "name": "gobo2",
+                            "center": true
+                        },
+                        {
+                            "range": [30, 39],
+                            "name": "gobo3",
+                            "center": true
+                        },
+                        {
+                            "range": [40, 49],
+                            "name": "gobo4",
+                            "center": true
+                        },
+                        {
+                            "range": [50, 59],
+                            "name": "gobo5",
+                            "center": true
+                        },
+                        {
+                            "range": [60, 69],
+                            "name": "gobo6",
+                            "center": true
+                        },
+                        {
+                            "range": [70, 79],
+                            "name": "gobo7",
+                            "center": true
+                        },
+                        {
+                            "range": [80, 89],
+                            "name": "gobo8",
+                            "center": true
+                        },
+                        {
+                            "range": [90, 104],
+                            "name": "shake8",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [105, 119],
+                            "name": "shake7",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [120, 134],
+                            "name": "shake6",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [135, 149],
+                            "name": "shake5",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [150, 164],
+                            "name": "shake4",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [165, 179],
+                            "name": "shake3",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [180, 194],
+                            "name": "shake2",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [195, 209],
+                            "name": "shake1",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [210, 232],
+                            "name": "fast to slow",
+                            "center": true
+                        },
+                        {
+                            "range": [233, 255],
+                            "name": "slow to fast",
+                            "center": true
+                        }
+                    ]
+                },
+                "Gobo <>": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 2],
+                            "name": "static",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [3, 127],
+                            "name": ">>",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [128, 252],
+                            "name": "<<",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [253, 255],
+                            "name": "static",
+                            "showInMenu": false
+                        }
+                    ]
+                },
+                "Focus": {
+                    "type": "Beam",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Prism": {
+                    "type": "Prism",
+                    "capabilities": [
+                        {
+                            "range": [0, 19],
+                            "name": "open"
+                        },
+                        {
+                            "range": [20, 79],
+                            "name": "prism<<",
+                            "center": true
+                        },
+                        {
+                            "range": [80, 89],
+                            "name": "rot stop"
+                        },
+                        {
+                            "range": [90, 149],
+                            "name": "prism>>",
+                            "center": true
+                        },
+                        {
+                            "range": [150, 215],
+                            "name": "open",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [216, 220],
+                            "name": "macro1",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [221, 225],
+                            "name": "macro2",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [226, 230],
+                            "name": "macro3",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [231, 235],
+                            "name": "macro4",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [236, 240],
+                            "name": "macro5",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [241, 245],
+                            "name": "macro6",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [246, 250],
+                            "name": "macro7",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [251, 255],
+                            "name": "macro8",
+                            "showInMenu": false
+                        }
+                    ]
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "11-channel Mode",
+                    "shortName": "11ch",
+                    "channels": [
+                        "Strobe",
+                        "Intensity",
+                        "Colour",
+                        "Gobo",
+                        "Gobo <>",
+                        "Focus",
+                        "Prism",
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Martin",
+            "name": "Mac 250 Entour",
+            "shortName": "Mac250E",
+            "comment": "16 bit Modus",
+            "physical": {
+                "dimensions": [375, 375, 550]
+            },
+            "availableChannels": {
+                "Shutter": {
+                    "type": "Shutter",
+                    "capabilities": [
+                        {
+                            "range": [0, 19],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [20, 49],
+                            "name": "open"
+                        },
+                        {
+                            "range": [50, 72],
+                            "name": "strobe"
+                        },
+                        {
+                            "range": [73, 79],
+                            "name": "open"
+                        },
+                        {
+                            "range": [80, 119],
+                            "name": "pulse"
+                        },
+                        {
+                            "range": [120, 127],
+                            "name": "open"
+                        },
+                        {
+                            "range": [128, 187],
+                            "name": "random strobe"
+                        },
+                        {
+                            "range": [188, 190],
+                            "name": "open"
+                        },
+                        {
+                            "range": [191, 202],
+                            "name": "random pulse"
+                        },
+                        {
+                            "range": [203, 207],
+                            "name": "open"
+                        },
+                        {
+                            "range": [208, 217],
+                            "name": "reset"
+                        },
+                        {
+                            "range": [218, 227],
+                            "name": "open"
+                        },
+                        {
+                            "range": [228, 237],
+                            "name": "lamp on"
+                        },
+                        {
+                            "range": [238, 247],
+                            "name": "open"
+                        },
+                        {
+                            "range": [248, 255],
+                            "name": "lamp off"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Color": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 10],
+                            "name": "white",
+                            "color": "#ffffff"
+                        },
+                        {
+                            "range": [11, 21],
+                            "name": "CTC"
+                        },
+                        {
+                            "range": [22, 32],
+                            "name": "yello 603"
+                        },
+                        {
+                            "range": [33, 43],
+                            "name": "blue 104"
+                        },
+                        {
+                            "range": [44, 54],
+                            "name": "pink 312"
+                        },
+                        {
+                            "range": [55, 65],
+                            "name": "green 206"
+                        },
+                        {
+                            "range": [66, 76],
+                            "name": "blue 108"
+                        },
+                        {
+                            "range": [77, 87],
+                            "name": "red 301"
+                        },
+                        {
+                            "range": [88, 98],
+                            "name": "magenta 507"
+                        },
+                        {
+                            "range": [99, 109],
+                            "name": "blue 101"
+                        },
+                        {
+                            "range": [110, 120],
+                            "name": "orange 306"
+                        },
+                        {
+                            "range": [121, 131],
+                            "name": "dark green",
+                            "color": "#013220"
+                        },
+                        {
+                            "range": [132, 142],
+                            "name": "pur 502"
+                        },
+                        {
+                            "range": [143, 155],
+                            "name": "white",
+                            "color": "#ffffff"
+                        },
+                        {
+                            "range": [156, 159],
+                            "name": "pur 502"
+                        },
+                        {
+                            "range": [160, 163],
+                            "name": "dark green",
+                            "color": "#013220"
+                        },
+                        {
+                            "range": [164, 167],
+                            "name": "orange 306"
+                        },
+                        {
+                            "range": [168, 171],
+                            "name": "blue 101"
+                        },
+                        {
+                            "range": [172, 175],
+                            "name": "magenta 507"
+                        },
+                        {
+                            "range": [176, 179],
+                            "name": "red 301"
+                        },
+                        {
+                            "range": [180, 183],
+                            "name": "blue 108"
+                        },
+                        {
+                            "range": [184, 187],
+                            "name": "green 206"
+                        },
+                        {
+                            "range": [188, 191],
+                            "name": "pink 312"
+                        },
+                        {
+                            "range": [192, 195],
+                            "name": "blue 104"
+                        },
+                        {
+                            "range": [196, 199],
+                            "name": "yellow 603"
+                        },
+                        {
+                            "range": [200, 203],
+                            "name": "CTC"
+                        },
+                        {
+                            "range": [204, 207],
+                            "name": "white",
+                            "color": "#ffffff"
+                        },
+                        {
+                            "range": [208, 226],
+                            "name": "rot CW"
+                        },
+                        {
+                            "range": [227, 245],
+                            "name": "rot CCW"
+                        },
+                        {
+                            "range": [246, 255],
+                            "name": "random"
+                        }
+                    ]
+                },
+                "Gobo1": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 4],
+                            "name": "open"
+                        },
+                        {
+                            "range": [5, 10],
+                            "name": "Gobo 1"
+                        },
+                        {
+                            "range": [11, 15],
+                            "name": "Gobo 2"
+                        },
+                        {
+                            "range": [16, 20],
+                            "name": "Gobo 3"
+                        },
+                        {
+                            "range": [21, 25],
+                            "name": "Gobo 4"
+                        },
+                        {
+                            "range": [26, 30],
+                            "name": "Gobo 5"
+                        },
+                        {
+                            "range": [31, 35],
+                            "name": "Gobo 6"
+                        },
+                        {
+                            "range": [36, 42],
+                            "name": "Gobo 7"
+                        },
+                        {
+                            "range": [43, 50],
+                            "name": "TOpen"
+                        },
+                        {
+                            "range": [51, 58],
+                            "name": "TGobo 1"
+                        },
+                        {
+                            "range": [59, 65],
+                            "name": "TGobo 2"
+                        },
+                        {
+                            "range": [66, 73],
+                            "name": "TGobo 3"
+                        },
+                        {
+                            "range": [74, 81],
+                            "name": "TGobo 4"
+                        },
+                        {
+                            "range": [82, 89],
+                            "name": "TGobo 5"
+                        },
+                        {
+                            "range": [90, 96],
+                            "name": "TGobo 6"
+                        },
+                        {
+                            "range": [97, 104],
+                            "name": "TGobo 7"
+                        },
+                        {
+                            "range": [105, 119],
+                            "name": "SGobo 7"
+                        },
+                        {
+                            "range": [120, 134],
+                            "name": "SGobo 6"
+                        },
+                        {
+                            "range": [135, 149],
+                            "name": "SGobo 5"
+                        },
+                        {
+                            "range": [150, 164],
+                            "name": "SGobo 4"
+                        },
+                        {
+                            "range": [180, 194],
+                            "name": "SGobo 3"
+                        },
+                        {
+                            "range": [180, 194],
+                            "name": "SGobo 2"
+                        },
+                        {
+                            "range": [195, 209],
+                            "name": "SGobo 1"
+                        },
+                        {
+                            "range": [210, 232],
+                            "name": "Rot CW"
+                        },
+                        {
+                            "range": [233, 255],
+                            "name": "Rot CCW"
+                        }
+                    ]
+                },
+                "Gobo Rot": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "Index",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "Gobo Rot fine": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "Index",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "Gobo2": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 7],
+                            "name": "open"
+                        },
+                        {
+                            "range": [8, 15],
+                            "name": "Gobo 1"
+                        },
+                        {
+                            "range": [16, 23],
+                            "name": "Gobo 2"
+                        },
+                        {
+                            "range": [28, 31],
+                            "name": "Gobo 3"
+                        },
+                        {
+                            "range": [32, 39],
+                            "name": "Gobo 4"
+                        },
+                        {
+                            "range": [40, 47],
+                            "name": "Gobo 5"
+                        },
+                        {
+                            "range": [48, 55],
+                            "name": "Gobo 6"
+                        },
+                        {
+                            "range": [56, 63],
+                            "name": "Gobo 7"
+                        },
+                        {
+                            "range": [64, 71],
+                            "name": "Gobo 8"
+                        },
+                        {
+                            "range": [72, 79],
+                            "name": "Gobo 9"
+                        },
+                        {
+                            "range": [80, 87],
+                            "name": "Gobo 10"
+                        },
+                        {
+                            "range": [88, 95],
+                            "name": "open"
+                        },
+                        {
+                            "range": [96, 105],
+                            "name": "SGobo 10"
+                        },
+                        {
+                            "range": [106, 115],
+                            "name": "SGobo 9"
+                        },
+                        {
+                            "range": [116, 125],
+                            "name": "SGobo 8"
+                        },
+                        {
+                            "range": [126, 135],
+                            "name": "SGobo 7"
+                        },
+                        {
+                            "range": [136, 145],
+                            "name": "SGobo 6"
+                        },
+                        {
+                            "range": [146, 155],
+                            "name": "SGobo 5"
+                        },
+                        {
+                            "range": [156, 165],
+                            "name": "SGobo 4"
+                        },
+                        {
+                            "range": [166, 175],
+                            "name": "SGobo 3"
+                        },
+                        {
+                            "range": [176, 185],
+                            "name": "SGobo 2"
+                        },
+                        {
+                            "range": [186, 195],
+                            "name": "SGobo 1"
+                        },
+                        {
+                            "range": [196, 205],
+                            "name": "open"
+                        },
+                        {
+                            "range": [206, 230],
+                            "name": "Rot CW"
+                        },
+                        {
+                            "range": [231, 255],
+                            "name": "Rot CCW"
+                        }
+                    ]
+                },
+                "Focus": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Prism": {
+                    "type": "Prism",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 19],
+                            "name": "open"
+                        },
+                        {
+                            "range": [20, 79],
+                            "name": "Rot CCW"
+                        },
+                        {
+                            "range": [80, 89],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [90, 149],
+                            "name": "Rot CW"
+                        },
+                        {
+                            "range": [150, 215],
+                            "name": "open"
+                        },
+                        {
+                            "range": [216, 220],
+                            "name": "Makro 1"
+                        },
+                        {
+                            "range": [221, 225],
+                            "name": "Makro 2"
+                        },
+                        {
+                            "range": [226, 230],
+                            "name": "Makro 3"
+                        },
+                        {
+                            "range": [231, 235],
+                            "name": "Makro 4"
+                        },
+                        {
+                            "range": [236, 240],
+                            "name": "Makro 5"
+                        },
+                        {
+                            "range": [241, 245],
+                            "name": "Makro 6"
+                        },
+                        {
+                            "range": [246, 250],
+                            "name": "Makro 7"
+                        },
+                        {
+                            "range": [251, 255],
+                            "name": "Makro 8"
+                        }
+                    ]
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "P+T Speed": {
+                    "type": "Speed",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 2],
+                            "name": "Tracking"
+                        },
+                        {
+                            "range": [3, 245],
+                            "name": "fast-slow"
+                        },
+                        {
+                            "range": [246, 248],
+                            "name": "Tracking PTSP N"
+                        },
+                        {
+                            "range": [249, 251],
+                            "name": "Tracking PTSP F"
+                        },
+                        {
+                            "range": [252, 255],
+                            "name": "DBO Move"
+                        }
+                    ]
+                },
+                "Effect Speed": {
+                    "type": "Speed",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 2],
+                            "name": "Tracking"
+                        },
+                        {
+                            "range": [3, 245],
+                            "name": "fast-slow"
+                        },
+                        {
+                            "range": [246, 251],
+                            "name": "Tracking"
+                        },
+                        {
+                            "range": [252, 255],
+                            "name": "Maximum Speed"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Gobo Rot",
+                    "Gobo Rot fine"
+                ],
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "15-channel Mode",
+                    "shortName": "15ch",
+                    "channels": [
+                        "Shutter",
+                        "Intensity",
+                        "Color",
+                        "Gobo1",
+                        "Gobo Rot",
+                        "Gobo Rot fine",
+                        "Gobo2",
+                        "Focus",
+                        "Prism",
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "P+T Speed",
+                        "Effect Speed"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Martin",
+            "name": "Mac 250 Entour E",
+            "shortName": "Mac250EE",
+            "comment": "16 bit Extended Modus",
+            "physical": {
+                "dimensions": [375, 375, 550]
+            },
+            "availableChannels": {
+                "Shutter": {
+                    "type": "Shutter",
+                    "capabilities": [
+                        {
+                            "range": [0, 19],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [20, 49],
+                            "name": "open"
+                        },
+                        {
+                            "range": [50, 72],
+                            "name": "strobe"
+                        },
+                        {
+                            "range": [73, 79],
+                            "name": "open"
+                        },
+                        {
+                            "range": [80, 119],
+                            "name": "pulse"
+                        },
+                        {
+                            "range": [120, 127],
+                            "name": "open"
+                        },
+                        {
+                            "range": [128, 187],
+                            "name": "random strobe"
+                        },
+                        {
+                            "range": [188, 190],
+                            "name": "open"
+                        },
+                        {
+                            "range": [191, 202],
+                            "name": "random pulse"
+                        },
+                        {
+                            "range": [203, 207],
+                            "name": "open"
+                        },
+                        {
+                            "range": [208, 217],
+                            "name": "reset"
+                        },
+                        {
+                            "range": [218, 227],
+                            "name": "open"
+                        },
+                        {
+                            "range": [228, 237],
+                            "name": "lamp on"
+                        },
+                        {
+                            "range": [238, 247],
+                            "name": "open"
+                        },
+                        {
+                            "range": [248, 255],
+                            "name": "lamp off"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 0,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "defaultValue": null
+                },
+                "Intensity fine": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "defaultValue": null
+                },
+                "Color": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 2815],
+                            "name": "white",
+                            "warning": "Out of range!",
+                            "color": "#ffffff"
+                        },
+                        {
+                            "range": [2816, 5631],
+                            "name": "CTC",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [5632, 8447],
+                            "name": "yello 603",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [8448, 11263],
+                            "name": "blue 104",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [11264, 14079],
+                            "name": "pink 312",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [14080, 16895],
+                            "name": "green 206",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [16896, 19711],
+                            "name": "blue 108",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [19712, 22527],
+                            "name": "red 301",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [22528, 25343],
+                            "name": "magenta 507",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [25344, 28159],
+                            "name": "blue 101",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [28160, 30975],
+                            "name": "orange 306",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [30976, 33791],
+                            "name": "dark green",
+                            "warning": "Out of range!",
+                            "color": "#013220"
+                        },
+                        {
+                            "range": [33792, 36607],
+                            "name": "pur 502",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [36608, 39935],
+                            "name": "white",
+                            "warning": "Out of range!",
+                            "color": "#ffffff"
+                        },
+                        {
+                            "range": [39936, 40704],
+                            "name": "pur 502",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [40960, 41728],
+                            "name": "dark green",
+                            "warning": "Out of range!",
+                            "color": "#013220"
+                        },
+                        {
+                            "range": [41984, 42752],
+                            "name": "orange 306",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [43008, 43776],
+                            "name": "blue 101",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [44032, 44800],
+                            "name": "magenta 507",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [45056, 45824],
+                            "name": "red 301",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [46080, 46848],
+                            "name": "blue 108",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [47104, 47872],
+                            "name": "green 206",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [48128, 48896],
+                            "name": "pink 312",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [49152, 49920],
+                            "name": "blue 104",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [50176, 50944],
+                            "name": "yellow 603",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [51200, 51968],
+                            "name": "CTC",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [52224, 52992],
+                            "name": "white",
+                            "warning": "Out of range!",
+                            "color": "#ffffff"
+                        },
+                        {
+                            "range": [53248, 57856],
+                            "name": "rot CW",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [58112, 62720],
+                            "name": "rot CCW",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [62976, 65280],
+                            "name": "random",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "Color fine": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 2815],
+                            "name": "white",
+                            "warning": "Out of range!",
+                            "color": "#ffffff"
+                        },
+                        {
+                            "range": [2816, 5631],
+                            "name": "CTC",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [5632, 8447],
+                            "name": "yello 603",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [8448, 11263],
+                            "name": "blue 104",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [11264, 14079],
+                            "name": "pink 312",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [14080, 16895],
+                            "name": "green 206",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [16896, 19711],
+                            "name": "blue 108",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [19712, 22527],
+                            "name": "red 301",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [22528, 25343],
+                            "name": "magenta 507",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [25344, 28159],
+                            "name": "blue 101",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [28160, 30975],
+                            "name": "orange 306",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [30976, 33791],
+                            "name": "dark green",
+                            "warning": "Out of range!",
+                            "color": "#013220"
+                        },
+                        {
+                            "range": [33792, 36607],
+                            "name": "pur 502",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [36608, 39935],
+                            "name": "white",
+                            "warning": "Out of range!",
+                            "color": "#ffffff"
+                        },
+                        {
+                            "range": [39936, 40704],
+                            "name": "pur 502",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [40960, 41728],
+                            "name": "dark green",
+                            "warning": "Out of range!",
+                            "color": "#013220"
+                        },
+                        {
+                            "range": [41984, 42752],
+                            "name": "orange 306",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [43008, 43776],
+                            "name": "blue 101",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [44032, 44800],
+                            "name": "magenta 507",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [45056, 45824],
+                            "name": "red 301",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [46080, 46848],
+                            "name": "blue 108",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [47104, 47872],
+                            "name": "green 206",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [48128, 48896],
+                            "name": "pink 312",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [49152, 49920],
+                            "name": "blue 104",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [50176, 50944],
+                            "name": "yellow 603",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [51200, 51968],
+                            "name": "CTC",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [52224, 52992],
+                            "name": "white",
+                            "warning": "Out of range!",
+                            "color": "#ffffff"
+                        },
+                        {
+                            "range": [53248, 57856],
+                            "name": "rot CW",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [58112, 62720],
+                            "name": "rot CCW",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [62976, 65280],
+                            "name": "random",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "Gobo1": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 4],
+                            "name": "open"
+                        },
+                        {
+                            "range": [5, 10],
+                            "name": "Gobo 1"
+                        },
+                        {
+                            "range": [11, 15],
+                            "name": "Gobo 2"
+                        },
+                        {
+                            "range": [16, 20],
+                            "name": "Gobo 3"
+                        },
+                        {
+                            "range": [21, 25],
+                            "name": "Gobo 4"
+                        },
+                        {
+                            "range": [26, 30],
+                            "name": "Gobo 5"
+                        },
+                        {
+                            "range": [31, 35],
+                            "name": "Gobo 6"
+                        },
+                        {
+                            "range": [36, 42],
+                            "name": "Gobo 7"
+                        },
+                        {
+                            "range": [43, 50],
+                            "name": "TOpen"
+                        },
+                        {
+                            "range": [51, 58],
+                            "name": "TGobo 1"
+                        },
+                        {
+                            "range": [59, 65],
+                            "name": "TGobo 2"
+                        },
+                        {
+                            "range": [66, 73],
+                            "name": "TGobo 3"
+                        },
+                        {
+                            "range": [74, 81],
+                            "name": "TGobo 4"
+                        },
+                        {
+                            "range": [82, 89],
+                            "name": "TGobo 5"
+                        },
+                        {
+                            "range": [90, 96],
+                            "name": "TGobo 6"
+                        },
+                        {
+                            "range": [97, 104],
+                            "name": "TGobo 7"
+                        },
+                        {
+                            "range": [105, 119],
+                            "name": "SGobo 7"
+                        },
+                        {
+                            "range": [120, 134],
+                            "name": "SGobo 6"
+                        },
+                        {
+                            "range": [135, 149],
+                            "name": "SGobo 5"
+                        },
+                        {
+                            "range": [150, 164],
+                            "name": "SGobo 4"
+                        },
+                        {
+                            "range": [180, 194],
+                            "name": "SGobo 3"
+                        },
+                        {
+                            "range": [180, 194],
+                            "name": "SGobo 2"
+                        },
+                        {
+                            "range": [195, 209],
+                            "name": "SGobo 1"
+                        },
+                        {
+                            "range": [210, 232],
+                            "name": "Rot CW"
+                        },
+                        {
+                            "range": [233, 255],
+                            "name": "Rot CCW"
+                        }
+                    ]
+                },
+                "Gobo Rot": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "Index",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "Gobo Rot fine": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "Index",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "Gobo2": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 7],
+                            "name": "open"
+                        },
+                        {
+                            "range": [8, 15],
+                            "name": "Gobo 1"
+                        },
+                        {
+                            "range": [16, 23],
+                            "name": "Gobo 2"
+                        },
+                        {
+                            "range": [28, 31],
+                            "name": "Gobo 3"
+                        },
+                        {
+                            "range": [32, 39],
+                            "name": "Gobo 4"
+                        },
+                        {
+                            "range": [40, 47],
+                            "name": "Gobo 5"
+                        },
+                        {
+                            "range": [48, 55],
+                            "name": "Gobo 6"
+                        },
+                        {
+                            "range": [56, 63],
+                            "name": "Gobo 7"
+                        },
+                        {
+                            "range": [64, 71],
+                            "name": "Gobo 8"
+                        },
+                        {
+                            "range": [72, 79],
+                            "name": "Gobo 9"
+                        },
+                        {
+                            "range": [80, 87],
+                            "name": "Gobo 10"
+                        },
+                        {
+                            "range": [88, 95],
+                            "name": "open"
+                        },
+                        {
+                            "range": [96, 105],
+                            "name": "SGobo 10"
+                        },
+                        {
+                            "range": [106, 115],
+                            "name": "SGobo 9"
+                        },
+                        {
+                            "range": [116, 125],
+                            "name": "SGobo 8"
+                        },
+                        {
+                            "range": [126, 135],
+                            "name": "SGobo 7"
+                        },
+                        {
+                            "range": [136, 145],
+                            "name": "SGobo 6"
+                        },
+                        {
+                            "range": [146, 155],
+                            "name": "SGobo 5"
+                        },
+                        {
+                            "range": [156, 165],
+                            "name": "SGobo 4"
+                        },
+                        {
+                            "range": [166, 175],
+                            "name": "SGobo 3"
+                        },
+                        {
+                            "range": [176, 185],
+                            "name": "SGobo 2"
+                        },
+                        {
+                            "range": [186, 195],
+                            "name": "SGobo 1"
+                        },
+                        {
+                            "range": [196, 205],
+                            "name": "open"
+                        },
+                        {
+                            "range": [206, 230],
+                            "name": "Rot CW"
+                        },
+                        {
+                            "range": [231, 255],
+                            "name": "Rot CCW"
+                        }
+                    ]
+                },
+                "Focus": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "Focus fine": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "Prism": {
+                    "type": "Prism",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 19],
+                            "name": "open"
+                        },
+                        {
+                            "range": [20, 79],
+                            "name": "Rot CCW"
+                        },
+                        {
+                            "range": [80, 89],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [90, 149],
+                            "name": "Rot CW"
+                        },
+                        {
+                            "range": [150, 215],
+                            "name": "open"
+                        },
+                        {
+                            "range": [216, 220],
+                            "name": "Makro 1"
+                        },
+                        {
+                            "range": [221, 225],
+                            "name": "Makro 2"
+                        },
+                        {
+                            "range": [226, 230],
+                            "name": "Makro 3"
+                        },
+                        {
+                            "range": [231, 235],
+                            "name": "Makro 4"
+                        },
+                        {
+                            "range": [236, 240],
+                            "name": "Makro 5"
+                        },
+                        {
+                            "range": [241, 245],
+                            "name": "Makro 6"
+                        },
+                        {
+                            "range": [246, 250],
+                            "name": "Makro 7"
+                        },
+                        {
+                            "range": [251, 255],
+                            "name": "Makro 8"
+                        }
+                    ]
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "P/T Speed": {
+                    "type": "Speed",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 2],
+                            "name": "Tracking"
+                        },
+                        {
+                            "range": [3, 245],
+                            "name": "fast-slow"
+                        },
+                        {
+                            "range": [246, 248],
+                            "name": "Tracking PTSP N"
+                        },
+                        {
+                            "range": [249, 251],
+                            "name": "Tracking PTSP F"
+                        },
+                        {
+                            "range": [252, 255],
+                            "name": "DBO Move"
+                        }
+                    ]
+                },
+                "FX Speed": {
+                    "type": "Speed",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 2],
+                            "name": "track"
+                        },
+                        {
+                            "range": [3, 255],
+                            "name": "speed"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Intensity",
+                    "Intensity fine"
+                ],
+                [
+                    "Color",
+                    "Color fine"
+                ],
+                [
+                    "Gobo Rot",
+                    "Gobo Rot fine"
+                ],
+                [
+                    "Focus",
+                    "Focus fine"
+                ],
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "18-channel Mode",
+                    "shortName": "18ch",
+                    "channels": [
+                        "Shutter",
+                        "Intensity",
+                        "Intensity fine",
+                        "Color",
+                        "Color fine",
+                        "Gobo1",
+                        "Gobo Rot",
+                        "Gobo Rot fine",
+                        "Gobo2",
+                        "Focus",
+                        "Focus fine",
+                        "Prism",
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "P/T Speed",
+                        "FX Speed"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Martin",
+            "name": "Mac 250 Krypton",
+            "shortName": "Mac250Kryp",
+            "comment": "Mode 1/ 16bit Modus",
+            "physical": {
+                "dimensions": [375, 375, 550]
+            },
+            "availableChannels": {
+                "Strobe": {
+                    "type": "Strobe",
+                    "defaultValue": 20,
+                    "highlightValue": 20,
+                    "capabilities": [
+                        {
+                            "range": [0, 19],
+                            "name": "Closed"
+                        },
+                        {
+                            "range": [20, 49],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [50, 72],
+                            "name": "Strobe"
+                        },
+                        {
+                            "range": [80, 119],
+                            "name": "Pulse"
+                        },
+                        {
+                            "range": [128, 202],
+                            "name": "Random",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [208, 217],
+                            "name": "Reset",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [228, 237],
+                            "name": "Lamp On",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [248, 255],
+                            "name": "Lamp Off",
+                            "showInMenu": false
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Colour": {
+                    "type": "MultiColor",
+                    "capabilities": [
+                        {
+                            "range": [0, 10],
+                            "name": "White",
+                            "color": "#ffffff"
+                        },
+                        {
+                            "range": [11, 21],
+                            "name": "CTC"
+                        },
+                        {
+                            "range": [22, 32],
+                            "name": "Yellow",
+                            "color": "#ffff00"
+                        },
+                        {
+                            "range": [33, 43],
+                            "name": "Blue",
+                            "color": "#0000ff"
+                        },
+                        {
+                            "range": [44, 54],
+                            "name": "Pink",
+                            "color": "#ffc0cb"
+                        },
+                        {
+                            "range": [55, 65],
+                            "name": "Green",
+                            "color": "#00ff00"
+                        },
+                        {
+                            "range": [66, 76],
+                            "name": "Blue",
+                            "color": "#0000ff"
+                        },
+                        {
+                            "range": [77, 87],
+                            "name": "Red",
+                            "color": "#ff0000"
+                        },
+                        {
+                            "range": [88, 98],
+                            "name": "Magenta",
+                            "color": "#ca1f7b"
+                        },
+                        {
+                            "range": [99, 109],
+                            "name": "Blue",
+                            "color": "#0000ff"
+                        },
+                        {
+                            "range": [110, 120],
+                            "name": "Orange",
+                            "color": "#ff7f00"
+                        },
+                        {
+                            "range": [121, 131],
+                            "name": "Green",
+                            "color": "#00ff00"
+                        },
+                        {
+                            "range": [132, 155],
+                            "name": "Purple",
+                            "color": "#800080"
+                        },
+                        {
+                            "range": [156, 159],
+                            "name": "Purple",
+                            "color": "#800080",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [160, 163],
+                            "name": "Green",
+                            "color": "#00ff00",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [164, 167],
+                            "name": "Orange",
+                            "color": "#ff7f00",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [168, 171],
+                            "name": "Blue",
+                            "color": "#0000ff",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [172, 175],
+                            "name": "Magenta",
+                            "color": "#ca1f7b",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [176, 179],
+                            "name": "Red",
+                            "color": "#ff0000",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [180, 183],
+                            "name": "Blue",
+                            "color": "#0000ff",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [184, 187],
+                            "name": "Green",
+                            "color": "#00ff00",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [188, 191],
+                            "name": "Pink",
+                            "color": "#ffc0cb",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [192, 195],
+                            "name": "Blue",
+                            "color": "#0000ff",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [196, 199],
+                            "name": "Yellow",
+                            "color": "#ffff00",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [200, 203],
+                            "name": "CTC",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [204, 207],
+                            "name": "White",
+                            "color": "#ffffff",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [208, 226],
+                            "name": "RotR",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [227, 245],
+                            "name": "RotL",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [246, 255],
+                            "name": "RndCol",
+                            "showInMenu": false,
+                            "center": true
+                        }
+                    ]
+                },
+                "Gobo": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 4],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [5, 10],
+                            "name": "Gobo 1",
+                            "center": true
+                        },
+                        {
+                            "range": [11, 15],
+                            "name": "Gobo 2",
+                            "center": true
+                        },
+                        {
+                            "range": [16, 20],
+                            "name": "Gobo 3",
+                            "center": true
+                        },
+                        {
+                            "range": [21, 25],
+                            "name": "Gobo 4",
+                            "center": true
+                        },
+                        {
+                            "range": [26, 30],
+                            "name": "Gobo 5",
+                            "center": true
+                        },
+                        {
+                            "range": [31, 35],
+                            "name": "Gobo 6",
+                            "center": true
+                        },
+                        {
+                            "range": [36, 42],
+                            "name": "Gobo 7",
+                            "center": true
+                        },
+                        {
+                            "range": [43, 50],
+                            "name": "open",
+                            "center": true
+                        },
+                        {
+                            "range": [51, 58],
+                            "name": "Rot 1",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [59, 65],
+                            "name": "Rot 2",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [66, 73],
+                            "name": "Rot 3",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [74, 81],
+                            "name": "Rot 4",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [82, 89],
+                            "name": "Rot 5",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [90, 96],
+                            "name": "Rot 6",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [97, 104],
+                            "name": "Rot 7",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [105, 119],
+                            "name": "Shake 7",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [120, 134],
+                            "name": "Shake 6",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [135, 149],
+                            "name": "Shake 5",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [150, 164],
+                            "name": "Shake 4"
+                        },
+                        {
+                            "range": [165, 179],
+                            "name": "Shake 3"
+                        },
+                        {
+                            "range": [180, 194],
+                            "name": "Shake 2"
+                        },
+                        {
+                            "range": [195, 209],
+                            "name": "Shake 1"
+                        },
+                        {
+                            "range": [210, 232],
+                            "name": "RotR",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [235, 255],
+                            "name": "RotL"
+                        }
+                    ]
+                },
+                "Gobo Rot": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "index",
+                            "warning": "Out of range!",
+                            "showInMenu": false
+                        }
+                    ],
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "Gobo Rot fine": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "index",
+                            "warning": "Out of range!",
+                            "showInMenu": false
+                        }
+                    ],
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "Focus": {
+                    "type": "Beam",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "Distance"
+                        }
+                    ]
+                },
+                "Prism": {
+                    "type": "Prism",
+                    "capabilities": [
+                        {
+                            "range": [0, 19],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [20, 79],
+                            "name": "Rot Left",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [80, 89],
+                            "name": "No Rot"
+                        },
+                        {
+                            "range": [90, 149],
+                            "name": "Rot Right",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [150, 215],
+                            "name": "Open",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [216, 220],
+                            "name": "Macro 1",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [221, 225],
+                            "name": "Macro 2",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [226, 230],
+                            "name": "Macro 3",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [231, 235],
+                            "name": "Macro 4",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [241, 245],
+                            "name": "Macro 5",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [241, 245],
+                            "name": "Macro 6",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [246, 250],
+                            "name": "Macro 7",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [251, 255],
+                            "name": "Macro 8",
+                            "showInMenu": false
+                        }
+                    ]
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Speed": {
+                    "type": "Speed",
+                    "capabilities": [
+                        {
+                            "range": [0, 2],
+                            "name": "Track"
+                        },
+                        {
+                            "range": [3, 245],
+                            "name": "%"
+                        },
+                        {
+                            "range": [246, 248],
+                            "name": "PTSP"
+                        },
+                        {
+                            "range": [246, 248],
+                            "name": "Norm"
+                        },
+                        {
+                            "range": [249, 251],
+                            "name": "Fast"
+                        },
+                        {
+                            "range": [252, 255],
+                            "name": "Black",
+                            "color": "#000000"
+                        }
+                    ]
+                },
+                "Effect": {
+                    "type": "Effect",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Gobo Rot",
+                    "Gobo Rot fine"
+                ],
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "14-channel Mode",
+                    "shortName": "14ch",
+                    "channels": [
+                        "Strobe",
+                        "Intensity",
+                        "Colour",
+                        "Gobo",
+                        "Gobo Rot",
+                        "Gobo Rot fine",
+                        "Focus",
+                        "Prism",
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "Speed",
+                        "Effect"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Martin",
+            "name": "Mac 250 Mode4",
+            "shortName": "Mac250m4",
+            "comment": "cd",
+            "physical": {
+                "dimensions": [375, 375, 550]
+            },
+            "availableChannels": {
+                "Shutter": {
+                    "type": "Shutter",
+                    "highlightValue": 30,
+                    "capabilities": [
+                        {
+                            "range": [0, 19],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [20, 49],
+                            "name": "open"
+                        },
+                        {
+                            "range": [50, 72],
+                            "name": "strobe"
+                        },
+                        {
+                            "range": [73, 79],
+                            "name": "open"
+                        },
+                        {
+                            "range": [80, 99],
+                            "name": "pulse opening"
+                        },
+                        {
+                            "range": [100, 119],
+                            "name": "pulse closing"
+                        },
+                        {
+                            "range": [120, 127],
+                            "name": "open"
+                        },
+                        {
+                            "range": [128, 187],
+                            "name": "random strobe"
+                        },
+                        {
+                            "range": [188, 190],
+                            "name": "open"
+                        },
+                        {
+                            "range": [191, 202],
+                            "name": "random pulse"
+                        },
+                        {
+                            "range": [203, 207],
+                            "name": "open"
+                        },
+                        {
+                            "range": [208, 217],
+                            "name": "reset"
+                        },
+                        {
+                            "range": [218, 227],
+                            "name": "open"
+                        },
+                        {
+                            "range": [228, 237],
+                            "name": "lamp on"
+                        },
+                        {
+                            "range": [238, 247],
+                            "name": "open"
+                        },
+                        {
+                            "range": [248, 255],
+                            "name": "lamp off"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Color": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 11],
+                            "name": "open"
+                        },
+                        {
+                            "range": [12, 23],
+                            "name": "CTO"
+                        },
+                        {
+                            "range": [24, 35],
+                            "name": "yellow 603"
+                        },
+                        {
+                            "range": [36, 47],
+                            "name": "blue 104"
+                        },
+                        {
+                            "range": [48, 59],
+                            "name": "pink 312"
+                        },
+                        {
+                            "range": [60, 71],
+                            "name": "green 206"
+                        },
+                        {
+                            "range": [72, 83],
+                            "name": "blue 108"
+                        },
+                        {
+                            "range": [84, 95],
+                            "name": "red 301"
+                        },
+                        {
+                            "range": [96, 107],
+                            "name": "magenta 507"
+                        },
+                        {
+                            "range": [108, 119],
+                            "name": "blue 101"
+                        },
+                        {
+                            "range": [120, 131],
+                            "name": "orange 306"
+                        },
+                        {
+                            "range": [132, 143],
+                            "name": "green 202"
+                        },
+                        {
+                            "range": [144, 155],
+                            "name": "purble 502"
+                        },
+                        {
+                            "range": [156, 159],
+                            "name": "purble 502"
+                        },
+                        {
+                            "range": [160, 163],
+                            "name": "green 202"
+                        },
+                        {
+                            "range": [164, 167],
+                            "name": "orange 306"
+                        },
+                        {
+                            "range": [168, 171],
+                            "name": "blue 101"
+                        },
+                        {
+                            "range": [172, 175],
+                            "name": "magenta 507"
+                        },
+                        {
+                            "range": [176, 179],
+                            "name": "red 301"
+                        },
+                        {
+                            "range": [180, 183],
+                            "name": "blue 108"
+                        },
+                        {
+                            "range": [184, 187],
+                            "name": "green 206"
+                        },
+                        {
+                            "range": [188, 191],
+                            "name": "pink 312"
+                        },
+                        {
+                            "range": [192, 195],
+                            "name": "blue 104"
+                        },
+                        {
+                            "range": [196, 199],
+                            "name": "yellow 603"
+                        },
+                        {
+                            "range": [200, 203],
+                            "name": "CTO"
+                        },
+                        {
+                            "range": [204, 207],
+                            "name": "open"
+                        },
+                        {
+                            "range": [208, 226],
+                            "name": ">>"
+                        },
+                        {
+                            "range": [227, 245],
+                            "name": "<<"
+                        },
+                        {
+                            "range": [246, 255],
+                            "name": "random"
+                        }
+                    ]
+                },
+                "Gobo": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 9],
+                            "name": "open"
+                        },
+                        {
+                            "range": [10, 19],
+                            "name": "slot1"
+                        },
+                        {
+                            "range": [20, 29],
+                            "name": "slot2"
+                        },
+                        {
+                            "range": [30, 39],
+                            "name": "slot3"
+                        },
+                        {
+                            "range": [40, 49],
+                            "name": "slot4"
+                        },
+                        {
+                            "range": [50, 59],
+                            "name": "slot5"
+                        },
+                        {
+                            "range": [60, 69],
+                            "name": "slot6"
+                        },
+                        {
+                            "range": [70, 79],
+                            "name": "slot7"
+                        },
+                        {
+                            "range": [80, 89],
+                            "name": "slot8"
+                        },
+                        {
+                            "range": [90, 104],
+                            "name": "slot8 sh."
+                        },
+                        {
+                            "range": [105, 119],
+                            "name": "slot7 sh."
+                        },
+                        {
+                            "range": [120, 134],
+                            "name": "slot6 sh."
+                        },
+                        {
+                            "range": [135, 149],
+                            "name": "slot5 sh."
+                        },
+                        {
+                            "range": [150, 164],
+                            "name": "slot4 sh."
+                        },
+                        {
+                            "range": [165, 179],
+                            "name": "slot3 sh."
+                        },
+                        {
+                            "range": [180, 194],
+                            "name": "slot2 sh."
+                        },
+                        {
+                            "range": [195, 209],
+                            "name": "slot1 sh."
+                        },
+                        {
+                            "range": [210, 232],
+                            "name": ">>"
+                        },
+                        {
+                            "range": [233, 255],
+                            "name": "<<"
+                        }
+                    ]
+                },
+                "Gobo rot.": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Focus": {
+                    "type": "Beam",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Prisma": {
+                    "type": "Prism",
+                    "capabilities": [
+                        {
+                            "range": [0, 19],
+                            "name": "open"
+                        },
+                        {
+                            "range": [20, 79],
+                            "name": ">>"
+                        },
+                        {
+                            "range": [80, 89],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [90, 149],
+                            "name": "<<"
+                        },
+                        {
+                            "range": [150, 215],
+                            "name": "open"
+                        },
+                        {
+                            "range": [216, 220],
+                            "name": "macro1"
+                        },
+                        {
+                            "range": [221, 225],
+                            "name": "macro2"
+                        },
+                        {
+                            "range": [226, 230],
+                            "name": "macro3"
+                        },
+                        {
+                            "range": [231, 235],
+                            "name": "macro4"
+                        },
+                        {
+                            "range": [236, 240],
+                            "name": "macro5"
+                        },
+                        {
+                            "range": [241, 245],
+                            "name": "macro6"
+                        },
+                        {
+                            "range": [246, 250],
+                            "name": "macro7"
+                        },
+                        {
+                            "range": [251, 255],
+                            "name": "macro8"
+                        }
+                    ]
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "P/T speed": {
+                    "type": "Speed",
+                    "capabilities": [
+                        {
+                            "range": [0, 2],
+                            "name": "tracking"
+                        },
+                        {
+                            "range": [3, 245],
+                            "name": "speed"
+                        },
+                        {
+                            "range": [246, 248],
+                            "name": "track norm"
+                        },
+                        {
+                            "range": [249, 251],
+                            "name": "track fast"
+                        },
+                        {
+                            "range": [252, 255],
+                            "name": "MIB"
+                        }
+                    ]
+                },
+                "FX speed": {
+                    "type": "Speed",
+                    "capabilities": [
+                        {
+                            "range": [0, 2],
+                            "name": "tracking"
+                        },
+                        {
+                            "range": [3, 245],
+                            "name": "speed"
+                        },
+                        {
+                            "range": [252, 255],
+                            "name": "MIB"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "13-channel Mode",
+                    "shortName": "13ch",
+                    "channels": [
+                        "Shutter",
+                        "Intensity",
+                        "Color",
+                        "Gobo",
+                        "Gobo rot.",
+                        "Focus",
+                        "Prisma",
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "P/T speed",
+                        "FX speed"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Martin",
+            "name": "MAC 250 Wash",
+            "shortName": "MAC250Wash",
+            "comment": "cd",
+            "physical": {
+                "dimensions": [375, 375, 550]
+            },
+            "availableChannels": {
+                "Shutter": {
+                    "type": "Shutter",
+                    "capabilities": [
+                        {
+                            "range": [0, 19],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [20, 49],
+                            "name": "open"
+                        },
+                        {
+                            "range": [50, 72],
+                            "name": "strobe"
+                        },
+                        {
+                            "range": [73, 79],
+                            "name": "open"
+                        },
+                        {
+                            "range": [80, 119],
+                            "name": "pulse"
+                        },
+                        {
+                            "range": [120, 127],
+                            "name": "open"
+                        },
+                        {
+                            "range": [128, 187],
+                            "name": "random strobe"
+                        },
+                        {
+                            "range": [188, 190],
+                            "name": "open"
+                        },
+                        {
+                            "range": [191, 202],
+                            "name": "random pulse"
+                        },
+                        {
+                            "range": [203, 207],
+                            "name": "open"
+                        },
+                        {
+                            "range": [208, 217],
+                            "name": "reset"
+                        },
+                        {
+                            "range": [218, 227],
+                            "name": "open"
+                        },
+                        {
+                            "range": [228, 237],
+                            "name": "lamp on"
+                        },
+                        {
+                            "range": [238, 247],
+                            "name": "open"
+                        },
+                        {
+                            "range": [248, 255],
+                            "name": "lamp off"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Cyan": {
+                    "type": "SingleColor",
+                    "color": "Cyan",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Magenta": {
+                    "type": "SingleColor",
+                    "color": "Magenta",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Yellow": {
+                    "type": "SingleColor",
+                    "color": "Yellow",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Color": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 25],
+                            "name": "open"
+                        },
+                        {
+                            "range": [26, 50],
+                            "name": "CTO"
+                        },
+                        {
+                            "range": [51, 76],
+                            "name": "pink 312"
+                        },
+                        {
+                            "range": [77, 101],
+                            "name": "UV"
+                        },
+                        {
+                            "range": [102, 127],
+                            "name": "red 308"
+                        },
+                        {
+                            "range": [128, 152],
+                            "name": "green",
+                            "color": "#00ff00"
+                        },
+                        {
+                            "range": [153, 179],
+                            "name": "blue 108"
+                        },
+                        {
+                            "range": [180, 183],
+                            "name": "blue 108"
+                        },
+                        {
+                            "range": [184, 187],
+                            "name": "green 206"
+                        },
+                        {
+                            "range": [188, 191],
+                            "name": "red 308"
+                        },
+                        {
+                            "range": [192, 195],
+                            "name": "UV"
+                        },
+                        {
+                            "range": [196, 199],
+                            "name": "pink 312"
+                        },
+                        {
+                            "range": [200, 203],
+                            "name": "CTO"
+                        },
+                        {
+                            "range": [204, 207],
+                            "name": "open"
+                        },
+                        {
+                            "range": [208, 226],
+                            "name": ">>"
+                        },
+                        {
+                            "range": [227, 245],
+                            "name": "<<"
+                        },
+                        {
+                            "range": [246, 255],
+                            "name": "random"
+                        }
+                    ]
+                },
+                "Frost": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "P/T speed": {
+                    "type": "Speed",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 2],
+                            "name": "tracking"
+                        },
+                        {
+                            "range": [3, 245],
+                            "name": "speed"
+                        },
+                        {
+                            "range": [246, 251],
+                            "name": "tracking"
+                        },
+                        {
+                            "range": [252, 255],
+                            "name": "MIB"
+                        }
+                    ]
+                },
+                "Effect speed": {
+                    "type": "Speed",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 2],
+                            "name": "tracking"
+                        },
+                        {
+                            "range": [3, 245],
+                            "name": "speed"
+                        },
+                        {
+                            "range": [246, 251],
+                            "name": "tracking"
+                        },
+                        {
+                            "range": [252, 255],
+                            "name": "DIB"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "13-channel Mode",
+                    "shortName": "13ch",
+                    "channels": [
+                        "Shutter",
+                        "Intensity",
+                        "Cyan",
+                        "Magenta",
+                        "Yellow",
+                        "Color",
+                        "Frost",
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "P/T speed",
+                        "Effect speed"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Martin",
+            "name": "Mac 250+",
+            "shortName": "Mac250",
+            "comment": "Mode 2",
+            "physical": {
+                "dimensions": [375, 375, 550]
+            },
+            "availableChannels": {
+                "Strobe": {
+                    "type": "Strobe",
+                    "defaultValue": 20,
+                    "highlightValue": 20,
+                    "capabilities": [
+                        {
+                            "range": [0, 19],
+                            "name": "Closed"
+                        },
+                        {
+                            "range": [20, 49],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [50, 72],
+                            "name": "Strobe"
+                        },
+                        {
+                            "range": [80, 119],
+                            "name": "Pulse"
+                        },
+                        {
+                            "range": [128, 202],
+                            "name": "Random",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [208, 217],
+                            "name": "Reset",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [228, 237],
+                            "name": "Lamp On",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [248, 255],
+                            "name": "Lamp Off",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [73, 79],
+                            "name": "Open",
+                            "center": true
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Colour": {
+                    "type": "MultiColor",
+                    "capabilities": [
+                        {
+                            "range": [0, 11],
+                            "name": "White",
+                            "color": "#ffffff"
+                        },
+                        {
+                            "range": [12, 23],
+                            "name": "CTC"
+                        },
+                        {
+                            "range": [24, 35],
+                            "name": "Yellow",
+                            "color": "#ffff00"
+                        },
+                        {
+                            "range": [36, 47],
+                            "name": "Blue",
+                            "color": "#0000ff"
+                        },
+                        {
+                            "range": [48, 59],
+                            "name": "Pink",
+                            "color": "#ffc0cb"
+                        },
+                        {
+                            "range": [60, 71],
+                            "name": "Green",
+                            "color": "#00ff00"
+                        },
+                        {
+                            "range": [72, 83],
+                            "name": "Blue",
+                            "color": "#0000ff"
+                        },
+                        {
+                            "range": [84, 95],
+                            "name": "Red",
+                            "color": "#ff0000"
+                        },
+                        {
+                            "range": [96, 107],
+                            "name": "Magenta",
+                            "color": "#ca1f7b"
+                        },
+                        {
+                            "range": [108, 119],
+                            "name": "Blue",
+                            "color": "#0000ff"
+                        },
+                        {
+                            "range": [120, 131],
+                            "name": "Orange",
+                            "color": "#ff7f00"
+                        },
+                        {
+                            "range": [132, 143],
+                            "name": "Green",
+                            "color": "#00ff00"
+                        },
+                        {
+                            "range": [144, 155],
+                            "name": "Purple",
+                            "color": "#800080"
+                        },
+                        {
+                            "range": [156, 159],
+                            "name": "Purple",
+                            "color": "#800080",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [160, 163],
+                            "name": "Green",
+                            "color": "#00ff00",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [164, 167],
+                            "name": "Orange",
+                            "color": "#ff7f00",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [168, 171],
+                            "name": "Blue",
+                            "color": "#0000ff",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [172, 175],
+                            "name": "Magenta",
+                            "color": "#ca1f7b",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [176, 179],
+                            "name": "Red",
+                            "color": "#ff0000",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [180, 183],
+                            "name": "Blue",
+                            "color": "#0000ff",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [184, 187],
+                            "name": "Green",
+                            "color": "#00ff00",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [188, 191],
+                            "name": "Pink",
+                            "color": "#ffc0cb",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [192, 195],
+                            "name": "Blue",
+                            "color": "#0000ff",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [196, 199],
+                            "name": "Yellow",
+                            "color": "#ffff00",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [200, 203],
+                            "name": "CTC",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [204, 207],
+                            "name": "White",
+                            "color": "#ffffff",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [208, 226],
+                            "name": "RotR",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [227, 245],
+                            "name": "RotL",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [246, 255],
+                            "name": "RndCol",
+                            "showInMenu": false,
+                            "center": true
+                        }
+                    ]
+                },
+                "Gobo": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 4],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [5, 9],
+                            "name": "Gobo 1",
+                            "center": true
+                        },
+                        {
+                            "range": [0, 14],
+                            "name": "Gobo 2",
+                            "center": true
+                        },
+                        {
+                            "range": [15, 19],
+                            "name": "Gobo 3",
+                            "center": true
+                        },
+                        {
+                            "range": [20, 24],
+                            "name": "Gobo 4",
+                            "center": true
+                        },
+                        {
+                            "range": [25, 29],
+                            "name": "Gobo 5",
+                            "center": true
+                        },
+                        {
+                            "range": [30, 34],
+                            "name": "Gobo 6",
+                            "center": true
+                        },
+                        {
+                            "range": [35, 39],
+                            "name": "Gobo 7",
+                            "center": true
+                        },
+                        {
+                            "range": [40, 44],
+                            "name": "Gobo 8",
+                            "center": true
+                        },
+                        {
+                            "range": [90, 104],
+                            "name": "Shake 8",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [105, 119],
+                            "name": "Shake 7",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [120, 134],
+                            "name": "Shake 6",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [135, 149],
+                            "name": "Shake 5",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [150, 164],
+                            "name": "Shake 4",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [165, 179],
+                            "name": "Shake 3",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [180, 194],
+                            "name": "Shake 2",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [195, 209],
+                            "name": "Shake 1",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [210, 232],
+                            "name": "Rot Right",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [233, 255],
+                            "name": "Rot Left",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [50, 54],
+                            "name": "RotGobo1"
+                        },
+                        {
+                            "range": [55, 59],
+                            "name": "RotGobo2"
+                        },
+                        {
+                            "range": [60, 64],
+                            "name": "RotGobo3"
+                        },
+                        {
+                            "range": [65, 69],
+                            "name": "RotGobo4"
+                        },
+                        {
+                            "range": [70, 74],
+                            "name": "RotGobo5"
+                        },
+                        {
+                            "range": [75, 79],
+                            "name": "RotGobo6"
+                        },
+                        {
+                            "range": [80, 84],
+                            "name": "RotGobo7"
+                        },
+                        {
+                            "range": [85, 89],
+                            "name": "RotGobo8"
+                        }
+                    ]
+                },
+                "Gobo Rot": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 2],
+                            "name": "index",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [3, 127],
+                            "name": "Rot Right",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [128, 252],
+                            "name": "Rot Left",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [253, 255],
+                            "name": "Static",
+                            "showInMenu": false
+                        }
+                    ]
+                },
+                "Focus": {
+                    "type": "Beam",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "Distance"
+                        }
+                    ]
+                },
+                "Prism": {
+                    "type": "Prism",
+                    "capabilities": [
+                        {
+                            "range": [0, 19],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [20, 79],
+                            "name": "Rot Left",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [80, 89],
+                            "name": "No Rot"
+                        },
+                        {
+                            "range": [90, 149],
+                            "name": "Rot Right",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [150, 215],
+                            "name": "Open",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [216, 220],
+                            "name": "Macro 1",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [221, 225],
+                            "name": "Macro 2",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [226, 230],
+                            "name": "Macro 3",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [231, 235],
+                            "name": "Macro 4",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [236, 240],
+                            "name": "Macro 5",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [241, 245],
+                            "name": "Macro 6",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [246, 250],
+                            "name": "Macro 7",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [251, 255],
+                            "name": "Macro 8",
+                            "showInMenu": false
+                        }
+                    ]
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "11-channel Mode",
+                    "shortName": "11ch",
+                    "channels": [
+                        "Strobe",
+                        "Intensity",
+                        "Colour",
+                        "Gobo",
+                        "Gobo Rot",
+                        "Focus",
+                        "Prism",
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Martin",
+            "name": "Mac 300 m1",
+            "shortName": "Mac300m1",
+            "physical": {
+                "dimensions": [450, 450, 656]
+            },
+            "availableChannels": {
+                "Shutter": {
+                    "type": "Shutter",
+                    "defaultValue": 30,
+                    "highlightValue": 30,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 19],
+                            "name": "close",
+                            "center": true
+                        },
+                        {
+                            "range": [20, 49],
+                            "name": "open",
+                            "center": true
+                        },
+                        {
+                            "range": [50, 72],
+                            "name": "Strobe"
+                        },
+                        {
+                            "range": [73, 79],
+                            "name": "open",
+                            "center": true
+                        },
+                        {
+                            "range": [31, 39],
+                            "name": "t-open"
+                        },
+                        {
+                            "range": [39, 47],
+                            "name": "t-close"
+                        },
+                        {
+                            "range": [120, 127],
+                            "name": "open",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 147],
+                            "name": "rnd-str-ff",
+                            "center": true
+                        },
+                        {
+                            "range": [148, 167],
+                            "name": "rnd-str-m",
+                            "center": true
+                        },
+                        {
+                            "range": [168, 187],
+                            "name": "rnd-str-sl",
+                            "center": true
+                        },
+                        {
+                            "range": [188, 190],
+                            "name": "open",
+                            "center": true
+                        },
+                        {
+                            "range": [191, 193],
+                            "name": "puls-op-ff"
+                        },
+                        {
+                            "range": [194, 196],
+                            "name": "puls-op-sl"
+                        },
+                        {
+                            "range": [197, 199],
+                            "name": "puls-cl-ff"
+                        },
+                        {
+                            "range": [200, 202],
+                            "name": "puls-cl-sl"
+                        },
+                        {
+                            "range": [203, 207],
+                            "name": "open",
+                            "center": true
+                        },
+                        {
+                            "range": [208, 217],
+                            "name": "reset",
+                            "center": true
+                        },
+                        {
+                            "range": [218, 227],
+                            "name": "open",
+                            "center": true
+                        },
+                        {
+                            "range": [228, 237],
+                            "name": "on",
+                            "center": true
+                        },
+                        {
+                            "range": [238, 247],
+                            "name": "open",
+                            "center": true
+                        },
+                        {
+                            "range": [248, 255],
+                            "name": "off_t>5s",
+                            "center": true
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Cyan": {
+                    "type": "SingleColor",
+                    "color": "Cyan",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Magenta": {
+                    "type": "SingleColor",
+                    "color": "Magenta",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Yellow": {
+                    "type": "SingleColor",
+                    "color": "Yellow",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Color": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 179],
+                            "name": "cont."
+                        },
+                        {
+                            "range": [180, 183],
+                            "name": "blue_108"
+                        },
+                        {
+                            "range": [184, 187],
+                            "name": "green_206"
+                        },
+                        {
+                            "range": [188, 191],
+                            "name": "Red_308"
+                        },
+                        {
+                            "range": [192, 195],
+                            "name": "UV"
+                        },
+                        {
+                            "range": [196, 199],
+                            "name": "Pink_312"
+                        },
+                        {
+                            "range": [200, 203],
+                            "name": "5k5-2k9"
+                        },
+                        {
+                            "range": [204, 207],
+                            "name": "white",
+                            "color": "#ffffff"
+                        },
+                        {
+                            "range": [208, 226],
+                            "name": "cont.right"
+                        },
+                        {
+                            "range": [227, 245],
+                            "name": "cont.left"
+                        },
+                        {
+                            "range": [246, 255],
+                            "name": "rnd_cmy"
+                        }
+                    ]
+                },
+                "Frost": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "9-channel Mode",
+                    "shortName": "9ch",
+                    "channels": [
+                        "Shutter",
+                        "Intensity",
+                        "Cyan",
+                        "Magenta",
+                        "Yellow",
+                        "Color",
+                        "Frost",
+                        "Pan",
+                        "Tilt"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Martin",
+            "name": "Mac 300 m2",
+            "shortName": "Mac300m2",
+            "physical": {
+                "dimensions": [450, 450, 656]
+            },
+            "availableChannels": {
+                "Shutter": {
+                    "type": "Shutter",
+                    "defaultValue": 30,
+                    "highlightValue": 30,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 19],
+                            "name": "close",
+                            "center": true
+                        },
+                        {
+                            "range": [20, 49],
+                            "name": "open",
+                            "center": true
+                        },
+                        {
+                            "range": [50, 72],
+                            "name": "Strobe"
+                        },
+                        {
+                            "range": [73, 79],
+                            "name": "open",
+                            "center": true
+                        },
+                        {
+                            "range": [31, 39],
+                            "name": "t-open"
+                        },
+                        {
+                            "range": [39, 47],
+                            "name": "t-close"
+                        },
+                        {
+                            "range": [120, 127],
+                            "name": "open",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 147],
+                            "name": "rnd-str-ff",
+                            "center": true
+                        },
+                        {
+                            "range": [148, 167],
+                            "name": "rnd-str-m",
+                            "center": true
+                        },
+                        {
+                            "range": [168, 187],
+                            "name": "rnd-str-sl",
+                            "center": true
+                        },
+                        {
+                            "range": [188, 190],
+                            "name": "open",
+                            "center": true
+                        },
+                        {
+                            "range": [191, 193],
+                            "name": "puls-op-ff"
+                        },
+                        {
+                            "range": [194, 196],
+                            "name": "puls-op-sl"
+                        },
+                        {
+                            "range": [197, 199],
+                            "name": "puls-cl-ff"
+                        },
+                        {
+                            "range": [200, 202],
+                            "name": "puls-cl-sl"
+                        },
+                        {
+                            "range": [203, 207],
+                            "name": "open",
+                            "center": true
+                        },
+                        {
+                            "range": [208, 217],
+                            "name": "reset",
+                            "center": true
+                        },
+                        {
+                            "range": [218, 227],
+                            "name": "open",
+                            "center": true
+                        },
+                        {
+                            "range": [228, 237],
+                            "name": "on",
+                            "center": true
+                        },
+                        {
+                            "range": [238, 247],
+                            "name": "open",
+                            "center": true
+                        },
+                        {
+                            "range": [248, 255],
+                            "name": "off_t>5s",
+                            "center": true
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Cyan": {
+                    "type": "SingleColor",
+                    "color": "Cyan",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Magenta": {
+                    "type": "SingleColor",
+                    "color": "Magenta",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Yellow": {
+                    "type": "SingleColor",
+                    "color": "Yellow",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Color": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 179],
+                            "name": "cont."
+                        },
+                        {
+                            "range": [180, 183],
+                            "name": "blue_108"
+                        },
+                        {
+                            "range": [184, 187],
+                            "name": "green_206"
+                        },
+                        {
+                            "range": [188, 191],
+                            "name": "Red_308"
+                        },
+                        {
+                            "range": [192, 195],
+                            "name": "UV"
+                        },
+                        {
+                            "range": [196, 199],
+                            "name": "Pink_312"
+                        },
+                        {
+                            "range": [200, 203],
+                            "name": "5k5-2k9"
+                        },
+                        {
+                            "range": [204, 207],
+                            "name": "white",
+                            "color": "#ffffff"
+                        },
+                        {
+                            "range": [208, 226],
+                            "name": "cont.right"
+                        },
+                        {
+                            "range": [227, 245],
+                            "name": "cont.left"
+                        },
+                        {
+                            "range": [246, 255],
+                            "name": "rnd_cmy"
+                        }
+                    ]
+                },
+                "Frost": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "11-channel Mode",
+                    "shortName": "11ch",
+                    "channels": [
+                        "Shutter",
+                        "Intensity",
+                        "Cyan",
+                        "Magenta",
+                        "Yellow",
+                        "Color",
+                        "Frost",
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Martin",
+            "name": "Mac 300 m3",
+            "shortName": "Mac300m3",
+            "physical": {
+                "dimensions": [450, 450, 656]
+            },
+            "availableChannels": {
+                "Shutter": {
+                    "type": "Shutter",
+                    "defaultValue": 30,
+                    "highlightValue": 30,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 19],
+                            "name": "close",
+                            "center": true
+                        },
+                        {
+                            "range": [20, 49],
+                            "name": "open",
+                            "center": true
+                        },
+                        {
+                            "range": [50, 72],
+                            "name": "Strobe"
+                        },
+                        {
+                            "range": [73, 79],
+                            "name": "open",
+                            "center": true
+                        },
+                        {
+                            "range": [31, 39],
+                            "name": "t-open"
+                        },
+                        {
+                            "range": [39, 47],
+                            "name": "t-close"
+                        },
+                        {
+                            "range": [120, 127],
+                            "name": "open",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 147],
+                            "name": "rnd-str-ff",
+                            "center": true
+                        },
+                        {
+                            "range": [148, 167],
+                            "name": "rnd-str-m",
+                            "center": true
+                        },
+                        {
+                            "range": [168, 187],
+                            "name": "rnd-str-sl",
+                            "center": true
+                        },
+                        {
+                            "range": [188, 190],
+                            "name": "open",
+                            "center": true
+                        },
+                        {
+                            "range": [191, 193],
+                            "name": "puls-op-ff"
+                        },
+                        {
+                            "range": [194, 196],
+                            "name": "puls-op-sl"
+                        },
+                        {
+                            "range": [197, 199],
+                            "name": "puls-cl-ff"
+                        },
+                        {
+                            "range": [200, 202],
+                            "name": "puls-cl-sl"
+                        },
+                        {
+                            "range": [203, 207],
+                            "name": "open",
+                            "center": true
+                        },
+                        {
+                            "range": [208, 217],
+                            "name": "reset",
+                            "center": true
+                        },
+                        {
+                            "range": [218, 227],
+                            "name": "open",
+                            "center": true
+                        },
+                        {
+                            "range": [228, 237],
+                            "name": "on",
+                            "center": true
+                        },
+                        {
+                            "range": [238, 247],
+                            "name": "open",
+                            "center": true
+                        },
+                        {
+                            "range": [248, 255],
+                            "name": "off_t>5s",
+                            "center": true
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Cyan": {
+                    "type": "SingleColor",
+                    "color": "Cyan",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Magenta": {
+                    "type": "SingleColor",
+                    "color": "Magenta",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Yellow": {
+                    "type": "SingleColor",
+                    "color": "Yellow",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Color": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 179],
+                            "name": "cont."
+                        },
+                        {
+                            "range": [180, 183],
+                            "name": "blue_108"
+                        },
+                        {
+                            "range": [184, 187],
+                            "name": "green_206"
+                        },
+                        {
+                            "range": [188, 191],
+                            "name": "Red_308"
+                        },
+                        {
+                            "range": [192, 195],
+                            "name": "UV"
+                        },
+                        {
+                            "range": [196, 199],
+                            "name": "Pink_312"
+                        },
+                        {
+                            "range": [200, 203],
+                            "name": "5k5-2k9"
+                        },
+                        {
+                            "range": [204, 207],
+                            "name": "white",
+                            "color": "#ffffff"
+                        },
+                        {
+                            "range": [208, 226],
+                            "name": "cont.right"
+                        },
+                        {
+                            "range": [227, 245],
+                            "name": "cont.left"
+                        },
+                        {
+                            "range": [246, 255],
+                            "name": "rnd_cmy"
+                        }
+                    ]
+                },
+                "Frost": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Move": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 2],
+                            "name": "tracking"
+                        },
+                        {
+                            "range": [3, 245],
+                            "name": "speed"
+                        },
+                        {
+                            "range": [246, 248],
+                            "name": "PTSP_slow"
+                        },
+                        {
+                            "range": [249, 251],
+                            "name": "PTSP_fast"
+                        },
+                        {
+                            "range": [252, 255],
+                            "name": "DBO_move"
+                        }
+                    ]
+                },
+                "Effect": {
+                    "type": "Effect",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "11-channel Mode",
+                    "shortName": "11ch",
+                    "channels": [
+                        "Shutter",
+                        "Intensity",
+                        "Cyan",
+                        "Magenta",
+                        "Yellow",
+                        "Color",
+                        "Frost",
+                        "Pan",
+                        "Tilt",
+                        "Move",
+                        "Effect"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Martin",
+            "name": "Mac 300 m4",
+            "shortName": "Mac300m4",
+            "physical": {
+                "dimensions": [450, 450, 656]
+            },
+            "availableChannels": {
+                "Shutter": {
+                    "type": "Shutter",
+                    "defaultValue": 30,
+                    "highlightValue": 30,
+                    "capabilities": [
+                        {
+                            "range": [0, 19],
+                            "name": "close",
+                            "center": true
+                        },
+                        {
+                            "range": [20, 49],
+                            "name": "open",
+                            "center": true
+                        },
+                        {
+                            "range": [50, 72],
+                            "name": "Strobe"
+                        },
+                        {
+                            "range": [73, 79],
+                            "name": "open",
+                            "center": true
+                        },
+                        {
+                            "range": [31, 39],
+                            "name": "t-open"
+                        },
+                        {
+                            "range": [39, 47],
+                            "name": "t-close"
+                        },
+                        {
+                            "range": [120, 127],
+                            "name": "open",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 147],
+                            "name": "rnd-str-ff",
+                            "center": true
+                        },
+                        {
+                            "range": [148, 167],
+                            "name": "rnd-str-m",
+                            "center": true
+                        },
+                        {
+                            "range": [168, 187],
+                            "name": "rnd-str-sl",
+                            "center": true
+                        },
+                        {
+                            "range": [188, 190],
+                            "name": "open",
+                            "center": true
+                        },
+                        {
+                            "range": [191, 193],
+                            "name": "puls-op-ff"
+                        },
+                        {
+                            "range": [194, 196],
+                            "name": "puls-op-sl"
+                        },
+                        {
+                            "range": [197, 199],
+                            "name": "puls-cl-ff"
+                        },
+                        {
+                            "range": [200, 202],
+                            "name": "puls-cl-sl"
+                        },
+                        {
+                            "range": [203, 207],
+                            "name": "open",
+                            "center": true
+                        },
+                        {
+                            "range": [208, 217],
+                            "name": "reset",
+                            "center": true
+                        },
+                        {
+                            "range": [218, 227],
+                            "name": "open",
+                            "center": true
+                        },
+                        {
+                            "range": [228, 237],
+                            "name": "on",
+                            "center": true
+                        },
+                        {
+                            "range": [238, 247],
+                            "name": "open",
+                            "center": true
+                        },
+                        {
+                            "range": [248, 255],
+                            "name": "off_t>5s",
+                            "center": true
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Cyan": {
+                    "type": "SingleColor",
+                    "color": "Cyan",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Magenta": {
+                    "type": "SingleColor",
+                    "color": "Magenta",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Yellow": {
+                    "type": "SingleColor",
+                    "color": "Yellow",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Color": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 179],
+                            "name": "cont."
+                        },
+                        {
+                            "range": [180, 183],
+                            "name": "blue_108"
+                        },
+                        {
+                            "range": [184, 187],
+                            "name": "green_206"
+                        },
+                        {
+                            "range": [188, 191],
+                            "name": "Red_308"
+                        },
+                        {
+                            "range": [192, 195],
+                            "name": "UV"
+                        },
+                        {
+                            "range": [196, 199],
+                            "name": "Pink_312"
+                        },
+                        {
+                            "range": [200, 203],
+                            "name": "5k5-2k9"
+                        },
+                        {
+                            "range": [204, 207],
+                            "name": "white",
+                            "color": "#ffffff"
+                        },
+                        {
+                            "range": [208, 226],
+                            "name": "cont.right"
+                        },
+                        {
+                            "range": [227, 245],
+                            "name": "cont.left"
+                        },
+                        {
+                            "range": [246, 255],
+                            "name": "rnd_cmy"
+                        }
+                    ]
+                },
+                "Frost": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Move": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 2],
+                            "name": "tracking"
+                        },
+                        {
+                            "range": [3, 245],
+                            "name": "speed"
+                        },
+                        {
+                            "range": [246, 248],
+                            "name": "PTSP_slow"
+                        },
+                        {
+                            "range": [249, 251],
+                            "name": "PTSP_fast"
+                        },
+                        {
+                            "range": [252, 255],
+                            "name": "DBO_move"
+                        }
+                    ]
+                },
+                "Effect": {
+                    "type": "Effect",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "13-channel Mode",
+                    "shortName": "13ch",
+                    "channels": [
+                        "Shutter",
+                        "Intensity",
+                        "Cyan",
+                        "Magenta",
+                        "Yellow",
+                        "Color",
+                        "Frost",
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "Move",
+                        "Effect"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Martin",
+            "name": "Mac 401 RGB",
+            "shortName": "Mac401RGB",
+            "comment": "LED Movinghead",
+            "physical": {
+                "dimensions": [505, 530, 375],
+                "weight": 21,
+                "power": 766
+            },
+            "availableChannels": {
+                "Strobe V Shutte": {
+                    "type": "Strobe",
+                    "defaultValue": 25,
+                    "highlightValue": 25,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 19],
+                            "name": "Closed",
+                            "center": true
+                        },
+                        {
+                            "range": [20, 49],
+                            "name": "Open",
+                            "center": true
+                        },
+                        {
+                            "range": [50, 64],
+                            "name": "Strobe F-S"
+                        },
+                        {
+                            "range": [65, 69],
+                            "name": "Open",
+                            "center": true
+                        },
+                        {
+                            "range": [70, 84],
+                            "name": "Pulse Open S-F"
+                        },
+                        {
+                            "range": [85, 89],
+                            "name": "Open",
+                            "center": true
+                        },
+                        {
+                            "range": [90, 104],
+                            "name": "Pulse Close F-S"
+                        },
+                        {
+                            "range": [105, 109],
+                            "name": "Open",
+                            "center": true
+                        },
+                        {
+                            "range": [110, 124],
+                            "name": "RND strobe F-S"
+                        },
+                        {
+                            "range": [125, 129],
+                            "name": "Closed",
+                            "center": true
+                        },
+                        {
+                            "range": [130, 144],
+                            "name": "RNDPulse Op F-S"
+                        },
+                        {
+                            "range": [145, 149],
+                            "name": "Open",
+                            "center": true
+                        },
+                        {
+                            "range": [150, 164],
+                            "name": "RNDPulse Cl F-S"
+                        },
+                        {
+                            "range": [165, 169],
+                            "name": "Closed",
+                            "center": true
+                        },
+                        {
+                            "range": [170, 184],
+                            "name": "Burst pulse F-S"
+                        },
+                        {
+                            "range": [185, 189],
+                            "name": "Open",
+                            "center": true
+                        },
+                        {
+                            "range": [190, 204],
+                            "name": "RND Burst F-S"
+                        },
+                        {
+                            "range": [205, 209],
+                            "name": "Closed",
+                            "center": true
+                        },
+                        {
+                            "range": [210, 224],
+                            "name": "Sinuswave F-S"
+                        },
+                        {
+                            "range": [225, 229],
+                            "name": "Open",
+                            "center": true
+                        },
+                        {
+                            "range": [230, 244],
+                            "name": "el Burst F-S"
+                        },
+                        {
+                            "range": [245, 255],
+                            "name": "Open",
+                            "center": true
+                        }
+                    ]
+                },
+                "Dimmer": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Zoom": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 200],
+                            "name": "Far-Close",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [201, 210],
+                            "name": "Hypermode",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [211, 255],
+                            "name": "No Function"
+                        }
+                    ]
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Dev Function": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 9],
+                            "name": "No Function ",
+                            "center": true
+                        },
+                        {
+                            "range": [10, 14],
+                            "name": "Reset All",
+                            "center": true
+                        },
+                        {
+                            "range": [15, 19],
+                            "name": "No Function ",
+                            "center": true
+                        },
+                        {
+                            "range": [20, 24],
+                            "name": "RST Effect 1",
+                            "center": true
+                        },
+                        {
+                            "range": [25, 29],
+                            "name": "No Function ",
+                            "center": true
+                        },
+                        {
+                            "range": [30, 34],
+                            "name": "RST P+T",
+                            "center": true
+                        },
+                        {
+                            "range": [35, 39],
+                            "name": "No Function ",
+                            "center": true
+                        },
+                        {
+                            "range": [40, 44],
+                            "name": "PTSP Norm",
+                            "center": true
+                        },
+                        {
+                            "range": [45, 49],
+                            "name": "PTSP Fast",
+                            "center": true
+                        },
+                        {
+                            "range": [50, 54],
+                            "name": "No Function ",
+                            "center": true
+                        },
+                        {
+                            "range": [55, 59],
+                            "name": "Reserve",
+                            "center": true
+                        },
+                        {
+                            "range": [60, 64],
+                            "name": "No Function ",
+                            "center": true
+                        },
+                        {
+                            "range": [65, 69],
+                            "name": "Fan Full",
+                            "center": true
+                        },
+                        {
+                            "range": [70, 74],
+                            "name": "No Function ",
+                            "center": true
+                        },
+                        {
+                            "range": [75, 79],
+                            "name": "Fan controlled",
+                            "center": true
+                        },
+                        {
+                            "range": [80, 84],
+                            "name": "No Function ",
+                            "center": true
+                        },
+                        {
+                            "range": [85, 89],
+                            "name": "Fan Silent",
+                            "center": true
+                        },
+                        {
+                            "range": [90, 94],
+                            "name": "No Function ",
+                            "center": true
+                        },
+                        {
+                            "range": [95, 99],
+                            "name": "LIN",
+                            "center": true
+                        },
+                        {
+                            "range": [100, 104],
+                            "name": "No Function ",
+                            "center": true
+                        },
+                        {
+                            "range": [105, 109],
+                            "name": "SQR",
+                            "center": true
+                        },
+                        {
+                            "range": [110, 114],
+                            "name": "No Function ",
+                            "center": true
+                        },
+                        {
+                            "range": [115, 119],
+                            "name": "ISQR",
+                            "center": true
+                        },
+                        {
+                            "range": [120, 124],
+                            "name": "No Function ",
+                            "center": true
+                        },
+                        {
+                            "range": [125, 129],
+                            "name": "SCUR",
+                            "center": true
+                        },
+                        {
+                            "range": [130, 249],
+                            "name": "No Function ",
+                            "center": true
+                        },
+                        {
+                            "range": [250, 255],
+                            "name": "Display On",
+                            "center": true
+                        }
+                    ]
+                },
+                "Color Wheel": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 9],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [10, 14],
+                            "name": "LEE 790",
+                            "center": true
+                        },
+                        {
+                            "range": [15, 19],
+                            "name": "LEE 157",
+                            "center": true
+                        },
+                        {
+                            "range": [20, 24],
+                            "name": "LEE 332",
+                            "center": true
+                        },
+                        {
+                            "range": [25, 29],
+                            "name": "LEE 328",
+                            "center": true
+                        },
+                        {
+                            "range": [30, 34],
+                            "name": "LEE 345",
+                            "center": true
+                        },
+                        {
+                            "range": [35, 39],
+                            "name": "LEE 194",
+                            "center": true
+                        },
+                        {
+                            "range": [40, 44],
+                            "name": "LEE  181",
+                            "center": true
+                        },
+                        {
+                            "range": [45, 49],
+                            "name": "LEE 071",
+                            "center": true
+                        },
+                        {
+                            "range": [50, 54],
+                            "name": "LEE 120",
+                            "center": true
+                        },
+                        {
+                            "range": [55, 59],
+                            "name": "LEE 079",
+                            "center": true
+                        },
+                        {
+                            "range": [60, 64],
+                            "name": "LEE 132",
+                            "center": true
+                        },
+                        {
+                            "range": [65, 69],
+                            "name": "LEE 200",
+                            "center": true
+                        },
+                        {
+                            "range": [70, 74],
+                            "name": "LEE 161",
+                            "center": true
+                        },
+                        {
+                            "range": [75, 79],
+                            "name": "LEE 201",
+                            "center": true
+                        },
+                        {
+                            "range": [80, 84],
+                            "name": "LEE 202",
+                            "center": true
+                        },
+                        {
+                            "range": [85, 89],
+                            "name": "LEE 117",
+                            "center": true
+                        },
+                        {
+                            "range": [90, 94],
+                            "name": "LEE 353",
+                            "center": true
+                        },
+                        {
+                            "range": [95, 99],
+                            "name": "LEE 118",
+                            "center": true
+                        },
+                        {
+                            "range": [100, 104],
+                            "name": "LEE 116",
+                            "center": true
+                        },
+                        {
+                            "range": [105, 109],
+                            "name": "LEE 124",
+                            "center": true
+                        },
+                        {
+                            "range": [110, 114],
+                            "name": "LEE 139",
+                            "center": true
+                        },
+                        {
+                            "range": [115, 119],
+                            "name": "LEE 089",
+                            "center": true
+                        },
+                        {
+                            "range": [120, 124],
+                            "name": "LEE 122",
+                            "center": true
+                        },
+                        {
+                            "range": [125, 129],
+                            "name": "LEE 738",
+                            "center": true
+                        },
+                        {
+                            "range": [130, 134],
+                            "name": "LEE 088",
+                            "center": true
+                        },
+                        {
+                            "range": [135, 139],
+                            "name": "LEE 100",
+                            "center": true
+                        },
+                        {
+                            "range": [140, 144],
+                            "name": "LEE 104",
+                            "center": true
+                        },
+                        {
+                            "range": [145, 149],
+                            "name": "LEE 179",
+                            "center": true
+                        },
+                        {
+                            "range": [150, 154],
+                            "name": "LEE 105",
+                            "center": true
+                        },
+                        {
+                            "range": [155, 159],
+                            "name": "LEE 021",
+                            "center": true
+                        },
+                        {
+                            "range": [160, 164],
+                            "name": "LEE 778",
+                            "center": true
+                        },
+                        {
+                            "range": [165, 169],
+                            "name": "LEE 135",
+                            "center": true
+                        },
+                        {
+                            "range": [170, 174],
+                            "name": "LEE 164",
+                            "center": true
+                        },
+                        {
+                            "range": [175, 179],
+                            "name": "Open",
+                            "center": true
+                        },
+                        {
+                            "range": [180, 201],
+                            "name": "S-F Right"
+                        },
+                        {
+                            "range": [202, 207],
+                            "name": "No Rotation",
+                            "center": true
+                        },
+                        {
+                            "range": [208, 229],
+                            "name": "S-F Right"
+                        },
+                        {
+                            "range": [230, 234],
+                            "name": "Open",
+                            "center": true
+                        },
+                        {
+                            "range": [235, 239],
+                            "name": "RND Col Fast",
+                            "center": true
+                        },
+                        {
+                            "range": [240, 244],
+                            "name": "RND Col Med",
+                            "center": true
+                        },
+                        {
+                            "range": [245, 249],
+                            "name": "RND Col Slow",
+                            "center": true
+                        },
+                        {
+                            "range": [250, 255],
+                            "name": "Open",
+                            "center": true
+                        }
+                    ]
+                },
+                "Red or Color": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Green or Satura": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Blue or Value": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "CTC": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 19],
+                            "name": "No Function"
+                        },
+                        {
+                            "range": [20, 255],
+                            "name": "10000K to 2000K"
+                        }
+                    ]
+                },
+                "Red or Color-qkzft": {
+                    "name": "Red or Color",
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Green or Satura-kc4ee": {
+                    "name": "Green or Satura",
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Blue or Value-gfrkv": {
+                    "name": "Blue or Value",
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "CTC-tfbyh": {
+                    "name": "CTC",
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 19],
+                            "name": "No Function"
+                        },
+                        {
+                            "range": [20, 255],
+                            "name": "10000K to 2000K"
+                        }
+                    ]
+                },
+                "Red or Color-h38y5": {
+                    "name": "Red or Color",
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Green or Satura-06gp6": {
+                    "name": "Green or Satura",
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Blue or Value-av1s1": {
+                    "name": "Blue or Value",
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "CTC-cjuzc": {
+                    "name": "CTC",
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 19],
+                            "name": "No Function"
+                        },
+                        {
+                            "range": [20, 255],
+                            "name": "10000K to 2000K"
+                        }
+                    ]
+                },
+                "Red or Color-gg3oc": {
+                    "name": "Red or Color",
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Green or Satura-bi3od": {
+                    "name": "Green or Satura",
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Blue or Value-2o1ta": {
+                    "name": "Blue or Value",
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "CTC-qhp28": {
+                    "name": "CTC",
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 19],
+                            "name": "No Function"
+                        },
+                        {
+                            "range": [20, 255],
+                            "name": "10000K to 2000K"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "25-channel Mode",
+                    "shortName": "25ch",
+                    "channels": [
+                        "Strobe V Shutte",
+                        "Dimmer",
+                        "Zoom",
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "Dev Function",
+                        "Color Wheel",
+                        "Red or Color",
+                        "Green or Satura",
+                        "Blue or Value",
+                        "CTC",
+                        "Red or Color-qkzft",
+                        "Green or Satura-kc4ee",
+                        "Blue or Value-gfrkv",
+                        "CTC-tfbyh",
+                        "Red or Color-h38y5",
+                        "Green or Satura-06gp6",
+                        "Blue or Value-av1s1",
+                        "CTC-cjuzc",
+                        "Red or Color-gg3oc",
+                        "Green or Satura-bi3od",
+                        "Blue or Value-2o1ta",
+                        "CTC-qhp28"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Martin",
+            "name": "Mac 401 RGBX",
+            "shortName": "Mac401RGBX",
+            "comment": "LED Movinghead",
+            "physical": {
+                "dimensions": [505, 530, 375],
+                "weight": 21,
+                "power": 766
+            },
+            "availableChannels": {
+                "Strobe V Shutte": {
+                    "type": "Strobe",
+                    "defaultValue": 25,
+                    "highlightValue": 25,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 19],
+                            "name": "Closed",
+                            "center": true
+                        },
+                        {
+                            "range": [20, 49],
+                            "name": "Open",
+                            "center": true
+                        },
+                        {
+                            "range": [50, 64],
+                            "name": "Strobe F-S"
+                        },
+                        {
+                            "range": [65, 69],
+                            "name": "Open",
+                            "center": true
+                        },
+                        {
+                            "range": [70, 84],
+                            "name": "Pulse Open S-F"
+                        },
+                        {
+                            "range": [85, 89],
+                            "name": "Open",
+                            "center": true
+                        },
+                        {
+                            "range": [90, 104],
+                            "name": "Pulse Close F-S"
+                        },
+                        {
+                            "range": [105, 109],
+                            "name": "Open",
+                            "center": true
+                        },
+                        {
+                            "range": [110, 124],
+                            "name": "RND strobe F-S"
+                        },
+                        {
+                            "range": [125, 129],
+                            "name": "Closed",
+                            "center": true
+                        },
+                        {
+                            "range": [130, 144],
+                            "name": "RNDPulse Op F-S"
+                        },
+                        {
+                            "range": [145, 149],
+                            "name": "Open",
+                            "center": true
+                        },
+                        {
+                            "range": [150, 164],
+                            "name": "RNDPulse Cl F-S"
+                        },
+                        {
+                            "range": [165, 169],
+                            "name": "Closed",
+                            "center": true
+                        },
+                        {
+                            "range": [170, 184],
+                            "name": "Burst pulse F-S"
+                        },
+                        {
+                            "range": [185, 189],
+                            "name": "Open",
+                            "center": true
+                        },
+                        {
+                            "range": [190, 204],
+                            "name": "RND Burst F-S"
+                        },
+                        {
+                            "range": [205, 209],
+                            "name": "Closed",
+                            "center": true
+                        },
+                        {
+                            "range": [210, 224],
+                            "name": "Sinuswave F-S"
+                        },
+                        {
+                            "range": [225, 229],
+                            "name": "Open",
+                            "center": true
+                        },
+                        {
+                            "range": [230, 244],
+                            "name": "el Burst F-S"
+                        },
+                        {
+                            "range": [245, 255],
+                            "name": "Open",
+                            "center": true
+                        }
+                    ]
+                },
+                "Dimmer": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Effect Macro 1": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 19],
+                            "name": "No Effect"
+                        },
+                        {
+                            "range": [20, 39],
+                            "name": "Effect 1",
+                            "center": true
+                        },
+                        {
+                            "range": [40, 59],
+                            "name": "Effect 2",
+                            "center": true
+                        },
+                        {
+                            "range": [60, 79],
+                            "name": "Effect 3",
+                            "center": true
+                        },
+                        {
+                            "range": [80, 89],
+                            "name": "Effect 4",
+                            "center": true
+                        },
+                        {
+                            "range": [85, 89],
+                            "name": "Effect 5",
+                            "center": true
+                        },
+                        {
+                            "range": [90, 94],
+                            "name": "Effect 6",
+                            "center": true
+                        },
+                        {
+                            "range": [95, 99],
+                            "name": "Effect 7",
+                            "center": true
+                        },
+                        {
+                            "range": [100, 104],
+                            "name": "Effect 8",
+                            "center": true
+                        },
+                        {
+                            "range": [105, 109],
+                            "name": "Effect 9",
+                            "center": true
+                        },
+                        {
+                            "range": [110, 114],
+                            "name": "Effect 10",
+                            "center": true
+                        },
+                        {
+                            "range": [115, 119],
+                            "name": "Effect 11",
+                            "center": true
+                        },
+                        {
+                            "range": [120, 124],
+                            "name": "Effect 12",
+                            "center": true
+                        },
+                        {
+                            "range": [125, 129],
+                            "name": "Effect 13",
+                            "center": true
+                        },
+                        {
+                            "range": [130, 134],
+                            "name": "Effect 14",
+                            "center": true
+                        },
+                        {
+                            "range": [135, 139],
+                            "name": "Effect 15",
+                            "center": true
+                        },
+                        {
+                            "range": [140, 144],
+                            "name": "Effect 16",
+                            "center": true
+                        },
+                        {
+                            "range": [145, 149],
+                            "name": "Effect 17",
+                            "center": true
+                        },
+                        {
+                            "range": [150, 154],
+                            "name": "Effect 18",
+                            "center": true
+                        },
+                        {
+                            "range": [155, 159],
+                            "name": "Effect 19",
+                            "center": true
+                        },
+                        {
+                            "range": [160, 164],
+                            "name": "Effect 20",
+                            "center": true
+                        },
+                        {
+                            "range": [165, 169],
+                            "name": "Effect 21",
+                            "center": true
+                        },
+                        {
+                            "range": [170, 174],
+                            "name": "Effect 22",
+                            "center": true
+                        },
+                        {
+                            "range": [175, 179],
+                            "name": "Effect 23",
+                            "center": true
+                        },
+                        {
+                            "range": [180, 184],
+                            "name": "Effect 24",
+                            "center": true
+                        },
+                        {
+                            "range": [185, 189],
+                            "name": "Effect 25",
+                            "center": true
+                        },
+                        {
+                            "range": [190, 194],
+                            "name": "Effect 26",
+                            "center": true
+                        },
+                        {
+                            "range": [195, 199],
+                            "name": "Effect 27",
+                            "center": true
+                        },
+                        {
+                            "range": [200, 204],
+                            "name": "Effect 28",
+                            "center": true
+                        },
+                        {
+                            "range": [205, 209],
+                            "name": "Effect 29",
+                            "center": true
+                        },
+                        {
+                            "range": [210, 214],
+                            "name": "Effect 30",
+                            "center": true
+                        },
+                        {
+                            "range": [215, 219],
+                            "name": "Effect 31",
+                            "center": true
+                        },
+                        {
+                            "range": [220, 224],
+                            "name": "Effect 32",
+                            "center": true
+                        },
+                        {
+                            "range": [225, 229],
+                            "name": "Effect 33",
+                            "center": true
+                        },
+                        {
+                            "range": [230, 234],
+                            "name": "Effect 34",
+                            "center": true
+                        },
+                        {
+                            "range": [235, 239],
+                            "name": "Effect 35",
+                            "center": true
+                        },
+                        {
+                            "range": [240, 244],
+                            "name": "Effect 36",
+                            "center": true
+                        },
+                        {
+                            "range": [245, 249],
+                            "name": "Effect 37",
+                            "center": true
+                        },
+                        {
+                            "range": [250, 255],
+                            "name": "Effect 38",
+                            "center": true
+                        }
+                    ]
+                },
+                "Macro 1 Speed": {
+                    "type": "Speed",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 2],
+                            "name": "Stop"
+                        },
+                        {
+                            "range": [3, 126],
+                            "name": "F-S right"
+                        },
+                        {
+                            "range": [127, 129],
+                            "name": "Stop"
+                        },
+                        {
+                            "range": [130, 253],
+                            "name": "S-F left"
+                        },
+                        {
+                            "range": [254, 255],
+                            "name": "Stop"
+                        }
+                    ]
+                },
+                "Macro 1 ofglare": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Macro 1 brightn": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Effect Macro 2": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 19],
+                            "name": "No Effect"
+                        },
+                        {
+                            "range": [20, 39],
+                            "name": "Effect 1",
+                            "center": true
+                        },
+                        {
+                            "range": [40, 59],
+                            "name": "Effect 2",
+                            "center": true
+                        },
+                        {
+                            "range": [60, 79],
+                            "name": "Effect 3",
+                            "center": true
+                        },
+                        {
+                            "range": [80, 89],
+                            "name": "Effect 4",
+                            "center": true
+                        },
+                        {
+                            "range": [85, 89],
+                            "name": "Effect 5",
+                            "center": true
+                        },
+                        {
+                            "range": [90, 94],
+                            "name": "Effect 6",
+                            "center": true
+                        },
+                        {
+                            "range": [95, 99],
+                            "name": "Effect 7",
+                            "center": true
+                        },
+                        {
+                            "range": [100, 104],
+                            "name": "Effect 8",
+                            "center": true
+                        },
+                        {
+                            "range": [105, 109],
+                            "name": "Effect 9",
+                            "center": true
+                        },
+                        {
+                            "range": [110, 114],
+                            "name": "Effect 10",
+                            "center": true
+                        },
+                        {
+                            "range": [115, 119],
+                            "name": "Effect 11",
+                            "center": true
+                        },
+                        {
+                            "range": [120, 124],
+                            "name": "Effect 12",
+                            "center": true
+                        },
+                        {
+                            "range": [125, 129],
+                            "name": "Effect 13",
+                            "center": true
+                        },
+                        {
+                            "range": [130, 134],
+                            "name": "Effect 14",
+                            "center": true
+                        },
+                        {
+                            "range": [135, 139],
+                            "name": "Effect 15",
+                            "center": true
+                        },
+                        {
+                            "range": [140, 144],
+                            "name": "Effect 16",
+                            "center": true
+                        },
+                        {
+                            "range": [145, 149],
+                            "name": "Effect 17",
+                            "center": true
+                        },
+                        {
+                            "range": [150, 154],
+                            "name": "Effect 18",
+                            "center": true
+                        },
+                        {
+                            "range": [155, 159],
+                            "name": "Effect 19",
+                            "center": true
+                        },
+                        {
+                            "range": [160, 164],
+                            "name": "Effect 20",
+                            "center": true
+                        },
+                        {
+                            "range": [165, 169],
+                            "name": "Effect 21",
+                            "center": true
+                        },
+                        {
+                            "range": [170, 174],
+                            "name": "Effect 22",
+                            "center": true
+                        },
+                        {
+                            "range": [175, 179],
+                            "name": "Effect 23",
+                            "center": true
+                        },
+                        {
+                            "range": [180, 184],
+                            "name": "Effect 24",
+                            "center": true
+                        },
+                        {
+                            "range": [185, 189],
+                            "name": "Effect 25",
+                            "center": true
+                        },
+                        {
+                            "range": [190, 194],
+                            "name": "Effect 26",
+                            "center": true
+                        },
+                        {
+                            "range": [195, 199],
+                            "name": "Effect 27",
+                            "center": true
+                        },
+                        {
+                            "range": [200, 204],
+                            "name": "Effect 28",
+                            "center": true
+                        },
+                        {
+                            "range": [205, 209],
+                            "name": "Effect 29",
+                            "center": true
+                        },
+                        {
+                            "range": [210, 214],
+                            "name": "Effect 30",
+                            "center": true
+                        },
+                        {
+                            "range": [215, 219],
+                            "name": "Effect 31",
+                            "center": true
+                        },
+                        {
+                            "range": [220, 224],
+                            "name": "Effect 32",
+                            "center": true
+                        },
+                        {
+                            "range": [225, 229],
+                            "name": "Effect 33",
+                            "center": true
+                        },
+                        {
+                            "range": [230, 234],
+                            "name": "Effect 34",
+                            "center": true
+                        },
+                        {
+                            "range": [235, 239],
+                            "name": "Effect 35",
+                            "center": true
+                        },
+                        {
+                            "range": [240, 244],
+                            "name": "Effect 36",
+                            "center": true
+                        },
+                        {
+                            "range": [245, 249],
+                            "name": "Effect 37",
+                            "center": true
+                        },
+                        {
+                            "range": [250, 255],
+                            "name": "Effect 38",
+                            "center": true
+                        }
+                    ]
+                },
+                "Macro 2 Speed": {
+                    "type": "Speed",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 2],
+                            "name": "Stop"
+                        },
+                        {
+                            "range": [3, 126],
+                            "name": "F-S right"
+                        },
+                        {
+                            "range": [127, 129],
+                            "name": "Stop"
+                        },
+                        {
+                            "range": [130, 253],
+                            "name": "S-F left"
+                        },
+                        {
+                            "range": [254, 255],
+                            "name": "Stop"
+                        }
+                    ]
+                },
+                "Macro 2 ofglare": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Macro 2 brightn": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Zoom": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 200],
+                            "name": "Far-Close",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [201, 210],
+                            "name": "Hypermode",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [211, 255],
+                            "name": "No Function"
+                        }
+                    ]
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Dev Function": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 9],
+                            "name": "No Function ",
+                            "center": true
+                        },
+                        {
+                            "range": [10, 14],
+                            "name": "Reset All",
+                            "center": true
+                        },
+                        {
+                            "range": [15, 19],
+                            "name": "No Function ",
+                            "center": true
+                        },
+                        {
+                            "range": [20, 24],
+                            "name": "RST Effect 1",
+                            "center": true
+                        },
+                        {
+                            "range": [25, 29],
+                            "name": "No Function ",
+                            "center": true
+                        },
+                        {
+                            "range": [30, 34],
+                            "name": "RST P+T",
+                            "center": true
+                        },
+                        {
+                            "range": [35, 39],
+                            "name": "No Function ",
+                            "center": true
+                        },
+                        {
+                            "range": [40, 44],
+                            "name": "PTSP Norm",
+                            "center": true
+                        },
+                        {
+                            "range": [45, 49],
+                            "name": "PTSP Fast",
+                            "center": true
+                        },
+                        {
+                            "range": [50, 54],
+                            "name": "No Function ",
+                            "center": true
+                        },
+                        {
+                            "range": [55, 59],
+                            "name": "Reserve",
+                            "center": true
+                        },
+                        {
+                            "range": [60, 64],
+                            "name": "No Function ",
+                            "center": true
+                        },
+                        {
+                            "range": [65, 69],
+                            "name": "Fan Full",
+                            "center": true
+                        },
+                        {
+                            "range": [70, 74],
+                            "name": "No Function ",
+                            "center": true
+                        },
+                        {
+                            "range": [75, 79],
+                            "name": "Fan controlled",
+                            "center": true
+                        },
+                        {
+                            "range": [80, 84],
+                            "name": "No Function ",
+                            "center": true
+                        },
+                        {
+                            "range": [85, 89],
+                            "name": "Fan Silent",
+                            "center": true
+                        },
+                        {
+                            "range": [90, 94],
+                            "name": "No Function ",
+                            "center": true
+                        },
+                        {
+                            "range": [95, 99],
+                            "name": "LIN",
+                            "center": true
+                        },
+                        {
+                            "range": [100, 104],
+                            "name": "No Function ",
+                            "center": true
+                        },
+                        {
+                            "range": [105, 109],
+                            "name": "SQR",
+                            "center": true
+                        },
+                        {
+                            "range": [110, 114],
+                            "name": "No Function ",
+                            "center": true
+                        },
+                        {
+                            "range": [115, 119],
+                            "name": "ISQR",
+                            "center": true
+                        },
+                        {
+                            "range": [120, 124],
+                            "name": "No Function ",
+                            "center": true
+                        },
+                        {
+                            "range": [125, 129],
+                            "name": "SCUR",
+                            "center": true
+                        },
+                        {
+                            "range": [130, 249],
+                            "name": "No Function ",
+                            "center": true
+                        },
+                        {
+                            "range": [250, 255],
+                            "name": "Display On",
+                            "center": true
+                        }
+                    ]
+                },
+                "Color Wheel": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 9],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [10, 14],
+                            "name": "LEE 790",
+                            "center": true
+                        },
+                        {
+                            "range": [15, 19],
+                            "name": "LEE 157",
+                            "center": true
+                        },
+                        {
+                            "range": [20, 24],
+                            "name": "LEE 332",
+                            "center": true
+                        },
+                        {
+                            "range": [25, 29],
+                            "name": "LEE 328",
+                            "center": true
+                        },
+                        {
+                            "range": [30, 34],
+                            "name": "LEE 345",
+                            "center": true
+                        },
+                        {
+                            "range": [35, 39],
+                            "name": "LEE 194",
+                            "center": true
+                        },
+                        {
+                            "range": [40, 44],
+                            "name": "LEE  181",
+                            "center": true
+                        },
+                        {
+                            "range": [45, 49],
+                            "name": "LEE 071",
+                            "center": true
+                        },
+                        {
+                            "range": [50, 54],
+                            "name": "LEE 120",
+                            "center": true
+                        },
+                        {
+                            "range": [55, 59],
+                            "name": "LEE 079",
+                            "center": true
+                        },
+                        {
+                            "range": [60, 64],
+                            "name": "LEE 132",
+                            "center": true
+                        },
+                        {
+                            "range": [65, 69],
+                            "name": "LEE 200",
+                            "center": true
+                        },
+                        {
+                            "range": [70, 74],
+                            "name": "LEE 161",
+                            "center": true
+                        },
+                        {
+                            "range": [75, 79],
+                            "name": "LEE 201",
+                            "center": true
+                        },
+                        {
+                            "range": [80, 84],
+                            "name": "LEE 202",
+                            "center": true
+                        },
+                        {
+                            "range": [85, 89],
+                            "name": "LEE 117",
+                            "center": true
+                        },
+                        {
+                            "range": [90, 94],
+                            "name": "LEE 353",
+                            "center": true
+                        },
+                        {
+                            "range": [95, 99],
+                            "name": "LEE 118",
+                            "center": true
+                        },
+                        {
+                            "range": [100, 104],
+                            "name": "LEE 116",
+                            "center": true
+                        },
+                        {
+                            "range": [105, 109],
+                            "name": "LEE 124",
+                            "center": true
+                        },
+                        {
+                            "range": [110, 114],
+                            "name": "LEE 139",
+                            "center": true
+                        },
+                        {
+                            "range": [115, 119],
+                            "name": "LEE 089",
+                            "center": true
+                        },
+                        {
+                            "range": [120, 124],
+                            "name": "LEE 122",
+                            "center": true
+                        },
+                        {
+                            "range": [125, 129],
+                            "name": "LEE 738",
+                            "center": true
+                        },
+                        {
+                            "range": [130, 134],
+                            "name": "LEE 088",
+                            "center": true
+                        },
+                        {
+                            "range": [135, 139],
+                            "name": "LEE 100",
+                            "center": true
+                        },
+                        {
+                            "range": [140, 144],
+                            "name": "LEE 104",
+                            "center": true
+                        },
+                        {
+                            "range": [145, 149],
+                            "name": "LEE 179",
+                            "center": true
+                        },
+                        {
+                            "range": [150, 154],
+                            "name": "LEE 105",
+                            "center": true
+                        },
+                        {
+                            "range": [155, 159],
+                            "name": "LEE 021",
+                            "center": true
+                        },
+                        {
+                            "range": [160, 164],
+                            "name": "LEE 778",
+                            "center": true
+                        },
+                        {
+                            "range": [165, 169],
+                            "name": "LEE 135",
+                            "center": true
+                        },
+                        {
+                            "range": [170, 174],
+                            "name": "LEE 164",
+                            "center": true
+                        },
+                        {
+                            "range": [175, 179],
+                            "name": "Open",
+                            "center": true
+                        },
+                        {
+                            "range": [180, 201],
+                            "name": "S-F Right"
+                        },
+                        {
+                            "range": [202, 207],
+                            "name": "No Rotation",
+                            "center": true
+                        },
+                        {
+                            "range": [208, 229],
+                            "name": "S-F Right"
+                        },
+                        {
+                            "range": [230, 234],
+                            "name": "Open",
+                            "center": true
+                        },
+                        {
+                            "range": [235, 239],
+                            "name": "RND Col Fast",
+                            "center": true
+                        },
+                        {
+                            "range": [240, 244],
+                            "name": "RND Col Med",
+                            "center": true
+                        },
+                        {
+                            "range": [245, 249],
+                            "name": "RND Col Slow",
+                            "center": true
+                        },
+                        {
+                            "range": [250, 255],
+                            "name": "Open",
+                            "center": true
+                        }
+                    ]
+                },
+                "Red or Color": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Green or Satura": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Blue or Value": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "CTC": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 19],
+                            "name": "No Function"
+                        },
+                        {
+                            "range": [20, 255],
+                            "name": "10000K to 2000K"
+                        }
+                    ]
+                },
+                "Red or Color-tvd6v": {
+                    "name": "Red or Color",
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Green or Satura-q343u": {
+                    "name": "Green or Satura",
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Blue or Value-c1q4w": {
+                    "name": "Blue or Value",
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "CTC-re2ke": {
+                    "name": "CTC",
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 19],
+                            "name": "No Function"
+                        },
+                        {
+                            "range": [20, 255],
+                            "name": "10000K to 2000K"
+                        }
+                    ]
+                },
+                "Red or Color-qt2l7": {
+                    "name": "Red or Color",
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Green or Satura-zdmpi": {
+                    "name": "Green or Satura",
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Blue or Value-zaifz": {
+                    "name": "Blue or Value",
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "CTC-5gd1e": {
+                    "name": "CTC",
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 19],
+                            "name": "No Function"
+                        },
+                        {
+                            "range": [20, 255],
+                            "name": "10000K to 2000K"
+                        }
+                    ]
+                },
+                "Red or Color-jzrtz": {
+                    "name": "Red or Color",
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Green or Satura-yut7n": {
+                    "name": "Green or Satura",
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Blue or Value-a3yft": {
+                    "name": "Blue or Value",
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "CTC-kddxk": {
+                    "name": "CTC",
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 19],
+                            "name": "No Function"
+                        },
+                        {
+                            "range": [20, 255],
+                            "name": "10000K to 2000K"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "33-channel Mode",
+                    "shortName": "33ch",
+                    "channels": [
+                        "Strobe V Shutte",
+                        "Dimmer",
+                        "Effect Macro 1",
+                        "Macro 1 Speed",
+                        "Macro 1 ofglare",
+                        "Macro 1 brightn",
+                        "Effect Macro 2",
+                        "Macro 2 Speed",
+                        "Macro 2 ofglare",
+                        "Macro 2 brightn",
+                        "Zoom",
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "Dev Function",
+                        "Color Wheel",
+                        "Red or Color",
+                        "Green or Satura",
+                        "Blue or Value",
+                        "CTC",
+                        "Red or Color-tvd6v",
+                        "Green or Satura-q343u",
+                        "Blue or Value-c1q4w",
+                        "CTC-re2ke",
+                        "Red or Color-qt2l7",
+                        "Green or Satura-zdmpi",
+                        "Blue or Value-zaifz",
+                        "CTC-5gd1e",
+                        "Red or Color-jzrtz",
+                        "Green or Satura-yut7n",
+                        "Blue or Value-a3yft",
+                        "CTC-kddxk"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Martin",
+            "name": "Mac 500 Mode4",
+            "shortName": "Mac500m4",
+            "comment": "cd",
+            "physical": {
+                "dimensions": [450, 450, 656]
+            },
+            "availableChannels": {
+                "Shutter": {
+                    "type": "Shutter",
+                    "highlightValue": 30,
+                    "capabilities": [
+                        {
+                            "range": [0, 19],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [20, 49],
+                            "name": "open"
+                        },
+                        {
+                            "range": [50, 72],
+                            "name": "strobe"
+                        },
+                        {
+                            "range": [73, 79],
+                            "name": "open"
+                        },
+                        {
+                            "range": [80, 99],
+                            "name": "pulse opening"
+                        },
+                        {
+                            "range": [100, 119],
+                            "name": "pulse closing"
+                        },
+                        {
+                            "range": [120, 127],
+                            "name": "open"
+                        },
+                        {
+                            "range": [128, 187],
+                            "name": "random strobe"
+                        },
+                        {
+                            "range": [188, 190],
+                            "name": "open"
+                        },
+                        {
+                            "range": [191, 202],
+                            "name": "random pulse"
+                        },
+                        {
+                            "range": [203, 207],
+                            "name": "open"
+                        },
+                        {
+                            "range": [208, 217],
+                            "name": "reset"
+                        },
+                        {
+                            "range": [218, 227],
+                            "name": "open"
+                        },
+                        {
+                            "range": [228, 237],
+                            "name": "lamp on"
+                        },
+                        {
+                            "range": [238, 247],
+                            "name": "open"
+                        },
+                        {
+                            "range": [248, 255],
+                            "name": "lamp off"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Color1": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 16],
+                            "name": "open"
+                        },
+                        {
+                            "range": [16, 32],
+                            "name": "blue 111"
+                        },
+                        {
+                            "range": [32, 48],
+                            "name": "red 301"
+                        },
+                        {
+                            "range": [48, 64],
+                            "name": "magenta 507"
+                        },
+                        {
+                            "range": [64, 80],
+                            "name": "green 202"
+                        },
+                        {
+                            "range": [80, 96],
+                            "name": "yellow 604"
+                        },
+                        {
+                            "range": [96, 112],
+                            "name": "purble 502"
+                        },
+                        {
+                            "range": [112, 128],
+                            "name": "blue 101"
+                        },
+                        {
+                            "range": [128, 144],
+                            "name": "pink 312"
+                        },
+                        {
+                            "range": [145, 148],
+                            "name": "cyan 401"
+                        },
+                        {
+                            "range": [149, 152],
+                            "name": "pink 312"
+                        },
+                        {
+                            "range": [153, 156],
+                            "name": "blue 101"
+                        },
+                        {
+                            "range": [157, 160],
+                            "name": "purble 502"
+                        },
+                        {
+                            "range": [161, 164],
+                            "name": "yellow 604"
+                        },
+                        {
+                            "range": [165, 168],
+                            "name": "green 202"
+                        },
+                        {
+                            "range": [169, 172],
+                            "name": "magenta 507"
+                        },
+                        {
+                            "range": [173, 176],
+                            "name": "red 301"
+                        },
+                        {
+                            "range": [177, 180],
+                            "name": "blue 111"
+                        },
+                        {
+                            "range": [181, 184],
+                            "name": "open"
+                        },
+                        {
+                            "range": [185, 215],
+                            "name": ">>"
+                        },
+                        {
+                            "range": [216, 245],
+                            "name": "<<"
+                        },
+                        {
+                            "range": [246, 255],
+                            "name": "special"
+                        }
+                    ]
+                },
+                "Color2": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 16],
+                            "name": "open"
+                        },
+                        {
+                            "range": [16, 32],
+                            "name": "CTB"
+                        },
+                        {
+                            "range": [32, 48],
+                            "name": "CTB2"
+                        },
+                        {
+                            "range": [48, 64],
+                            "name": "blue 104"
+                        },
+                        {
+                            "range": [64, 80],
+                            "name": "blue 108"
+                        },
+                        {
+                            "range": [80, 96],
+                            "name": "green 206"
+                        },
+                        {
+                            "range": [96, 112],
+                            "name": "red 308"
+                        },
+                        {
+                            "range": [112, 128],
+                            "name": "yellow 603"
+                        },
+                        {
+                            "range": [128, 144],
+                            "name": "CTO"
+                        },
+                        {
+                            "range": [145, 148],
+                            "name": "CTO2"
+                        },
+                        {
+                            "range": [149, 152],
+                            "name": "CTO"
+                        },
+                        {
+                            "range": [153, 156],
+                            "name": "yellow 603"
+                        },
+                        {
+                            "range": [157, 160],
+                            "name": "red 308"
+                        },
+                        {
+                            "range": [161, 164],
+                            "name": "green 206"
+                        },
+                        {
+                            "range": [165, 168],
+                            "name": "blue 108"
+                        },
+                        {
+                            "range": [169, 172],
+                            "name": "blue 104"
+                        },
+                        {
+                            "range": [173, 176],
+                            "name": "CTB2"
+                        },
+                        {
+                            "range": [177, 180],
+                            "name": "CTB"
+                        },
+                        {
+                            "range": [181, 184],
+                            "name": "open"
+                        },
+                        {
+                            "range": [185, 215],
+                            "name": ">>"
+                        },
+                        {
+                            "range": [216, 245],
+                            "name": "<<"
+                        },
+                        {
+                            "range": [246, 255],
+                            "name": "random"
+                        }
+                    ]
+                },
+                "Gobo1": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 55],
+                            "name": "open"
+                        },
+                        {
+                            "range": [56, 75],
+                            "name": "slot1 ind."
+                        },
+                        {
+                            "range": [76, 95],
+                            "name": "slot2 ind."
+                        },
+                        {
+                            "range": [96, 115],
+                            "name": "slot3 ind."
+                        },
+                        {
+                            "range": [116, 135],
+                            "name": "slot4 ind."
+                        },
+                        {
+                            "range": [136, 155],
+                            "name": "slot5 ind."
+                        },
+                        {
+                            "range": [156, 175],
+                            "name": "slot5 rot."
+                        },
+                        {
+                            "range": [176, 195],
+                            "name": "slot4 rot."
+                        },
+                        {
+                            "range": [196, 215],
+                            "name": "slot3 rot."
+                        },
+                        {
+                            "range": [216, 235],
+                            "name": "slot2 rot."
+                        },
+                        {
+                            "range": [236, 255],
+                            "name": "slot1 rot."
+                        }
+                    ]
+                },
+                "Gobo1 ind./rot.": {
+                    "type": "Gobo",
+                    "defaultValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Gobo2": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 9],
+                            "name": "open"
+                        },
+                        {
+                            "range": [10, 19],
+                            "name": "slot1"
+                        },
+                        {
+                            "range": [20, 29],
+                            "name": "slot2"
+                        },
+                        {
+                            "range": [30, 39],
+                            "name": "slot3"
+                        },
+                        {
+                            "range": [40, 49],
+                            "name": "slot4"
+                        },
+                        {
+                            "range": [50, 59],
+                            "name": "slot5"
+                        },
+                        {
+                            "range": [60, 69],
+                            "name": "slot6"
+                        },
+                        {
+                            "range": [70, 79],
+                            "name": "slot7"
+                        },
+                        {
+                            "range": [80, 89],
+                            "name": "slot8"
+                        },
+                        {
+                            "range": [90, 102],
+                            "name": "slot9"
+                        },
+                        {
+                            "range": [103, 119],
+                            "name": "slot9 sh."
+                        },
+                        {
+                            "range": [120, 136],
+                            "name": "slot8 sh."
+                        },
+                        {
+                            "range": [137, 153],
+                            "name": "slot7 sh."
+                        },
+                        {
+                            "range": [154, 170],
+                            "name": "slot6 sh."
+                        },
+                        {
+                            "range": [171, 187],
+                            "name": "slot5 sh."
+                        },
+                        {
+                            "range": [188, 204],
+                            "name": "slot4 sh."
+                        },
+                        {
+                            "range": [205, 221],
+                            "name": "slot3 sh."
+                        },
+                        {
+                            "range": [222, 238],
+                            "name": "slot2 sh."
+                        },
+                        {
+                            "range": [239, 255],
+                            "name": "slot1 sh."
+                        }
+                    ]
+                },
+                "Focus": {
+                    "type": "Beam",
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Iris": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "open"
+                        },
+                        {
+                            "range": [1, 199],
+                            "name": "%"
+                        },
+                        {
+                            "range": [200, 215],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [216, 229],
+                            "name": "pulse opening"
+                        },
+                        {
+                            "range": [230, 243],
+                            "name": "pulse closing"
+                        },
+                        {
+                            "range": [244, 255],
+                            "name": "random pulse"
+                        }
+                    ]
+                },
+                "Prisma": {
+                    "type": "Prism",
+                    "capabilities": [
+                        {
+                            "range": [0, 19],
+                            "name": "open"
+                        },
+                        {
+                            "range": [20, 79],
+                            "name": ">>"
+                        },
+                        {
+                            "range": [80, 89],
+                            "name": "stop",
+                            "center": true
+                        },
+                        {
+                            "range": [90, 149],
+                            "name": "<<"
+                        },
+                        {
+                            "range": [150, 215],
+                            "name": "open"
+                        },
+                        {
+                            "range": [216, 220],
+                            "name": "macro1"
+                        },
+                        {
+                            "range": [221, 225],
+                            "name": "macro2"
+                        },
+                        {
+                            "range": [226, 230],
+                            "name": "macro3"
+                        },
+                        {
+                            "range": [231, 235],
+                            "name": "macro4"
+                        },
+                        {
+                            "range": [236, 240],
+                            "name": "macro5"
+                        },
+                        {
+                            "range": [241, 245],
+                            "name": "macro6"
+                        },
+                        {
+                            "range": [246, 250],
+                            "name": "macro7"
+                        },
+                        {
+                            "range": [251, 255],
+                            "name": "macro8"
+                        }
+                    ]
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "P/T speed": {
+                    "type": "Speed",
+                    "capabilities": [
+                        {
+                            "range": [0, 2],
+                            "name": "tracking"
+                        },
+                        {
+                            "range": [3, 245],
+                            "name": "speed"
+                        },
+                        {
+                            "range": [246, 248],
+                            "name": "track norm"
+                        },
+                        {
+                            "range": [249, 251],
+                            "name": "track fast"
+                        },
+                        {
+                            "range": [252, 255],
+                            "name": "MIB"
+                        }
+                    ]
+                },
+                "FX speed": {
+                    "type": "Speed",
+                    "capabilities": [
+                        {
+                            "range": [0, 2],
+                            "name": "tracking"
+                        },
+                        {
+                            "range": [3, 245],
+                            "name": "speed"
+                        },
+                        {
+                            "range": [252, 255],
+                            "name": "MIB"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "16-channel Mode",
+                    "shortName": "16ch",
+                    "channels": [
+                        "Shutter",
+                        "Intensity",
+                        "Color1",
+                        "Color2",
+                        "Gobo1",
+                        "Gobo1 ind./rot.",
+                        "Gobo2",
+                        "Focus",
+                        "Iris",
+                        "Prisma",
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "P/T speed",
+                        "FX speed"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Martin",
+            "name": "Mac 500E Mode 1",
+            "shortName": "Mac500m1",
+            "comment": "Mode 1",
+            "physical": {
+                "dimensions": [450, 450, 656]
+            },
+            "availableChannels": {
+                "Strobe": {
+                    "type": "Strobe",
+                    "defaultValue": 20,
+                    "highlightValue": 20,
+                    "capabilities": [
+                        {
+                            "range": [0, 19],
+                            "name": "Closed"
+                        },
+                        {
+                            "range": [20, 49],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [50, 72],
+                            "name": "Strobe"
+                        },
+                        {
+                            "range": [80, 119],
+                            "name": "Pulse"
+                        },
+                        {
+                            "range": [128, 187],
+                            "name": "Random",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [208, 227],
+                            "name": "Reset",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [228, 247],
+                            "name": "Lamp on",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [248, 255],
+                            "name": "Lamp Off",
+                            "showInMenu": false
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Colour": {
+                    "type": "MultiColor",
+                    "capabilities": [
+                        {
+                            "range": [0, 7],
+                            "name": "White",
+                            "color": "#ffffff"
+                        },
+                        {
+                            "range": [8, 23],
+                            "name": "White-Blue",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [24, 39],
+                            "name": "Blue-Red",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [40, 55],
+                            "name": "Red-Mag",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [56, 71],
+                            "name": "Mag-Green",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [72, 87],
+                            "name": "Green-Yell",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [88, 103],
+                            "name": "Yell-Purple",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [104, 119],
+                            "name": "Purple-Blue",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [120, 135],
+                            "name": "Blue-Pink",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [136, 146],
+                            "name": "Pink-Cyan",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [147, 150],
+                            "name": "Cyan",
+                            "color": "#00ffff"
+                        },
+                        {
+                            "range": [151, 154],
+                            "name": "Pink",
+                            "color": "#ffc0cb"
+                        },
+                        {
+                            "range": [155, 158],
+                            "name": "Blue",
+                            "color": "#0000ff"
+                        },
+                        {
+                            "range": [159, 162],
+                            "name": "Purple",
+                            "color": "#800080"
+                        },
+                        {
+                            "range": [163, 166],
+                            "name": "Yellow",
+                            "color": "#ffff00"
+                        },
+                        {
+                            "range": [167, 170],
+                            "name": "Green",
+                            "color": "#00ff00"
+                        },
+                        {
+                            "range": [171, 174],
+                            "name": "Magenta",
+                            "color": "#ca1f7b"
+                        },
+                        {
+                            "range": [175, 178],
+                            "name": "Red",
+                            "color": "#ff0000"
+                        },
+                        {
+                            "range": [179, 182],
+                            "name": "Blue",
+                            "color": "#0000ff"
+                        },
+                        {
+                            "range": [183, 184],
+                            "name": "White",
+                            "color": "#ffffff"
+                        },
+                        {
+                            "range": [185, 215],
+                            "name": "Rot Right",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [216, 245],
+                            "name": "Rot Left",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [246, 255],
+                            "name": "Add Funcs"
+                        }
+                    ]
+                },
+                "Colour 2": {
+                    "type": "MultiColor",
+                    "capabilities": [
+                        {
+                            "range": [0, 8],
+                            "name": "White",
+                            "color": "#ffffff"
+                        },
+                        {
+                            "range": [24, 39],
+                            "name": "CTC1->CTC2",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [40, 55],
+                            "name": "CTC2->Blue",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [56, 71],
+                            "name": "Blue1->Blue2",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [72, 87],
+                            "name": "Blue->Green",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [88, 103],
+                            "name": "Green->Red",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [104, 119],
+                            "name": "Red->Yell",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [120, 135],
+                            "name": "Yell->CTC3",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [136, 144],
+                            "name": "CTC3->CTC4",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [145, 148],
+                            "name": "CTC 4",
+                            "center": true
+                        },
+                        {
+                            "range": [149, 152],
+                            "name": "CTC 3",
+                            "center": true
+                        },
+                        {
+                            "range": [153, 156],
+                            "name": "Yellow",
+                            "color": "#ffff00",
+                            "center": true
+                        },
+                        {
+                            "range": [157, 160],
+                            "name": "Red",
+                            "color": "#ff0000",
+                            "center": true
+                        },
+                        {
+                            "range": [161, 164],
+                            "name": "Green",
+                            "color": "#00ff00",
+                            "center": true
+                        },
+                        {
+                            "range": [165, 168],
+                            "name": "Blue 1",
+                            "center": true
+                        },
+                        {
+                            "range": [169, 172],
+                            "name": "Blue 2",
+                            "center": true
+                        },
+                        {
+                            "range": [173, 176],
+                            "name": "CTC 2",
+                            "center": true
+                        },
+                        {
+                            "range": [177, 180],
+                            "name": "CTC 1",
+                            "center": true
+                        },
+                        {
+                            "range": [181, 184],
+                            "name": "White",
+                            "color": "#ffffff",
+                            "center": true
+                        },
+                        {
+                            "range": [185, 215],
+                            "name": "Rot Right",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [216, 245],
+                            "name": "Rot Left",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [246, 255],
+                            "name": "Random"
+                        }
+                    ]
+                },
+                "RotGobo": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 65],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [66, 85],
+                            "name": "Gobo 1"
+                        },
+                        {
+                            "range": [86, 105],
+                            "name": "Gobo 2"
+                        },
+                        {
+                            "range": [106, 125],
+                            "name": "Gobo 3"
+                        },
+                        {
+                            "range": [126, 145],
+                            "name": "Gobo 4"
+                        },
+                        {
+                            "range": [146, 165],
+                            "name": "Gobo 5"
+                        },
+                        {
+                            "range": [166, 185],
+                            "name": "Rot Gobo 5"
+                        },
+                        {
+                            "range": [186, 205],
+                            "name": "Rot Gobo 4"
+                        },
+                        {
+                            "range": [206, 225],
+                            "name": "Rot Gobo 3"
+                        },
+                        {
+                            "range": [226, 245],
+                            "name": "Rot Gobo 2"
+                        },
+                        {
+                            "range": [246, 255],
+                            "name": "Rot Gobo 1"
+                        }
+                    ]
+                },
+                "indexRG": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 2],
+                            "name": "Static",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [3, 127],
+                            "name": "Rot Left",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [128, 252],
+                            "name": "Rot Right",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [253, 255],
+                            "name": "Static",
+                            "showInMenu": false
+                        }
+                    ]
+                },
+                "Gobo": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 14],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [15, 24],
+                            "name": "Gobo 2-1"
+                        },
+                        {
+                            "range": [25, 34],
+                            "name": "Gobo 2-2"
+                        },
+                        {
+                            "range": [35, 44],
+                            "name": "Gobo 2-3"
+                        },
+                        {
+                            "range": [45, 54],
+                            "name": "Gobo 2-4"
+                        },
+                        {
+                            "range": [55, 64],
+                            "name": "Gobo 2-5"
+                        },
+                        {
+                            "range": [65, 74],
+                            "name": "Gobo 2-6"
+                        },
+                        {
+                            "range": [75, 84],
+                            "name": "Gobo 2-7"
+                        },
+                        {
+                            "range": [85, 95],
+                            "name": "Gobo 2-8"
+                        },
+                        {
+                            "range": [96, 102],
+                            "name": "Gobo 2-9"
+                        },
+                        {
+                            "range": [103, 119],
+                            "name": "Shake 9",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [120, 136],
+                            "name": "Shake 8",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [137, 153],
+                            "name": "Shake 7",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [154, 170],
+                            "name": "Shake 6",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [171, 187],
+                            "name": "Shake 5",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [188, 204],
+                            "name": "Shake 4",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [205, 221],
+                            "name": "Shake 3",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [222, 238],
+                            "name": "Shake 2",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [239, 255],
+                            "name": "Shake 1",
+                            "showInMenu": false
+                        }
+                    ]
+                },
+                "Focus": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "Distance"
+                        }
+                    ]
+                },
+                "Iris": {
+                    "type": "Beam",
+                    "invert": true,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 2],
+                            "name": "Tracking"
+                        },
+                        {
+                            "range": [3, 245],
+                            "name": "speed"
+                        }
+                    ]
+                },
+                "Prism": {
+                    "type": "Prism",
+                    "capabilities": [
+                        {
+                            "range": [0, 19],
+                            "name": "off",
+                            "center": true
+                        },
+                        {
+                            "range": [20, 149],
+                            "name": "rotation",
+                            "center": true
+                        },
+                        {
+                            "range": [150, 215],
+                            "name": "off",
+                            "center": true
+                        },
+                        {
+                            "range": [218, 222],
+                            "name": "Macro 1",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [223, 227],
+                            "name": "Macro 2",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [228, 232],
+                            "name": "Macro 3",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [233, 242],
+                            "name": "Macro 4",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [243, 237],
+                            "name": "Macro 6",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [238, 247],
+                            "name": "Macro 5",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [248, 252],
+                            "name": "Macro 7",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [253, 255],
+                            "name": "Macro 8",
+                            "showInMenu": false
+                        }
+                    ]
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "12-channel Mode",
+                    "shortName": "12ch",
+                    "channels": [
+                        "Strobe",
+                        "Intensity",
+                        "Colour",
+                        "Colour 2",
+                        "RotGobo",
+                        "indexRG",
+                        "Gobo",
+                        "Focus",
+                        "Iris",
+                        "Prism",
+                        "Pan",
+                        "Tilt"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Martin",
+            "name": "Mac 500E Mode 2",
+            "shortName": "Mac500",
+            "comment": "Mode 2",
+            "physical": {
+                "dimensions": [450, 450, 656]
+            },
+            "availableChannels": {
+                "Strobe": {
+                    "type": "Strobe",
+                    "defaultValue": 20,
+                    "highlightValue": 20,
+                    "capabilities": [
+                        {
+                            "range": [0, 19],
+                            "name": "Closed"
+                        },
+                        {
+                            "range": [20, 49],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [50, 72],
+                            "name": "Strobe"
+                        },
+                        {
+                            "range": [80, 119],
+                            "name": "Pulse"
+                        },
+                        {
+                            "range": [128, 187],
+                            "name": "Random",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [212, 231],
+                            "name": "Reset",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [232, 254],
+                            "name": "Lamp on",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "Lamp Off",
+                            "showInMenu": false
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Colour": {
+                    "type": "MultiColor",
+                    "defaultValue": 183,
+                    "highlightValue": 183,
+                    "capabilities": [
+                        {
+                            "range": [0, 7],
+                            "name": "White",
+                            "color": "#ffffff"
+                        },
+                        {
+                            "range": [8, 23],
+                            "name": "White-Blue",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [24, 39],
+                            "name": "Blue-Red",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [40, 55],
+                            "name": "Red-Mag",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [56, 71],
+                            "name": "Mag-Green",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [72, 87],
+                            "name": "Green-Yell",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [88, 103],
+                            "name": "Yell-Purple",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [104, 119],
+                            "name": "Purple-Blue",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [120, 135],
+                            "name": "Blue-Pink",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [136, 146],
+                            "name": "Pink-Cyan",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [147, 150],
+                            "name": "Cyan",
+                            "color": "#00ffff"
+                        },
+                        {
+                            "range": [151, 154],
+                            "name": "Pink",
+                            "color": "#ffc0cb"
+                        },
+                        {
+                            "range": [155, 158],
+                            "name": "Blue",
+                            "color": "#0000ff"
+                        },
+                        {
+                            "range": [159, 162],
+                            "name": "Purple",
+                            "color": "#800080"
+                        },
+                        {
+                            "range": [163, 166],
+                            "name": "Yellow",
+                            "color": "#ffff00"
+                        },
+                        {
+                            "range": [167, 170],
+                            "name": "Green",
+                            "color": "#00ff00"
+                        },
+                        {
+                            "range": [171, 174],
+                            "name": "Magenta",
+                            "color": "#ca1f7b"
+                        },
+                        {
+                            "range": [175, 178],
+                            "name": "Red",
+                            "color": "#ff0000"
+                        },
+                        {
+                            "range": [179, 182],
+                            "name": "Blue",
+                            "color": "#0000ff"
+                        },
+                        {
+                            "range": [183, 184],
+                            "name": "White",
+                            "color": "#ffffff"
+                        },
+                        {
+                            "range": [185, 215],
+                            "name": "Rot Right",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [216, 245],
+                            "name": "Rot Left",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [246, 255],
+                            "name": "Add Funcs"
+                        }
+                    ]
+                },
+                "Colour 2": {
+                    "type": "MultiColor",
+                    "defaultValue": 183,
+                    "highlightValue": 183,
+                    "capabilities": [
+                        {
+                            "range": [0, 8],
+                            "name": "White",
+                            "color": "#ffffff"
+                        },
+                        {
+                            "range": [24, 39],
+                            "name": "CTC1->CTC2",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [40, 55],
+                            "name": "CTC2->Blue",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [56, 71],
+                            "name": "Blue1->Blue2",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [72, 87],
+                            "name": "Blue->Green",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [88, 103],
+                            "name": "Green->Red",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [104, 119],
+                            "name": "Red->Yell",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [120, 135],
+                            "name": "Yell->CTC3",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [136, 144],
+                            "name": "CTC3->CTC4",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [145, 148],
+                            "name": "CTC 4",
+                            "center": true
+                        },
+                        {
+                            "range": [149, 152],
+                            "name": "CTC 3",
+                            "center": true
+                        },
+                        {
+                            "range": [153, 156],
+                            "name": "Yellow",
+                            "color": "#ffff00",
+                            "center": true
+                        },
+                        {
+                            "range": [157, 160],
+                            "name": "Red",
+                            "color": "#ff0000",
+                            "center": true
+                        },
+                        {
+                            "range": [161, 164],
+                            "name": "Green",
+                            "color": "#00ff00",
+                            "center": true
+                        },
+                        {
+                            "range": [165, 168],
+                            "name": "Blue 1",
+                            "center": true
+                        },
+                        {
+                            "range": [169, 172],
+                            "name": "Blue 2",
+                            "center": true
+                        },
+                        {
+                            "range": [173, 176],
+                            "name": "CTC 2",
+                            "center": true
+                        },
+                        {
+                            "range": [177, 180],
+                            "name": "CTC 1",
+                            "center": true
+                        },
+                        {
+                            "range": [181, 184],
+                            "name": "White",
+                            "color": "#ffffff",
+                            "center": true
+                        },
+                        {
+                            "range": [185, 215],
+                            "name": "Rot Right",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [216, 245],
+                            "name": "Rot Left",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [246, 255],
+                            "name": "Random"
+                        }
+                    ]
+                },
+                "Gobo": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 65],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [66, 85],
+                            "name": "Gobo 1"
+                        },
+                        {
+                            "range": [86, 105],
+                            "name": "Gobo 2"
+                        },
+                        {
+                            "range": [106, 125],
+                            "name": "Gobo 3"
+                        },
+                        {
+                            "range": [126, 145],
+                            "name": "Gobo 4"
+                        },
+                        {
+                            "range": [146, 165],
+                            "name": "Gobo 5"
+                        },
+                        {
+                            "range": [166, 185],
+                            "name": "Rot Gobo 5"
+                        },
+                        {
+                            "range": [186, 205],
+                            "name": "Rot Gobo 4"
+                        },
+                        {
+                            "range": [206, 225],
+                            "name": "Rot Gobo 3"
+                        },
+                        {
+                            "range": [226, 245],
+                            "name": "Rot Gobo 2"
+                        },
+                        {
+                            "range": [246, 255],
+                            "name": "Rot Gobo 1"
+                        }
+                    ]
+                },
+                "Gobo Rot": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 2],
+                            "name": "Static",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [3, 127],
+                            "name": "Rot Left",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [128, 252],
+                            "name": "Rot Right",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [253, 255],
+                            "name": "Static",
+                            "showInMenu": false
+                        }
+                    ]
+                },
+                "Gobo 2": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 14],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [15, 24],
+                            "name": "Gobo 2-1"
+                        },
+                        {
+                            "range": [25, 34],
+                            "name": "Gobo 2-2"
+                        },
+                        {
+                            "range": [35, 44],
+                            "name": "Gobo 2-3"
+                        },
+                        {
+                            "range": [45, 54],
+                            "name": "Gobo 2-4"
+                        },
+                        {
+                            "range": [55, 64],
+                            "name": "Gobo 2-5"
+                        },
+                        {
+                            "range": [65, 74],
+                            "name": "Gobo 2-6"
+                        },
+                        {
+                            "range": [75, 84],
+                            "name": "Gobo 2-7"
+                        },
+                        {
+                            "range": [85, 95],
+                            "name": "Gobo 2-8"
+                        },
+                        {
+                            "range": [96, 102],
+                            "name": "Gobo 2-9"
+                        },
+                        {
+                            "range": [103, 119],
+                            "name": "Shake 9",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [120, 136],
+                            "name": "Shake 8",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [137, 153],
+                            "name": "Shake 7",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [154, 170],
+                            "name": "Shake 6",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [171, 187],
+                            "name": "Shake 5",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [188, 204],
+                            "name": "Shake 4",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [205, 221],
+                            "name": "Shake 3",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [222, 238],
+                            "name": "Shake 2",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [239, 255],
+                            "name": "Shake 1",
+                            "showInMenu": false
+                        }
+                    ]
+                },
+                "Focus": {
+                    "type": "Beam",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "Distance"
+                        }
+                    ]
+                },
+                "Iris": {
+                    "type": "Beam",
+                    "invert": true,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 215],
+                            "name": "Open->Close"
+                        },
+                        {
+                            "range": [216, 255],
+                            "name": "Pulse",
+                            "showInMenu": false
+                        }
+                    ]
+                },
+                "Prism": {
+                    "type": "Prism",
+                    "capabilities": [
+                        {
+                            "range": [0, 19],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [20, 79],
+                            "name": "Rot Left",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [80, 89],
+                            "name": "No Rot"
+                        },
+                        {
+                            "range": [90, 149],
+                            "name": "Rot Right",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [150, 217],
+                            "name": "Close",
+                            "center": true
+                        },
+                        {
+                            "range": [218, 222],
+                            "name": "Macro 1",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [223, 227],
+                            "name": "Macro 2",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [228, 232],
+                            "name": "Macro 3",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [233, 237],
+                            "name": "Macro 4",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [238, 242],
+                            "name": "Macro 5",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [243, 247],
+                            "name": "Macro 6",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [248, 252],
+                            "name": "Macro 7",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [253, 255],
+                            "name": "Macro 8",
+                            "showInMenu": false
+                        }
+                    ]
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 0,
+                    "highlightValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 0,
+                    "highlightValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "14-channel Mode",
+                    "shortName": "14ch",
+                    "channels": [
+                        "Strobe",
+                        "Intensity",
+                        "Colour",
+                        "Colour 2",
+                        "Gobo",
+                        "Gobo Rot",
+                        "Gobo 2",
+                        "Focus",
+                        "Iris",
+                        "Prism",
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Martin",
+            "name": "Mac 550",
+            "shortName": "Mac550",
+            "comment": "basic cd",
+            "physical": {
+                "dimensions": [450, 450, 656]
+            },
+            "availableChannels": {
+                "Strobe": {
+                    "type": "Strobe",
+                    "defaultValue": 20,
+                    "highlightValue": 20,
+                    "capabilities": [
+                        {
+                            "range": [0, 19],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [20, 49],
+                            "name": "open"
+                        },
+                        {
+                            "range": [50, 72],
+                            "name": "strobe"
+                        },
+                        {
+                            "range": [80, 99],
+                            "name": "pulse opening"
+                        },
+                        {
+                            "range": [100, 119],
+                            "name": "pulse closing"
+                        },
+                        {
+                            "range": [128, 187],
+                            "name": "random",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [191, 202],
+                            "name": "random pulse",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [208, 217],
+                            "name": "reset",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [228, 247],
+                            "name": "lamp on",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [248, 255],
+                            "name": "lamp off",
+                            "showInMenu": false
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Color1": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 16],
+                            "name": "open"
+                        },
+                        {
+                            "range": [17, 33],
+                            "name": "red 308"
+                        },
+                        {
+                            "range": [34, 50],
+                            "name": "magenta 507"
+                        },
+                        {
+                            "range": [51, 67],
+                            "name": "purple 502"
+                        },
+                        {
+                            "range": [68, 84],
+                            "name": "blue 104"
+                        },
+                        {
+                            "range": [85, 101],
+                            "name": "green 206"
+                        },
+                        {
+                            "range": [102, 118],
+                            "name": "yellow 601"
+                        },
+                        {
+                            "range": [119, 135],
+                            "name": "orange 306M"
+                        },
+                        {
+                            "range": [136, 152],
+                            "name": "purple 509"
+                        },
+                        {
+                            "range": [153, 153],
+                            "name": "open"
+                        },
+                        {
+                            "range": [154, 158],
+                            "name": "purple 509"
+                        },
+                        {
+                            "range": [159, 163],
+                            "name": "orange 306M"
+                        },
+                        {
+                            "range": [164, 168],
+                            "name": "yellow 601"
+                        },
+                        {
+                            "range": [169, 173],
+                            "name": "green 206"
+                        },
+                        {
+                            "range": [174, 178],
+                            "name": "blue 104"
+                        },
+                        {
+                            "range": [179, 183],
+                            "name": "purple 502"
+                        },
+                        {
+                            "range": [184, 188],
+                            "name": "magenta 507"
+                        },
+                        {
+                            "range": [189, 193],
+                            "name": "red 308"
+                        },
+                        {
+                            "range": [194, 198],
+                            "name": "open"
+                        },
+                        {
+                            "range": [199, 219],
+                            "name": ">>"
+                        },
+                        {
+                            "range": [220, 240],
+                            "name": "<<"
+                        },
+                        {
+                            "range": [241, 255],
+                            "name": "random"
+                        }
+                    ]
+                },
+                "Color2": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 16],
+                            "name": "open"
+                        },
+                        {
+                            "range": [17, 33],
+                            "name": "green 208"
+                        },
+                        {
+                            "range": [34, 50],
+                            "name": "blue 102"
+                        },
+                        {
+                            "range": [51, 67],
+                            "name": "pink 312"
+                        },
+                        {
+                            "range": [68, 84],
+                            "name": "red 301"
+                        },
+                        {
+                            "range": [85, 101],
+                            "name": "yellow 603"
+                        },
+                        {
+                            "range": [102, 118],
+                            "name": "half - green"
+                        },
+                        {
+                            "range": [119, 135],
+                            "name": "CTO"
+                        },
+                        {
+                            "range": [136, 152],
+                            "name": "CTB"
+                        },
+                        {
+                            "range": [153, 153],
+                            "name": "open"
+                        },
+                        {
+                            "range": [154, 158],
+                            "name": "CTB"
+                        },
+                        {
+                            "range": [159, 163],
+                            "name": "CTO"
+                        },
+                        {
+                            "range": [164, 168],
+                            "name": "half - green"
+                        },
+                        {
+                            "range": [169, 173],
+                            "name": "yellow 603"
+                        },
+                        {
+                            "range": [174, 178],
+                            "name": "red 301"
+                        },
+                        {
+                            "range": [179, 183],
+                            "name": "pink 312"
+                        },
+                        {
+                            "range": [184, 188],
+                            "name": "blue 102"
+                        },
+                        {
+                            "range": [189, 193],
+                            "name": "green 208"
+                        },
+                        {
+                            "range": [194, 198],
+                            "name": "open"
+                        },
+                        {
+                            "range": [199, 219],
+                            "name": ">>"
+                        },
+                        {
+                            "range": [220, 240],
+                            "name": "<<"
+                        },
+                        {
+                            "range": [241, 255],
+                            "name": "random"
+                        }
+                    ]
+                },
+                "Gobo1": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 11],
+                            "name": "open"
+                        },
+                        {
+                            "range": [12, 15],
+                            "name": "slot1 ind."
+                        },
+                        {
+                            "range": [16, 19],
+                            "name": "slot2 ind."
+                        },
+                        {
+                            "range": [20, 23],
+                            "name": "slot3 ind."
+                        },
+                        {
+                            "range": [24, 27],
+                            "name": "slot4 ind."
+                        },
+                        {
+                            "range": [28, 31],
+                            "name": "slot5 ind."
+                        },
+                        {
+                            "range": [32, 35],
+                            "name": "slot6 ind."
+                        },
+                        {
+                            "range": [36, 39],
+                            "name": "slot1 rot."
+                        },
+                        {
+                            "range": [40, 43],
+                            "name": "slot2 rot."
+                        },
+                        {
+                            "range": [44, 47],
+                            "name": "slot3 rot."
+                        },
+                        {
+                            "range": [48, 51],
+                            "name": "slot4 rot."
+                        },
+                        {
+                            "range": [52, 55],
+                            "name": "slot5 rot."
+                        },
+                        {
+                            "range": [56, 59],
+                            "name": "slot6 rot."
+                        },
+                        {
+                            "range": [60, 71],
+                            "name": "slot1 ind. sh."
+                        },
+                        {
+                            "range": [72, 83],
+                            "name": "slot2 ind. sh."
+                        },
+                        {
+                            "range": [84, 95],
+                            "name": "slot3 ind. sh."
+                        },
+                        {
+                            "range": [96, 107],
+                            "name": "slot4 ind. sh."
+                        },
+                        {
+                            "range": [108, 119],
+                            "name": "slot5 ind. sh."
+                        },
+                        {
+                            "range": [120, 131],
+                            "name": "slot6 ind. sh."
+                        },
+                        {
+                            "range": [132, 143],
+                            "name": "slot6 rot. sh."
+                        },
+                        {
+                            "range": [144, 155],
+                            "name": "slot5 rot. sh."
+                        },
+                        {
+                            "range": [156, 167],
+                            "name": "slot4 rot. sh."
+                        },
+                        {
+                            "range": [168, 179],
+                            "name": "slot3 rot. sh."
+                        },
+                        {
+                            "range": [180, 191],
+                            "name": "slot2 rot. sh."
+                        },
+                        {
+                            "range": [192, 203],
+                            "name": "slot1 rot. sh."
+                        },
+                        {
+                            "range": [204, 229],
+                            "name": ">>"
+                        },
+                        {
+                            "range": [230, 255],
+                            "name": "<<"
+                        }
+                    ]
+                },
+                "Gobo1 rot.": {
+                    "type": "Gobo",
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "Gobo1 rot. fine": {
+                    "type": "Gobo",
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "Gobo2": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 10],
+                            "name": "open"
+                        },
+                        {
+                            "range": [11, 21],
+                            "name": "slot1"
+                        },
+                        {
+                            "range": [22, 32],
+                            "name": "slot2"
+                        },
+                        {
+                            "range": [33, 43],
+                            "name": "slot3"
+                        },
+                        {
+                            "range": [44, 54],
+                            "name": "slot4"
+                        },
+                        {
+                            "range": [55, 65],
+                            "name": "slot5"
+                        },
+                        {
+                            "range": [66, 76],
+                            "name": "slot6"
+                        },
+                        {
+                            "range": [77, 87],
+                            "name": "slot7"
+                        },
+                        {
+                            "range": [88, 98],
+                            "name": "slot8"
+                        },
+                        {
+                            "range": [99, 109],
+                            "name": "slot9"
+                        },
+                        {
+                            "range": [110, 112],
+                            "name": "open"
+                        },
+                        {
+                            "range": [113, 121],
+                            "name": "slot9"
+                        },
+                        {
+                            "range": [122, 130],
+                            "name": "slot8"
+                        },
+                        {
+                            "range": [131, 139],
+                            "name": "slot7"
+                        },
+                        {
+                            "range": [140, 148],
+                            "name": "slot6"
+                        },
+                        {
+                            "range": [149, 157],
+                            "name": "slot5"
+                        },
+                        {
+                            "range": [158, 166],
+                            "name": "slot4"
+                        },
+                        {
+                            "range": [167, 175],
+                            "name": "slot3"
+                        },
+                        {
+                            "range": [176, 184],
+                            "name": "slot2"
+                        },
+                        {
+                            "range": [185, 193],
+                            "name": "slot1"
+                        },
+                        {
+                            "range": [194, 202],
+                            "name": "open"
+                        },
+                        {
+                            "range": [203, 221],
+                            "name": ">>"
+                        },
+                        {
+                            "range": [222, 240],
+                            "name": "<<"
+                        },
+                        {
+                            "range": [241, 255],
+                            "name": "random"
+                        }
+                    ]
+                },
+                "G/C macro": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "open"
+                        },
+                        {
+                            "range": [16, 55],
+                            "name": "gobo2 shake"
+                        },
+                        {
+                            "range": [56, 95],
+                            "name": "color1 shake"
+                        },
+                        {
+                            "range": [96, 135],
+                            "name": "color2 shake"
+                        },
+                        {
+                            "range": [136, 175],
+                            "name": "g2/c1 shake"
+                        },
+                        {
+                            "range": [176, 215],
+                            "name": "g2/c2 shake"
+                        },
+                        {
+                            "range": [216, 255],
+                            "name": "g2/c12 shake"
+                        }
+                    ]
+                },
+                "Animation pos.": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 9],
+                            "name": "open"
+                        },
+                        {
+                            "range": [10, 19],
+                            "name": "hor. ind."
+                        },
+                        {
+                            "range": [20, 29],
+                            "name": "vert. ind."
+                        },
+                        {
+                            "range": [30, 39],
+                            "name": "hor. cont."
+                        },
+                        {
+                            "range": [40, 49],
+                            "name": "vert. cont."
+                        },
+                        {
+                            "range": [50, 139],
+                            "name": "angle ind."
+                        },
+                        {
+                            "range": [140, 229],
+                            "name": "angle cont."
+                        },
+                        {
+                            "range": [230, 235],
+                            "name": "open"
+                        },
+                        {
+                            "range": [236, 239],
+                            "name": "macro1"
+                        },
+                        {
+                            "range": [240, 243],
+                            "name": "macro2"
+                        },
+                        {
+                            "range": [244, 247],
+                            "name": "macro3"
+                        },
+                        {
+                            "range": [248, 251],
+                            "name": "macro4"
+                        },
+                        {
+                            "range": [252, 255],
+                            "name": "macro5"
+                        }
+                    ]
+                },
+                "Animation rot.": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 2],
+                            "name": "no rot."
+                        },
+                        {
+                            "range": [3, 127],
+                            "name": "<<"
+                        },
+                        {
+                            "range": [128, 252],
+                            "name": ">>"
+                        },
+                        {
+                            "range": [253, 255],
+                            "name": "no rot."
+                        }
+                    ]
+                },
+                "Prisma": {
+                    "type": "Prism",
+                    "capabilities": [
+                        {
+                            "range": [0, 19],
+                            "name": "open"
+                        },
+                        {
+                            "range": [20, 79],
+                            "name": "<<"
+                        },
+                        {
+                            "range": [80, 89],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [90, 149],
+                            "name": ">>"
+                        },
+                        {
+                            "range": [150, 215],
+                            "name": "open"
+                        },
+                        {
+                            "range": [216, 220],
+                            "name": "marco1"
+                        },
+                        {
+                            "range": [221, 225],
+                            "name": "marco2"
+                        },
+                        {
+                            "range": [226, 230],
+                            "name": "macro3"
+                        },
+                        {
+                            "range": [231, 235],
+                            "name": "marco4"
+                        },
+                        {
+                            "range": [236, 240],
+                            "name": "marco5"
+                        },
+                        {
+                            "range": [241, 245],
+                            "name": "marco6"
+                        },
+                        {
+                            "range": [246, 250],
+                            "name": "marco7"
+                        },
+                        {
+                            "range": [251, 255],
+                            "name": "macro8"
+                        }
+                    ]
+                },
+                "Iris": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "open"
+                        },
+                        {
+                            "range": [1, 199],
+                            "name": "%"
+                        },
+                        {
+                            "range": [200, 215],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [216, 229],
+                            "name": "pulse open"
+                        },
+                        {
+                            "range": [230, 243],
+                            "name": "pulse close"
+                        },
+                        {
+                            "range": [244, 255],
+                            "name": "random"
+                        }
+                    ]
+                },
+                "Focus": {
+                    "type": "Beam",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "Flood-Spot"
+                        }
+                    ]
+                },
+                "Zoom": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "Infinity-near"
+                        }
+                    ]
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "P/T speed": {
+                    "type": "Speed",
+                    "capabilities": [
+                        {
+                            "range": [0, 2],
+                            "name": "track"
+                        },
+                        {
+                            "range": [3, 242],
+                            "name": "speed"
+                        },
+                        {
+                            "range": [243, 251],
+                            "name": "track"
+                        },
+                        {
+                            "range": [252, 255],
+                            "name": "MIB"
+                        }
+                    ]
+                },
+                "FX speed": {
+                    "type": "Speed",
+                    "capabilities": [
+                        {
+                            "range": [0, 2],
+                            "name": "tracking"
+                        },
+                        {
+                            "range": [3, 245],
+                            "name": "speed"
+                        },
+                        {
+                            "range": [252, 255],
+                            "name": "MIB"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Gobo1 rot.",
+                    "Gobo1 rot. fine"
+                ],
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "21-channel Mode",
+                    "shortName": "21ch",
+                    "channels": [
+                        "Strobe",
+                        "Intensity",
+                        "Color1",
+                        "Color2",
+                        "Gobo1",
+                        "Gobo1 rot.",
+                        "Gobo1 rot. fine",
+                        "Gobo2",
+                        "G/C macro",
+                        "Animation pos.",
+                        "Animation rot.",
+                        "Prisma",
+                        "Iris",
+                        "Focus",
+                        "Zoom",
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "P/T speed",
+                        "FX speed"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Martin",
+            "name": "Mac 600 m2",
+            "shortName": "Mac600",
+            "physical": {
+                "dimensions": [450, 450, 656]
+            },
+            "availableChannels": {
+                "Strobe": {
+                    "type": "Strobe",
+                    "defaultValue": 20,
+                    "highlightValue": 20,
+                    "capabilities": [
+                        {
+                            "range": [0, 19],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [20, 49],
+                            "name": "open"
+                        },
+                        {
+                            "range": [50, 112],
+                            "name": "strobe"
+                        },
+                        {
+                            "range": [128, 187],
+                            "name": "random",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [212, 231],
+                            "name": "reset",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [232, 254],
+                            "name": "lamp on",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "lamp off",
+                            "showInMenu": false
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Cyan": {
+                    "type": "SingleColor",
+                    "color": "Cyan",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Magenta": {
+                    "type": "SingleColor",
+                    "color": "Magenta",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Yellow": {
+                    "type": "SingleColor",
+                    "color": "Yellow",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Colour": {
+                    "type": "MultiColor",
+                    "defaultValue": 183,
+                    "highlightValue": 183,
+                    "capabilities": [
+                        {
+                            "range": [0, 20],
+                            "name": "white",
+                            "color": "#ffffff",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [21, 60],
+                            "name": "cto",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [61, 100],
+                            "name": "red",
+                            "color": "#ff0000",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [101, 140],
+                            "name": "green",
+                            "color": "#00ff00",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [141, 160],
+                            "name": "blue",
+                            "color": "#0000ff",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [163, 167],
+                            "name": "blue",
+                            "color": "#0000ff"
+                        },
+                        {
+                            "range": [168, 172],
+                            "name": "green",
+                            "color": "#00ff00"
+                        },
+                        {
+                            "range": [173, 177],
+                            "name": "red",
+                            "color": "#ff0000"
+                        },
+                        {
+                            "range": [178, 182],
+                            "name": "cto"
+                        },
+                        {
+                            "range": [183, 185],
+                            "name": "white",
+                            "color": "#ffffff"
+                        },
+                        {
+                            "range": [186, 243],
+                            "name": ">>"
+                        },
+                        {
+                            "range": [244, 255],
+                            "name": "random",
+                            "showInMenu": false
+                        }
+                    ]
+                },
+                "Shape 1a": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Shape 1b": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 170],
+                            "name": "%"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "frost",
+                            "color": "#edf5dd"
+                        }
+                    ]
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "12-channel Mode",
+                    "shortName": "12ch",
+                    "channels": [
+                        "Strobe",
+                        "Intensity",
+                        "Cyan",
+                        "Magenta",
+                        "Yellow",
+                        "Colour",
+                        "Shape 1a",
+                        "Shape 1b",
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Martin",
+            "name": "Mac 600 m4",
+            "shortName": "Mac600M4",
+            "physical": {
+                "dimensions": [450, 450, 656]
+            },
+            "availableChannels": {
+                "Strobe": {
+                    "type": "Strobe",
+                    "defaultValue": 20,
+                    "highlightValue": 20,
+                    "capabilities": [
+                        {
+                            "range": [0, 19],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [20, 49],
+                            "name": "open"
+                        },
+                        {
+                            "range": [50, 112],
+                            "name": "strobe"
+                        },
+                        {
+                            "range": [128, 187],
+                            "name": "random",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [212, 231],
+                            "name": "reset",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [232, 254],
+                            "name": "lamp on",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "lamp off",
+                            "showInMenu": false
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Cyan": {
+                    "type": "SingleColor",
+                    "color": "Cyan",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Magenta": {
+                    "type": "SingleColor",
+                    "color": "Magenta",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Yellow": {
+                    "type": "SingleColor",
+                    "color": "Yellow",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Colour": {
+                    "type": "MultiColor",
+                    "defaultValue": 183,
+                    "highlightValue": 183,
+                    "capabilities": [
+                        {
+                            "range": [0, 20],
+                            "name": "white",
+                            "color": "#ffffff",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [21, 60],
+                            "name": "cto",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [61, 100],
+                            "name": "red",
+                            "color": "#ff0000",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [101, 140],
+                            "name": "green",
+                            "color": "#00ff00",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [141, 160],
+                            "name": "blue",
+                            "color": "#0000ff",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [163, 167],
+                            "name": "blue",
+                            "color": "#0000ff"
+                        },
+                        {
+                            "range": [168, 172],
+                            "name": "green",
+                            "color": "#00ff00"
+                        },
+                        {
+                            "range": [173, 177],
+                            "name": "red",
+                            "color": "#ff0000"
+                        },
+                        {
+                            "range": [178, 182],
+                            "name": "cto"
+                        },
+                        {
+                            "range": [183, 185],
+                            "name": "white",
+                            "color": "#ffffff"
+                        },
+                        {
+                            "range": [186, 243],
+                            "name": ">>"
+                        },
+                        {
+                            "range": [244, 255],
+                            "name": "random",
+                            "showInMenu": false
+                        }
+                    ]
+                },
+                "Shape 1a": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Shape 1b": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 170],
+                            "name": "%"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "frost",
+                            "color": "#edf5dd"
+                        }
+                    ]
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Speed": {
+                    "type": "Speed",
+                    "capabilities": [
+                        {
+                            "range": [0, 2],
+                            "name": "track",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [3, 245],
+                            "name": "speed",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [247, 249],
+                            "name": "ptspnorm",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [250, 254],
+                            "name": "ptspfast",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "blackout",
+                            "showInMenu": false
+                        }
+                    ]
+                },
+                "Control": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 2],
+                            "name": "track",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [3, 245],
+                            "name": "speed",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [247, 249],
+                            "name": "scut off",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [250, 254],
+                            "name": "scut on",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "blackout",
+                            "showInMenu": false
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "14-channel Mode",
+                    "shortName": "14ch",
+                    "channels": [
+                        "Strobe",
+                        "Intensity",
+                        "Cyan",
+                        "Magenta",
+                        "Yellow",
+                        "Colour",
+                        "Shape 1a",
+                        "Shape 1b",
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "Speed",
+                        "Control"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Martin",
+            "name": "Mac 700 Profil",
+            "shortName": "MAC700 pro",
+            "comment": "basic cd",
+            "physical": {
+                "dimensions": [450, 450, 656]
+            },
+            "availableChannels": {
+                "Shutter": {
+                    "type": "Shutter",
+                    "highlightValue": 30,
+                    "capabilities": [
+                        {
+                            "range": [0, 19],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [20, 49],
+                            "name": "open"
+                        },
+                        {
+                            "range": [50, 72],
+                            "name": "strobe"
+                        },
+                        {
+                            "range": [73, 79],
+                            "name": "open"
+                        },
+                        {
+                            "range": [80, 99],
+                            "name": "pulse opening"
+                        },
+                        {
+                            "range": [100, 119],
+                            "name": "pulse closing"
+                        },
+                        {
+                            "range": [120, 127],
+                            "name": "open"
+                        },
+                        {
+                            "range": [128, 187],
+                            "name": "random strobe"
+                        },
+                        {
+                            "range": [188, 190],
+                            "name": "open"
+                        },
+                        {
+                            "range": [191, 202],
+                            "name": "random pulse"
+                        },
+                        {
+                            "range": [203, 207],
+                            "name": "open"
+                        },
+                        {
+                            "range": [208, 217],
+                            "name": "reset"
+                        },
+                        {
+                            "range": [218, 227],
+                            "name": "open"
+                        },
+                        {
+                            "range": [228, 237],
+                            "name": "lamp on"
+                        },
+                        {
+                            "range": [238, 242],
+                            "name": "400W"
+                        },
+                        {
+                            "range": [243, 248],
+                            "name": "700W"
+                        },
+                        {
+                            "range": [248, 255],
+                            "name": "lamp off"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Cyan": {
+                    "type": "SingleColor",
+                    "color": "Cyan",
+                    "crossfade": true
+                },
+                "Magenta": {
+                    "type": "SingleColor",
+                    "color": "Magenta",
+                    "crossfade": true
+                },
+                "Yellow": {
+                    "type": "SingleColor",
+                    "color": "Yellow",
+                    "crossfade": true
+                },
+                "Color": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 16],
+                            "name": "open"
+                        },
+                        {
+                            "range": [17, 33],
+                            "name": "slot1"
+                        },
+                        {
+                            "range": [34, 50],
+                            "name": "slot2"
+                        },
+                        {
+                            "range": [51, 67],
+                            "name": "slot3"
+                        },
+                        {
+                            "range": [68, 84],
+                            "name": "slot4"
+                        },
+                        {
+                            "range": [85, 101],
+                            "name": "slot5"
+                        },
+                        {
+                            "range": [102, 118],
+                            "name": "slot6"
+                        },
+                        {
+                            "range": [119, 135],
+                            "name": "slot7"
+                        },
+                        {
+                            "range": [136, 152],
+                            "name": "slot8"
+                        },
+                        {
+                            "range": [153, 153],
+                            "name": "open"
+                        },
+                        {
+                            "range": [154, 158],
+                            "name": "slot8"
+                        },
+                        {
+                            "range": [159, 163],
+                            "name": "slot7"
+                        },
+                        {
+                            "range": [164, 168],
+                            "name": "slot6"
+                        },
+                        {
+                            "range": [169, 173],
+                            "name": "slot5"
+                        },
+                        {
+                            "range": [174, 178],
+                            "name": "slot4"
+                        },
+                        {
+                            "range": [179, 183],
+                            "name": "slot3"
+                        },
+                        {
+                            "range": [184, 188],
+                            "name": "slot2"
+                        },
+                        {
+                            "range": [189, 193],
+                            "name": "slot1"
+                        },
+                        {
+                            "range": [194, 198],
+                            "name": "open"
+                        },
+                        {
+                            "range": [199, 219],
+                            "name": ">>"
+                        },
+                        {
+                            "range": [220, 240],
+                            "name": "<<"
+                        },
+                        {
+                            "range": [241, 255],
+                            "name": "random"
+                        }
+                    ]
+                },
+                "Gobo1": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 11],
+                            "name": "open"
+                        },
+                        {
+                            "range": [12, 15],
+                            "name": "slot1 ind."
+                        },
+                        {
+                            "range": [16, 19],
+                            "name": "slot2 ind."
+                        },
+                        {
+                            "range": [20, 23],
+                            "name": "slot3 ind."
+                        },
+                        {
+                            "range": [24, 27],
+                            "name": "slot4 ind."
+                        },
+                        {
+                            "range": [28, 31],
+                            "name": "slot5 ind."
+                        },
+                        {
+                            "range": [32, 35],
+                            "name": "slot6 ind."
+                        },
+                        {
+                            "range": [36, 39],
+                            "name": "slot1 rot."
+                        },
+                        {
+                            "range": [40, 43],
+                            "name": "slot2 rot."
+                        },
+                        {
+                            "range": [44, 47],
+                            "name": "slot3 rot."
+                        },
+                        {
+                            "range": [48, 51],
+                            "name": "slot4 rot."
+                        },
+                        {
+                            "range": [52, 55],
+                            "name": "slot5 rot."
+                        },
+                        {
+                            "range": [56, 59],
+                            "name": "slot6 rot."
+                        },
+                        {
+                            "range": [60, 71],
+                            "name": "slot1 ind. sh."
+                        },
+                        {
+                            "range": [72, 83],
+                            "name": "slot2 ind. sh."
+                        },
+                        {
+                            "range": [84, 95],
+                            "name": "slot3 ind. sh."
+                        },
+                        {
+                            "range": [96, 107],
+                            "name": "slot4 ind. sh."
+                        },
+                        {
+                            "range": [108, 119],
+                            "name": "slot5 ind. sh."
+                        },
+                        {
+                            "range": [120, 131],
+                            "name": "slot6 ind. sh."
+                        },
+                        {
+                            "range": [132, 143],
+                            "name": "slot1 rot. sh."
+                        },
+                        {
+                            "range": [144, 155],
+                            "name": "slot2 rot. sh."
+                        },
+                        {
+                            "range": [156, 167],
+                            "name": "slot3 rot. sh."
+                        },
+                        {
+                            "range": [168, 179],
+                            "name": "slot4 rot. sh."
+                        },
+                        {
+                            "range": [180, 191],
+                            "name": "slot5 rot. sh."
+                        },
+                        {
+                            "range": [192, 203],
+                            "name": "slot6 rot. sh."
+                        },
+                        {
+                            "range": [204, 229],
+                            "name": ">>"
+                        },
+                        {
+                            "range": [230, 255],
+                            "name": "<<"
+                        }
+                    ]
+                },
+                "Gobo1 rot.": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 512],
+                            "name": "stop",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [768, 32512],
+                            "name": ">>",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [32768, 64512],
+                            "name": "<<",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [64768, 65280],
+                            "name": "stop",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "Gobo1 rot. fine": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 512],
+                            "name": "stop",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [768, 32512],
+                            "name": ">>",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [32768, 64512],
+                            "name": "<<",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [64768, 65280],
+                            "name": "stop",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "Gobo2": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 10],
+                            "name": "open"
+                        },
+                        {
+                            "range": [11, 21],
+                            "name": "slot1"
+                        },
+                        {
+                            "range": [22, 32],
+                            "name": "slot2"
+                        },
+                        {
+                            "range": [33, 43],
+                            "name": "slot3"
+                        },
+                        {
+                            "range": [44, 54],
+                            "name": "slot4"
+                        },
+                        {
+                            "range": [55, 65],
+                            "name": "slot5"
+                        },
+                        {
+                            "range": [66, 76],
+                            "name": "slot6"
+                        },
+                        {
+                            "range": [77, 87],
+                            "name": "slot7"
+                        },
+                        {
+                            "range": [88, 98],
+                            "name": "slot8"
+                        },
+                        {
+                            "range": [99, 109],
+                            "name": "slot9"
+                        },
+                        {
+                            "range": [110, 112],
+                            "name": "open"
+                        },
+                        {
+                            "range": [113, 121],
+                            "name": "slot9"
+                        },
+                        {
+                            "range": [122, 130],
+                            "name": "slot8"
+                        },
+                        {
+                            "range": [131, 139],
+                            "name": "slot7"
+                        },
+                        {
+                            "range": [140, 148],
+                            "name": "slot6"
+                        },
+                        {
+                            "range": [149, 157],
+                            "name": "slot5"
+                        },
+                        {
+                            "range": [158, 166],
+                            "name": "slot4"
+                        },
+                        {
+                            "range": [167, 175],
+                            "name": "slot3"
+                        },
+                        {
+                            "range": [176, 184],
+                            "name": "slot2"
+                        },
+                        {
+                            "range": [185, 193],
+                            "name": "slot1"
+                        },
+                        {
+                            "range": [194, 202],
+                            "name": "open"
+                        },
+                        {
+                            "range": [203, 221],
+                            "name": ">>"
+                        },
+                        {
+                            "range": [222, 240],
+                            "name": "<<"
+                        },
+                        {
+                            "range": [241, 255],
+                            "name": "random"
+                        }
+                    ]
+                },
+                "G/C macro": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "open"
+                        },
+                        {
+                            "range": [16, 55],
+                            "name": "gobo shake"
+                        },
+                        {
+                            "range": [56, 95],
+                            "name": "color shake"
+                        },
+                        {
+                            "range": [96, 135],
+                            "name": "g/c shake"
+                        },
+                        {
+                            "range": [136, 255],
+                            "name": "random CMY"
+                        }
+                    ]
+                },
+                "Animation pos.": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 9],
+                            "name": "open"
+                        },
+                        {
+                            "range": [10, 19],
+                            "name": "hor. ind."
+                        },
+                        {
+                            "range": [20, 29],
+                            "name": "vert. ind."
+                        },
+                        {
+                            "range": [30, 39],
+                            "name": "hor. cont."
+                        },
+                        {
+                            "range": [40, 49],
+                            "name": "vert. cont."
+                        },
+                        {
+                            "range": [50, 139],
+                            "name": "angle ind."
+                        },
+                        {
+                            "range": [140, 229],
+                            "name": "angle cont."
+                        },
+                        {
+                            "range": [230, 255],
+                            "name": "open"
+                        }
+                    ]
+                },
+                "Animation rot.": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 2],
+                            "name": "no rot."
+                        },
+                        {
+                            "range": [3, 127],
+                            "name": "<<"
+                        },
+                        {
+                            "range": [128, 252],
+                            "name": ">>"
+                        },
+                        {
+                            "range": [253, 255],
+                            "name": "no rot."
+                        }
+                    ]
+                },
+                "Prisma": {
+                    "type": "Prism",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 19],
+                            "name": "open"
+                        },
+                        {
+                            "range": [20, 79],
+                            "name": "<<"
+                        },
+                        {
+                            "range": [80, 89],
+                            "name": "no rot."
+                        },
+                        {
+                            "range": [90, 149],
+                            "name": ">>"
+                        },
+                        {
+                            "range": [150, 255],
+                            "name": "open"
+                        }
+                    ]
+                },
+                "Iris": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "open"
+                        },
+                        {
+                            "range": [1, 199],
+                            "name": "%"
+                        },
+                        {
+                            "range": [200, 215],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [216, 229],
+                            "name": "pulse open"
+                        },
+                        {
+                            "range": [230, 243],
+                            "name": "pulse close"
+                        },
+                        {
+                            "range": [244, 255],
+                            "name": "random"
+                        }
+                    ]
+                },
+                "Focus": {
+                    "type": "Beam",
+                    "highlightValue": 128,
+                    "crossfade": true
+                },
+                "Zoom": {
+                    "type": "Beam",
+                    "highlightValue": 128,
+                    "crossfade": true
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "P/T speed": {
+                    "type": "Speed",
+                    "capabilities": [
+                        {
+                            "range": [0, 2],
+                            "name": "track"
+                        },
+                        {
+                            "range": [3, 242],
+                            "name": "speed"
+                        },
+                        {
+                            "range": [243, 251],
+                            "name": "track"
+                        },
+                        {
+                            "range": [252, 255],
+                            "name": "MIB"
+                        }
+                    ]
+                },
+                "FX speed": {
+                    "type": "Speed",
+                    "capabilities": [
+                        {
+                            "range": [0, 2],
+                            "name": "tracking"
+                        },
+                        {
+                            "range": [3, 245],
+                            "name": "speed"
+                        },
+                        {
+                            "range": [252, 255],
+                            "name": "MIB"
+                        },
+                        {
+                            "range": [246, 251],
+                            "name": "tracking"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Gobo1 rot.",
+                    "Gobo1 rot. fine"
+                ],
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "23-channel Mode",
+                    "shortName": "23ch",
+                    "channels": [
+                        "Shutter",
+                        "Intensity",
+                        "Cyan",
+                        "Magenta",
+                        "Yellow",
+                        "Color",
+                        "Gobo1",
+                        "Gobo1 rot.",
+                        "Gobo1 rot. fine",
+                        "Gobo2",
+                        "G/C macro",
+                        "Animation pos.",
+                        "Animation rot.",
+                        "Prisma",
+                        "Iris",
+                        "Focus",
+                        "Zoom",
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "P/T speed",
+                        "FX speed"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Martin",
+            "name": "MAC 700 Wash",
+            "shortName": "MAC700w",
+            "comment": "basic cd",
+            "physical": {
+                "dimensions": [450, 450, 656]
+            },
+            "availableChannels": {
+                "Shutter": {
+                    "type": "Shutter",
+                    "highlightValue": 30,
+                    "capabilities": [
+                        {
+                            "range": [0, 19],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [20, 49],
+                            "name": "open"
+                        },
+                        {
+                            "range": [50, 72],
+                            "name": "strobe"
+                        },
+                        {
+                            "range": [73, 79],
+                            "name": "open"
+                        },
+                        {
+                            "range": [80, 99],
+                            "name": "pulse opening"
+                        },
+                        {
+                            "range": [100, 119],
+                            "name": "pulse closing"
+                        },
+                        {
+                            "range": [120, 127],
+                            "name": "open"
+                        },
+                        {
+                            "range": [128, 187],
+                            "name": "random strobe"
+                        },
+                        {
+                            "range": [188, 190],
+                            "name": "open"
+                        },
+                        {
+                            "range": [191, 202],
+                            "name": "random pulse"
+                        },
+                        {
+                            "range": [203, 207],
+                            "name": "open"
+                        },
+                        {
+                            "range": [208, 217],
+                            "name": "reset"
+                        },
+                        {
+                            "range": [218, 227],
+                            "name": "open"
+                        },
+                        {
+                            "range": [228, 237],
+                            "name": "lamp on"
+                        },
+                        {
+                            "range": [238, 242],
+                            "name": "400W"
+                        },
+                        {
+                            "range": [243, 248],
+                            "name": "700W"
+                        },
+                        {
+                            "range": [248, 255],
+                            "name": "lamp off"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Cyan": {
+                    "type": "SingleColor",
+                    "color": "Cyan",
+                    "crossfade": true
+                },
+                "Magenta": {
+                    "type": "SingleColor",
+                    "color": "Magenta",
+                    "crossfade": true
+                },
+                "Yellow": {
+                    "type": "SingleColor",
+                    "color": "Yellow",
+                    "crossfade": true
+                },
+                "CTO": {
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "crossfade": true
+                },
+                "Color": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 16],
+                            "name": "open"
+                        },
+                        {
+                            "range": [17, 33],
+                            "name": "slot1"
+                        },
+                        {
+                            "range": [34, 50],
+                            "name": "slot2"
+                        },
+                        {
+                            "range": [51, 67],
+                            "name": "slot3"
+                        },
+                        {
+                            "range": [68, 84],
+                            "name": "slot4"
+                        },
+                        {
+                            "range": [85, 101],
+                            "name": "slot5"
+                        },
+                        {
+                            "range": [102, 118],
+                            "name": "slot6"
+                        },
+                        {
+                            "range": [119, 135],
+                            "name": "slot7"
+                        },
+                        {
+                            "range": [136, 152],
+                            "name": "slot8"
+                        },
+                        {
+                            "range": [153, 153],
+                            "name": "open"
+                        },
+                        {
+                            "range": [154, 158],
+                            "name": "slot8"
+                        },
+                        {
+                            "range": [159, 163],
+                            "name": "slot7"
+                        },
+                        {
+                            "range": [164, 168],
+                            "name": "slot6"
+                        },
+                        {
+                            "range": [169, 173],
+                            "name": "slot5"
+                        },
+                        {
+                            "range": [174, 178],
+                            "name": "slot4"
+                        },
+                        {
+                            "range": [179, 183],
+                            "name": "slot3"
+                        },
+                        {
+                            "range": [184, 188],
+                            "name": "slot2"
+                        },
+                        {
+                            "range": [189, 193],
+                            "name": "slot1"
+                        },
+                        {
+                            "range": [194, 198],
+                            "name": "open"
+                        },
+                        {
+                            "range": [199, 219],
+                            "name": ">>"
+                        },
+                        {
+                            "range": [220, 240],
+                            "name": "<<"
+                        },
+                        {
+                            "range": [241, 255],
+                            "name": "random"
+                        }
+                    ]
+                },
+                "Beam shaper": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "B/C macro": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "open"
+                        },
+                        {
+                            "range": [16, 55],
+                            "name": "color shake"
+                        },
+                        {
+                            "range": [56, 95],
+                            "name": "beam rot."
+                        },
+                        {
+                            "range": [96, 135],
+                            "name": "b/c shake"
+                        },
+                        {
+                            "range": [136, 255],
+                            "name": "random CMY"
+                        }
+                    ]
+                },
+                "Zoom": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "P/T speed": {
+                    "type": "Speed",
+                    "capabilities": [
+                        {
+                            "range": [0, 2],
+                            "name": "track"
+                        },
+                        {
+                            "range": [3, 242],
+                            "name": "speed"
+                        },
+                        {
+                            "range": [243, 251],
+                            "name": "track"
+                        },
+                        {
+                            "range": [252, 255],
+                            "name": "MIB"
+                        }
+                    ]
+                },
+                "FX speed": {
+                    "type": "Speed",
+                    "capabilities": [
+                        {
+                            "range": [0, 2],
+                            "name": "tracking"
+                        },
+                        {
+                            "range": [3, 245],
+                            "name": "speed"
+                        },
+                        {
+                            "range": [252, 255],
+                            "name": "MIB"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "16-channel Mode",
+                    "shortName": "16ch",
+                    "channels": [
+                        "Shutter",
+                        "Intensity",
+                        "Cyan",
+                        "Magenta",
+                        "Yellow",
+                        "CTO",
+                        "Color",
+                        "Beam shaper",
+                        "B/C macro",
+                        "Zoom",
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "P/T speed",
+                        "FX speed"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Martin",
+            "name": "Mania SCX 600",
+            "shortName": "SCX600",
+            "physical": {
+                "dimensions": [500, 230, 400]
+            },
+            "availableChannels": {
+                "Shutter": {
+                    "type": "Shutter",
+                    "highlightValue": 10,
+                    "capabilities": [
+                        {
+                            "range": [0, 7],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [8, 15],
+                            "name": "open"
+                        },
+                        {
+                            "range": [16, 95],
+                            "name": "strobe"
+                        },
+                        {
+                            "range": [96, 103],
+                            "name": "open"
+                        },
+                        {
+                            "range": [104, 151],
+                            "name": "random strobe"
+                        },
+                        {
+                            "range": [152, 159],
+                            "name": "open"
+                        },
+                        {
+                            "range": [160, 199],
+                            "name": "audio strobe"
+                        },
+                        {
+                            "range": [200, 207],
+                            "name": "open"
+                        },
+                        {
+                            "range": [208, 247],
+                            "name": "music dim"
+                        },
+                        {
+                            "range": [248, 251],
+                            "name": "open"
+                        },
+                        {
+                            "range": [252, 255],
+                            "name": "reset"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Color": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 11],
+                            "name": "open"
+                        },
+                        {
+                            "range": [12, 23],
+                            "name": "blue",
+                            "color": "#0000ff"
+                        },
+                        {
+                            "range": [24, 35],
+                            "name": "red",
+                            "color": "#ff0000"
+                        },
+                        {
+                            "range": [36, 47],
+                            "name": "yellow",
+                            "color": "#ffff00"
+                        },
+                        {
+                            "range": [48, 59],
+                            "name": "magenta",
+                            "color": "#ca1f7b"
+                        },
+                        {
+                            "range": [60, 71],
+                            "name": "cyan",
+                            "color": "#00ffff"
+                        },
+                        {
+                            "range": [72, 83],
+                            "name": "green",
+                            "color": "#00ff00"
+                        },
+                        {
+                            "range": [84, 95],
+                            "name": "orange",
+                            "color": "#ff7f00"
+                        },
+                        {
+                            "range": [96, 107],
+                            "name": "congo"
+                        },
+                        {
+                            "range": [108, 119],
+                            "name": "pink",
+                            "color": "#ffc0cb"
+                        },
+                        {
+                            "range": [120, 128],
+                            "name": "open"
+                        },
+                        {
+                            "range": [129, 135],
+                            "name": "blue",
+                            "color": "#0000ff"
+                        },
+                        {
+                            "range": [136, 142],
+                            "name": "red",
+                            "color": "#ff0000"
+                        },
+                        {
+                            "range": [143, 149],
+                            "name": "yellow",
+                            "color": "#ffff00"
+                        },
+                        {
+                            "range": [150, 156],
+                            "name": "magenta",
+                            "color": "#ca1f7b"
+                        },
+                        {
+                            "range": [157, 163],
+                            "name": "cyan",
+                            "color": "#00ffff"
+                        },
+                        {
+                            "range": [164, 170],
+                            "name": "green",
+                            "color": "#00ff00"
+                        },
+                        {
+                            "range": [171, 177],
+                            "name": "orange",
+                            "color": "#ff7f00"
+                        },
+                        {
+                            "range": [178, 184],
+                            "name": "congo"
+                        },
+                        {
+                            "range": [185, 191],
+                            "name": "pink",
+                            "color": "#ffc0cb"
+                        },
+                        {
+                            "range": [192, 215],
+                            "name": ">>"
+                        },
+                        {
+                            "range": [216, 239],
+                            "name": "<<"
+                        },
+                        {
+                            "range": [240, 255],
+                            "name": "audio random"
+                        }
+                    ]
+                },
+                "Gobo": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "open"
+                        },
+                        {
+                            "range": [16, 31],
+                            "name": "slot1"
+                        },
+                        {
+                            "range": [32, 47],
+                            "name": "slot2"
+                        },
+                        {
+                            "range": [48, 63],
+                            "name": "slot3"
+                        },
+                        {
+                            "range": [64, 79],
+                            "name": "slot4"
+                        },
+                        {
+                            "range": [80, 95],
+                            "name": "slot5"
+                        },
+                        {
+                            "range": [96, 111],
+                            "name": "slot6"
+                        },
+                        {
+                            "range": [112, 127],
+                            "name": "slot7"
+                        },
+                        {
+                            "range": [128, 143],
+                            "name": "slot1 sh."
+                        },
+                        {
+                            "range": [144, 159],
+                            "name": "slot2 sh."
+                        },
+                        {
+                            "range": [160, 175],
+                            "name": "slot3 sh."
+                        },
+                        {
+                            "range": [176, 191],
+                            "name": "slot4 sh."
+                        },
+                        {
+                            "range": [192, 207],
+                            "name": "slot5 sh."
+                        },
+                        {
+                            "range": [208, 223],
+                            "name": "slot6 sh."
+                        },
+                        {
+                            "range": [224, 239],
+                            "name": "slot7 sh."
+                        },
+                        {
+                            "range": [240, 255],
+                            "name": "audio random"
+                        }
+                    ]
+                },
+                "Gobo rot.": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 7],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [8, 77],
+                            "name": ">>"
+                        },
+                        {
+                            "range": [78, 147],
+                            "name": "<<"
+                        },
+                        {
+                            "range": [148, 153],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [154, 223],
+                            "name": ">>"
+                        },
+                        {
+                            "range": [224, 239],
+                            "name": ">sh.<"
+                        },
+                        {
+                            "range": [240, 255],
+                            "name": "audio random"
+                        }
+                    ]
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "7-channel Mode",
+                    "shortName": "7ch",
+                    "channels": [
+                        "Shutter",
+                        "Intensity",
+                        "Color",
+                        "Gobo",
+                        "Gobo rot.",
+                        "Pan",
+                        "Tilt"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Martin",
+            "name": "Mini Mac Maestro m2",
+            "shortName": "MiniMacMa2",
+            "comment": "Mode 2",
+            "physical": {
+                "dimensions": [375, 375, 550]
+            },
+            "availableChannels": {
+                "Shutter": {
+                    "type": "Shutter",
+                    "capabilities": [
+                        {
+                            "range": [0, 19],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [20, 49],
+                            "name": "open"
+                        },
+                        {
+                            "range": [50, 112],
+                            "name": "strobe"
+                        },
+                        {
+                            "range": [113, 127],
+                            "name": "open"
+                        },
+                        {
+                            "range": [128, 157],
+                            "name": "random"
+                        },
+                        {
+                            "range": [158, 207],
+                            "name": "open"
+                        },
+                        {
+                            "range": [208, 217],
+                            "name": "reset"
+                        },
+                        {
+                            "range": [218, 227],
+                            "name": "open"
+                        },
+                        {
+                            "range": [228, 237],
+                            "name": "lamp on"
+                        },
+                        {
+                            "range": [238, 247],
+                            "name": "open"
+                        },
+                        {
+                            "range": [248, 255],
+                            "name": "lamp off"
+                        }
+                    ]
+                },
+                "Picture": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 19],
+                            "name": "theme 1"
+                        },
+                        {
+                            "range": [20, 39],
+                            "name": "theme 2"
+                        },
+                        {
+                            "range": [40, 59],
+                            "name": "theme 3"
+                        },
+                        {
+                            "range": [60, 79],
+                            "name": "theme 4"
+                        },
+                        {
+                            "range": [80, 99],
+                            "name": "theme 1 cont"
+                        },
+                        {
+                            "range": [100, 119],
+                            "name": "theme 2 cont"
+                        },
+                        {
+                            "range": [120, 139],
+                            "name": "theme 3 cont"
+                        },
+                        {
+                            "range": [140, 159],
+                            "name": "theme 4 cont"
+                        },
+                        {
+                            "range": [160, 198],
+                            "name": "turn cw"
+                        },
+                        {
+                            "range": [199, 237],
+                            "name": "turn ccw"
+                        },
+                        {
+                            "range": [238, 246],
+                            "name": "random"
+                        },
+                        {
+                            "range": [247, 255],
+                            "name": "random cont"
+                        }
+                    ]
+                },
+                "Rotation": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "index",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "Rotation fine": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "index",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "Focus": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Rotation",
+                    "Rotation fine"
+                ],
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "9-channel Mode",
+                    "shortName": "9ch",
+                    "channels": [
+                        "Shutter",
+                        "Picture",
+                        "Rotation",
+                        "Rotation fine",
+                        "Focus",
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Martin",
+            "name": "Mini Mac Maestro m4",
+            "shortName": "MiniMacMa4",
+            "comment": "Mode 4",
+            "physical": {
+                "dimensions": [375, 375, 550]
+            },
+            "availableChannels": {
+                "Shutter": {
+                    "type": "Shutter",
+                    "capabilities": [
+                        {
+                            "range": [0, 19],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [20, 49],
+                            "name": "open"
+                        },
+                        {
+                            "range": [50, 112],
+                            "name": "strobe"
+                        },
+                        {
+                            "range": [113, 127],
+                            "name": "open"
+                        },
+                        {
+                            "range": [128, 157],
+                            "name": "random"
+                        },
+                        {
+                            "range": [158, 207],
+                            "name": "open"
+                        },
+                        {
+                            "range": [208, 217],
+                            "name": "reset"
+                        },
+                        {
+                            "range": [218, 227],
+                            "name": "open"
+                        },
+                        {
+                            "range": [228, 237],
+                            "name": "lamp on"
+                        },
+                        {
+                            "range": [238, 247],
+                            "name": "open"
+                        },
+                        {
+                            "range": [248, 255],
+                            "name": "lamp off"
+                        }
+                    ]
+                },
+                "Picture": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 19],
+                            "name": "theme 1"
+                        },
+                        {
+                            "range": [20, 39],
+                            "name": "theme 2"
+                        },
+                        {
+                            "range": [40, 59],
+                            "name": "theme 3"
+                        },
+                        {
+                            "range": [60, 79],
+                            "name": "theme 4"
+                        },
+                        {
+                            "range": [80, 99],
+                            "name": "theme 1 cont"
+                        },
+                        {
+                            "range": [100, 119],
+                            "name": "theme 2 cont"
+                        },
+                        {
+                            "range": [120, 139],
+                            "name": "theme 3 cont"
+                        },
+                        {
+                            "range": [140, 159],
+                            "name": "theme 4 cont"
+                        },
+                        {
+                            "range": [160, 198],
+                            "name": "turn cw"
+                        },
+                        {
+                            "range": [199, 237],
+                            "name": "turn ccw"
+                        },
+                        {
+                            "range": [238, 246],
+                            "name": "random"
+                        },
+                        {
+                            "range": [247, 255],
+                            "name": "random cont"
+                        }
+                    ]
+                },
+                "Rotation": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "index",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "Rotation fine": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "index",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "Focus": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Speed Move": {
+                    "type": "Speed",
+                    "capabilities": [
+                        {
+                            "range": [0, 2],
+                            "name": "Tracking"
+                        },
+                        {
+                            "range": [3, 245],
+                            "name": "speed"
+                        },
+                        {
+                            "range": [246, 248],
+                            "name": "SLO"
+                        },
+                        {
+                            "range": [249, 251],
+                            "name": "FSt"
+                        },
+                        {
+                            "range": [252, 255],
+                            "name": "DBO Move"
+                        }
+                    ]
+                },
+                "Speed Theme": {
+                    "type": "Speed",
+                    "capabilities": [
+                        {
+                            "range": [0, 2],
+                            "name": "Tracking"
+                        },
+                        {
+                            "range": [3, 251],
+                            "name": "speed"
+                        },
+                        {
+                            "range": [252, 255],
+                            "name": "DBO Move"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Rotation",
+                    "Rotation fine"
+                ],
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "11-channel Mode",
+                    "shortName": "11ch",
+                    "channels": [
+                        "Shutter",
+                        "Picture",
+                        "Rotation",
+                        "Rotation fine",
+                        "Focus",
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "Speed Move",
+                        "Speed Theme"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Martin",
+            "name": "Mini Mac Wash m2",
+            "shortName": "MiniMacWa2",
+            "comment": "Mode 2",
+            "physical": {
+                "dimensions": [375, 375, 550]
+            },
+            "availableChannels": {
+                "Shutter": {
+                    "type": "Shutter",
+                    "defaultValue": 14,
+                    "capabilities": [
+                        {
+                            "range": [0, 19],
+                            "name": "Closed"
+                        },
+                        {
+                            "range": [20, 38],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [39, 49],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [50, 112],
+                            "name": "Strobe"
+                        },
+                        {
+                            "range": [113, 127],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [128, 137],
+                            "name": "RND Fast"
+                        },
+                        {
+                            "range": [138, 147],
+                            "name": "RND Med"
+                        },
+                        {
+                            "range": [148, 157],
+                            "name": "RND"
+                        },
+                        {
+                            "range": [158, 167],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [168, 177],
+                            "name": "Snd2Light"
+                        },
+                        {
+                            "range": [178, 187],
+                            "name": "Auto"
+                        },
+                        {
+                            "range": [188, 207],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [208, 217],
+                            "name": "*Reset"
+                        },
+                        {
+                            "range": [218, 227],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [228, 237],
+                            "name": "Lamp On"
+                        },
+                        {
+                            "range": [238, 247],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [248, 255],
+                            "name": "OFF(5sec)"
+                        }
+                    ]
+                },
+                "Color": {
+                    "type": "MultiColor",
+                    "capabilities": [
+                        {
+                            "range": [0, 11],
+                            "name": "White",
+                            "color": "#ffffff",
+                            "center": true
+                        },
+                        {
+                            "range": [12, 23],
+                            "name": "CTC5500",
+                            "center": true
+                        },
+                        {
+                            "range": [24, 35],
+                            "name": "Pink312",
+                            "center": true
+                        },
+                        {
+                            "range": [36, 47],
+                            "name": "Red 301",
+                            "center": true
+                        },
+                        {
+                            "range": [48, 59],
+                            "name": "Green 206",
+                            "center": true
+                        },
+                        {
+                            "range": [60, 71],
+                            "name": "Cyan",
+                            "color": "#00ffff",
+                            "center": true
+                        },
+                        {
+                            "range": [72, 83],
+                            "name": "Yellow",
+                            "color": "#ffff00",
+                            "center": true
+                        },
+                        {
+                            "range": [84, 95],
+                            "name": "Magenta",
+                            "color": "#ca1f7b",
+                            "center": true
+                        },
+                        {
+                            "range": [96, 107],
+                            "name": "Blue",
+                            "color": "#0000ff",
+                            "center": true
+                        },
+                        {
+                            "range": [108, 119],
+                            "name": "Green",
+                            "color": "#00ff00",
+                            "center": true
+                        },
+                        {
+                            "range": [120, 131],
+                            "name": "Purple",
+                            "color": "#800080",
+                            "center": true
+                        },
+                        {
+                            "range": [132, 143],
+                            "name": "Orange",
+                            "color": "#ff7f00",
+                            "center": true
+                        },
+                        {
+                            "range": [144, 150],
+                            "name": "Blue",
+                            "color": "#0000ff",
+                            "center": true
+                        },
+                        {
+                            "range": [151, 159],
+                            "name": "Blue",
+                            "color": "#0000ff",
+                            "center": true
+                        },
+                        {
+                            "range": [160, 163],
+                            "name": "Orange",
+                            "color": "#ff7f00",
+                            "center": true
+                        },
+                        {
+                            "range": [164, 167],
+                            "name": "Purple",
+                            "color": "#800080",
+                            "center": true
+                        },
+                        {
+                            "range": [168, 171],
+                            "name": "Green",
+                            "color": "#00ff00",
+                            "center": true
+                        },
+                        {
+                            "range": [172, 175],
+                            "name": "Blue",
+                            "color": "#0000ff",
+                            "center": true
+                        },
+                        {
+                            "range": [176, 179],
+                            "name": "Magenta",
+                            "color": "#ca1f7b",
+                            "center": true
+                        },
+                        {
+                            "range": [180, 183],
+                            "name": "Yellow",
+                            "color": "#ffff00",
+                            "center": true
+                        },
+                        {
+                            "range": [184, 187],
+                            "name": "Cyan",
+                            "color": "#00ffff",
+                            "center": true
+                        },
+                        {
+                            "range": [188, 191],
+                            "name": "Green",
+                            "color": "#00ff00",
+                            "center": true
+                        },
+                        {
+                            "range": [192, 195],
+                            "name": "Red",
+                            "color": "#ff0000",
+                            "center": true
+                        },
+                        {
+                            "range": [196, 199],
+                            "name": "Pink",
+                            "color": "#ffc0cb",
+                            "center": true
+                        },
+                        {
+                            "range": [200, 203],
+                            "name": "CTC5500",
+                            "center": true
+                        },
+                        {
+                            "range": [204, 207],
+                            "name": "White",
+                            "color": "#ffffff",
+                            "center": true
+                        },
+                        {
+                            "range": [208, 245],
+                            "name": "cont_rot"
+                        },
+                        {
+                            "range": [246, 248],
+                            "name": "random_ff",
+                            "center": true
+                        },
+                        {
+                            "range": [249, 251],
+                            "name": "random_m",
+                            "center": true
+                        },
+                        {
+                            "range": [252, 255],
+                            "name": "random_sl",
+                            "center": true
+                        }
+                    ]
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "6-channel Mode",
+                    "shortName": "6ch",
+                    "channels": [
+                        "Shutter",
+                        "Color",
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Martin",
+            "name": "Mini Mac Wash m4",
+            "shortName": "MiniMacWa4",
+            "comment": "Mode 4",
+            "physical": {
+                "dimensions": [375, 375, 550]
+            },
+            "availableChannels": {
+                "Shutter": {
+                    "type": "Shutter",
+                    "defaultValue": 14,
+                    "capabilities": [
+                        {
+                            "range": [0, 19],
+                            "name": "Closed"
+                        },
+                        {
+                            "range": [20, 38],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [39, 49],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [50, 112],
+                            "name": "Strobe"
+                        },
+                        {
+                            "range": [113, 127],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [128, 137],
+                            "name": "RND Fast"
+                        },
+                        {
+                            "range": [138, 147],
+                            "name": "RND Med"
+                        },
+                        {
+                            "range": [148, 157],
+                            "name": "RND"
+                        },
+                        {
+                            "range": [158, 167],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [168, 177],
+                            "name": "Snd2Light"
+                        },
+                        {
+                            "range": [178, 187],
+                            "name": "Auto"
+                        },
+                        {
+                            "range": [188, 207],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [208, 217],
+                            "name": "*Reset"
+                        },
+                        {
+                            "range": [218, 227],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [228, 237],
+                            "name": "Lamp On"
+                        },
+                        {
+                            "range": [238, 247],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [248, 255],
+                            "name": "OFF(5sec)"
+                        }
+                    ]
+                },
+                "Color": {
+                    "type": "MultiColor",
+                    "capabilities": [
+                        {
+                            "range": [0, 11],
+                            "name": "White",
+                            "color": "#ffffff",
+                            "center": true
+                        },
+                        {
+                            "range": [12, 23],
+                            "name": "CTC5500",
+                            "center": true
+                        },
+                        {
+                            "range": [24, 35],
+                            "name": "Pink312",
+                            "center": true
+                        },
+                        {
+                            "range": [36, 47],
+                            "name": "Red 301",
+                            "center": true
+                        },
+                        {
+                            "range": [48, 59],
+                            "name": "Green 206",
+                            "center": true
+                        },
+                        {
+                            "range": [60, 71],
+                            "name": "Cyan",
+                            "color": "#00ffff",
+                            "center": true
+                        },
+                        {
+                            "range": [72, 83],
+                            "name": "Yellow",
+                            "color": "#ffff00",
+                            "center": true
+                        },
+                        {
+                            "range": [84, 95],
+                            "name": "Magenta",
+                            "color": "#ca1f7b",
+                            "center": true
+                        },
+                        {
+                            "range": [96, 107],
+                            "name": "Blue",
+                            "color": "#0000ff",
+                            "center": true
+                        },
+                        {
+                            "range": [108, 119],
+                            "name": "Green",
+                            "color": "#00ff00",
+                            "center": true
+                        },
+                        {
+                            "range": [120, 131],
+                            "name": "Purple",
+                            "color": "#800080",
+                            "center": true
+                        },
+                        {
+                            "range": [132, 143],
+                            "name": "Orange",
+                            "color": "#ff7f00",
+                            "center": true
+                        },
+                        {
+                            "range": [144, 150],
+                            "name": "Blue",
+                            "color": "#0000ff",
+                            "center": true
+                        },
+                        {
+                            "range": [151, 159],
+                            "name": "Blue",
+                            "color": "#0000ff",
+                            "center": true
+                        },
+                        {
+                            "range": [160, 163],
+                            "name": "Orange",
+                            "color": "#ff7f00",
+                            "center": true
+                        },
+                        {
+                            "range": [164, 167],
+                            "name": "Purple",
+                            "color": "#800080",
+                            "center": true
+                        },
+                        {
+                            "range": [168, 171],
+                            "name": "Green",
+                            "color": "#00ff00",
+                            "center": true
+                        },
+                        {
+                            "range": [172, 175],
+                            "name": "Blue",
+                            "color": "#0000ff",
+                            "center": true
+                        },
+                        {
+                            "range": [176, 179],
+                            "name": "Magenta",
+                            "color": "#ca1f7b",
+                            "center": true
+                        },
+                        {
+                            "range": [180, 183],
+                            "name": "Yellow",
+                            "color": "#ffff00",
+                            "center": true
+                        },
+                        {
+                            "range": [184, 187],
+                            "name": "Cyan",
+                            "color": "#00ffff",
+                            "center": true
+                        },
+                        {
+                            "range": [188, 191],
+                            "name": "Green",
+                            "color": "#00ff00",
+                            "center": true
+                        },
+                        {
+                            "range": [192, 195],
+                            "name": "Red",
+                            "color": "#ff0000",
+                            "center": true
+                        },
+                        {
+                            "range": [196, 199],
+                            "name": "Pink",
+                            "color": "#ffc0cb",
+                            "center": true
+                        },
+                        {
+                            "range": [200, 203],
+                            "name": "CTC5500",
+                            "center": true
+                        },
+                        {
+                            "range": [204, 207],
+                            "name": "White",
+                            "color": "#ffffff",
+                            "center": true
+                        },
+                        {
+                            "range": [208, 245],
+                            "name": "cont_rot"
+                        },
+                        {
+                            "range": [246, 248],
+                            "name": "random_ff",
+                            "center": true
+                        },
+                        {
+                            "range": [249, 251],
+                            "name": "random_m",
+                            "center": true
+                        },
+                        {
+                            "range": [252, 255],
+                            "name": "random_sl",
+                            "center": true
+                        }
+                    ]
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Speed": {
+                    "type": "Speed",
+                    "capabilities": [
+                        {
+                            "range": [0, 2],
+                            "name": "tracking"
+                        },
+                        {
+                            "range": [3, 245],
+                            "name": "vector"
+                        },
+                        {
+                            "range": [246, 248],
+                            "name": "PtS=SLOW"
+                        },
+                        {
+                            "range": [249, 251],
+                            "name": "PtS=FAST"
+                        },
+                        {
+                            "range": [252, 255],
+                            "name": "DBO_Move"
+                        }
+                    ]
+                },
+                "Effects": {
+                    "type": "Effect",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 2],
+                            "name": "tracking"
+                        },
+                        {
+                            "range": [3, 251],
+                            "name": "vector"
+                        },
+                        {
+                            "range": [252, 255],
+                            "name": "DBO_move"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "8-channel Mode",
+                    "shortName": "8ch",
+                    "channels": [
+                        "Shutter",
+                        "Color",
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "Speed",
+                        "Effects"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Martin",
+            "name": "MiniMAC Profile",
+            "shortName": "MiniMacPro4",
+            "comment": "Mode 4",
+            "physical": {
+                "dimensions": [375, 375, 550],
+                "weight": 10,
+                "power": 200
+            },
+            "availableChannels": {
+                "Shutter": {
+                    "type": "Shutter",
+                    "defaultValue": 14,
+                    "capabilities": [
+                        {
+                            "range": [0, 19],
+                            "name": "Closed"
+                        },
+                        {
+                            "range": [20, 38],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [39, 49],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [50, 112],
+                            "name": "Strobe"
+                        },
+                        {
+                            "range": [113, 127],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [128, 137],
+                            "name": "RND Fast"
+                        },
+                        {
+                            "range": [138, 147],
+                            "name": "RND Med"
+                        },
+                        {
+                            "range": [148, 157],
+                            "name": "RND"
+                        },
+                        {
+                            "range": [158, 167],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [168, 177],
+                            "name": "Snd2Light"
+                        },
+                        {
+                            "range": [178, 187],
+                            "name": "Auto"
+                        },
+                        {
+                            "range": [188, 207],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [208, 217],
+                            "name": "*Reset"
+                        },
+                        {
+                            "range": [218, 227],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [228, 237],
+                            "name": "Lamp On"
+                        },
+                        {
+                            "range": [238, 247],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [248, 255],
+                            "name": "OFF(5sec)"
+                        }
+                    ]
+                },
+                "Color": {
+                    "type": "MultiColor",
+                    "capabilities": [
+                        {
+                            "range": [0, 11],
+                            "name": "White",
+                            "color": "#ffffff",
+                            "center": true
+                        },
+                        {
+                            "range": [12, 23],
+                            "name": "CTC5500",
+                            "center": true
+                        },
+                        {
+                            "range": [24, 35],
+                            "name": "Pink312",
+                            "center": true
+                        },
+                        {
+                            "range": [36, 47],
+                            "name": "Red 301",
+                            "center": true
+                        },
+                        {
+                            "range": [48, 59],
+                            "name": "Green 206",
+                            "center": true
+                        },
+                        {
+                            "range": [60, 71],
+                            "name": "Cyan",
+                            "color": "#00ffff",
+                            "center": true
+                        },
+                        {
+                            "range": [72, 83],
+                            "name": "Yellow",
+                            "color": "#ffff00",
+                            "center": true
+                        },
+                        {
+                            "range": [84, 95],
+                            "name": "Magenta",
+                            "color": "#ca1f7b",
+                            "center": true
+                        },
+                        {
+                            "range": [96, 107],
+                            "name": "Blue",
+                            "color": "#0000ff",
+                            "center": true
+                        },
+                        {
+                            "range": [108, 119],
+                            "name": "Green",
+                            "color": "#00ff00",
+                            "center": true
+                        },
+                        {
+                            "range": [120, 131],
+                            "name": "Purple",
+                            "color": "#800080",
+                            "center": true
+                        },
+                        {
+                            "range": [132, 143],
+                            "name": "Orange",
+                            "color": "#ff7f00",
+                            "center": true
+                        },
+                        {
+                            "range": [144, 150],
+                            "name": "Blue",
+                            "color": "#0000ff",
+                            "center": true
+                        },
+                        {
+                            "range": [151, 159],
+                            "name": "Blue",
+                            "color": "#0000ff",
+                            "center": true
+                        },
+                        {
+                            "range": [160, 163],
+                            "name": "Orange",
+                            "color": "#ff7f00",
+                            "center": true
+                        },
+                        {
+                            "range": [164, 167],
+                            "name": "Purple",
+                            "color": "#800080",
+                            "center": true
+                        },
+                        {
+                            "range": [168, 171],
+                            "name": "Green",
+                            "color": "#00ff00",
+                            "center": true
+                        },
+                        {
+                            "range": [172, 175],
+                            "name": "Blue",
+                            "color": "#0000ff",
+                            "center": true
+                        },
+                        {
+                            "range": [176, 179],
+                            "name": "Magenta",
+                            "color": "#ca1f7b",
+                            "center": true
+                        },
+                        {
+                            "range": [180, 183],
+                            "name": "Yellow",
+                            "color": "#ffff00",
+                            "center": true
+                        },
+                        {
+                            "range": [184, 187],
+                            "name": "Cyan",
+                            "color": "#00ffff",
+                            "center": true
+                        },
+                        {
+                            "range": [188, 191],
+                            "name": "Green",
+                            "color": "#00ff00",
+                            "center": true
+                        },
+                        {
+                            "range": [192, 195],
+                            "name": "Red",
+                            "color": "#ff0000",
+                            "center": true
+                        },
+                        {
+                            "range": [196, 199],
+                            "name": "Pink",
+                            "color": "#ffc0cb",
+                            "center": true
+                        },
+                        {
+                            "range": [200, 203],
+                            "name": "CTC5500",
+                            "center": true
+                        },
+                        {
+                            "range": [204, 207],
+                            "name": "White",
+                            "color": "#ffffff",
+                            "center": true
+                        },
+                        {
+                            "range": [208, 245],
+                            "name": "cont_rot"
+                        },
+                        {
+                            "range": [246, 248],
+                            "name": "random_ff",
+                            "center": true
+                        },
+                        {
+                            "range": [249, 251],
+                            "name": "random_m",
+                            "center": true
+                        },
+                        {
+                            "range": [252, 255],
+                            "name": "random_sl",
+                            "center": true
+                        }
+                    ]
+                },
+                "Gobo": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 20],
+                            "name": "Open",
+                            "center": true
+                        },
+                        {
+                            "range": [21, 35],
+                            "name": "Fibroid",
+                            "center": true
+                        },
+                        {
+                            "range": [36, 50],
+                            "name": "Radial",
+                            "center": true
+                        },
+                        {
+                            "range": [51, 65],
+                            "name": "Stardust",
+                            "color": "#9f9f9c",
+                            "center": true
+                        },
+                        {
+                            "range": [66, 80],
+                            "name": "Atomic",
+                            "center": true
+                        },
+                        {
+                            "range": [81, 95],
+                            "name": "Highway",
+                            "center": true
+                        },
+                        {
+                            "range": [96, 110],
+                            "name": "Decentered",
+                            "center": true
+                        },
+                        {
+                            "range": [111, 125],
+                            "name": "Sunburst",
+                            "center": true
+                        },
+                        {
+                            "range": [126, 145],
+                            "name": "Decentered_sh",
+                            "center": true
+                        },
+                        {
+                            "range": [146, 165],
+                            "name": "Highway_sh",
+                            "center": true
+                        },
+                        {
+                            "range": [166, 185],
+                            "name": "Atomic_sh",
+                            "center": true
+                        },
+                        {
+                            "range": [186, 205],
+                            "name": "Stardust_sh",
+                            "center": true
+                        },
+                        {
+                            "range": [206, 225],
+                            "name": "Radial_sh",
+                            "center": true
+                        },
+                        {
+                            "range": [226, 245],
+                            "name": "Fibroid_sh",
+                            "center": true
+                        },
+                        {
+                            "range": [246, 248],
+                            "name": "random_ff",
+                            "center": true
+                        },
+                        {
+                            "range": [249, 251],
+                            "name": "random_m",
+                            "center": true
+                        },
+                        {
+                            "range": [252, 255],
+                            "name": "random_sl",
+                            "center": true
+                        }
+                    ]
+                },
+                "Goborot": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 2],
+                            "name": "none",
+                            "center": true
+                        },
+                        {
+                            "range": [3, 117],
+                            "name": "cw_sl->ff"
+                        },
+                        {
+                            "range": [118, 232],
+                            "name": "ccw_ff->sl"
+                        },
+                        {
+                            "range": [233, 239],
+                            "name": "none",
+                            "center": true
+                        },
+                        {
+                            "range": [240, 255],
+                            "name": "swing"
+                        }
+                    ]
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "PanTiltSpd": {
+                    "type": "Pan",
+                    "capabilities": [
+                        {
+                            "range": [0, 2],
+                            "name": "Tracking",
+                            "center": true
+                        },
+                        {
+                            "range": [3, 245],
+                            "name": "ff->sl"
+                        },
+                        {
+                            "range": [246, 248],
+                            "name": "Tracking_FTS",
+                            "center": true
+                        },
+                        {
+                            "range": [249, 251],
+                            "name": "Tracking_FTS",
+                            "center": true
+                        },
+                        {
+                            "range": [252, 255],
+                            "name": "Blackout",
+                            "center": true
+                        }
+                    ]
+                },
+                "FX Speed": {
+                    "type": "Speed",
+                    "capabilities": [
+                        {
+                            "range": [0, 2],
+                            "name": "Tracking",
+                            "center": true
+                        },
+                        {
+                            "range": [3, 251],
+                            "name": "ff->sl"
+                        },
+                        {
+                            "range": [252, 255],
+                            "name": "Blackout",
+                            "center": true
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "10-channel Mode",
+                    "shortName": "10ch",
+                    "channels": [
+                        "Shutter",
+                        "Color",
+                        "Gobo",
+                        "Goborot",
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "PanTiltSpd",
+                        "FX Speed"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Martin",
+            "name": "MX1",
+            "shortName": "MX1",
+            "comment": "cd",
+            "physical": {
+                "dimensions": [340, 735, 315]
+            },
+            "availableChannels": {
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 160,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 4],
+                            "name": "close"
+                        },
+                        {
+                            "range": [5, 154],
+                            "name": "dim"
+                        },
+                        {
+                            "range": [155, 169],
+                            "name": "open"
+                        },
+                        {
+                            "range": [170, 229],
+                            "name": "strobe"
+                        },
+                        {
+                            "range": [230, 239],
+                            "name": "music trigger"
+                        },
+                        {
+                            "range": [240, 249],
+                            "name": "auto trigger"
+                        },
+                        {
+                            "range": [250, 255],
+                            "name": "reset"
+                        }
+                    ]
+                },
+                "no Func.": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Color/Gobo": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 11],
+                            "name": "open"
+                        },
+                        {
+                            "range": [12, 23],
+                            "name": "worms"
+                        },
+                        {
+                            "range": [24, 35],
+                            "name": "web"
+                        },
+                        {
+                            "range": [36, 47],
+                            "name": "petals"
+                        },
+                        {
+                            "range": [48, 59],
+                            "name": "spokes"
+                        },
+                        {
+                            "range": [60, 71],
+                            "name": "cone"
+                        },
+                        {
+                            "range": [72, 83],
+                            "name": "maze"
+                        },
+                        {
+                            "range": [84, 95],
+                            "name": "crater"
+                        },
+                        {
+                            "range": [96, 107],
+                            "name": "holes"
+                        },
+                        {
+                            "range": [108, 119],
+                            "name": "cross"
+                        },
+                        {
+                            "range": [120, 131],
+                            "name": "jagged cross"
+                        },
+                        {
+                            "range": [132, 143],
+                            "name": "atomic"
+                        },
+                        {
+                            "range": [144, 155],
+                            "name": "dot circle"
+                        },
+                        {
+                            "range": [156, 167],
+                            "name": "nordic"
+                        },
+                        {
+                            "range": [168, 179],
+                            "name": "aim"
+                        },
+                        {
+                            "range": [180, 191],
+                            "name": "pie"
+                        },
+                        {
+                            "range": [192, 203],
+                            "name": "tie"
+                        },
+                        {
+                            "range": [204, 215],
+                            "name": "nova"
+                        },
+                        {
+                            "range": [216, 227],
+                            "name": "trible beam"
+                        },
+                        {
+                            "range": [228, 239],
+                            "name": "close"
+                        },
+                        {
+                            "range": [240, 255],
+                            "name": "random"
+                        }
+                    ]
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 127,
+                    "crossfade": true
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 127,
+                    "crossfade": true
+                },
+                "P/T speed": {
+                    "type": "Speed",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 2],
+                            "name": "track"
+                        },
+                        {
+                            "range": [3, 255],
+                            "name": "speed"
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "6-channel Mode",
+                    "shortName": "6ch",
+                    "channels": [
+                        "Intensity",
+                        "no Func.",
+                        "Color/Gobo",
+                        "Pan",
+                        "Tilt",
+                        "P/T speed"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Martin",
+            "name": "MX10 Extreme",
+            "shortName": "mx10",
+            "comment": "cd",
+            "physical": {
+                "dimensions": [340, 735, 315],
+                "weight": 22,
+                "power": 350
+            },
+            "availableChannels": {
+                "Shutter": {
+                    "type": "Shutter",
+                    "highlightValue": 25,
+                    "capabilities": [
+                        {
+                            "range": [0, 19],
+                            "name": "closed",
+                            "center": true
+                        },
+                        {
+                            "range": [20, 49],
+                            "name": "open",
+                            "center": true
+                        },
+                        {
+                            "range": [50, 72],
+                            "name": "strobe"
+                        },
+                        {
+                            "range": [80, 99],
+                            "name": "puls open"
+                        },
+                        {
+                            "range": [100, 119],
+                            "name": "puls close"
+                        },
+                        {
+                            "range": [120, 127],
+                            "name": "open",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 187],
+                            "name": "random strobe",
+                            "center": true
+                        },
+                        {
+                            "range": [188, 190],
+                            "name": "open",
+                            "center": true
+                        },
+                        {
+                            "range": [191, 196],
+                            "name": "random  puls op"
+                        },
+                        {
+                            "range": [197, 202],
+                            "name": "Random puls clo"
+                        },
+                        {
+                            "range": [203, 207],
+                            "name": "open",
+                            "center": true
+                        },
+                        {
+                            "range": [208, 217],
+                            "name": "reset",
+                            "center": true
+                        },
+                        {
+                            "range": [218, 227],
+                            "name": "open",
+                            "center": true
+                        },
+                        {
+                            "range": [228, 237],
+                            "name": "lamp on",
+                            "center": true
+                        },
+                        {
+                            "range": [238, 247],
+                            "name": "open",
+                            "center": true
+                        },
+                        {
+                            "range": [248, 255],
+                            "name": "lamp off",
+                            "center": true
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Color": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 11],
+                            "name": "open"
+                        },
+                        {
+                            "range": [12, 23],
+                            "name": "CTO"
+                        },
+                        {
+                            "range": [24, 35],
+                            "name": "yellow 603"
+                        },
+                        {
+                            "range": [36, 47],
+                            "name": "blue 104"
+                        },
+                        {
+                            "range": [48, 59],
+                            "name": "pink 312"
+                        },
+                        {
+                            "range": [60, 71],
+                            "name": "green 206"
+                        },
+                        {
+                            "range": [72, 83],
+                            "name": "blue 108"
+                        },
+                        {
+                            "range": [84, 95],
+                            "name": "red 301"
+                        },
+                        {
+                            "range": [96, 107],
+                            "name": "magenta 507"
+                        },
+                        {
+                            "range": [108, 119],
+                            "name": "blue 101"
+                        },
+                        {
+                            "range": [120, 131],
+                            "name": "orange 306"
+                        },
+                        {
+                            "range": [132, 143],
+                            "name": "dark green",
+                            "color": "#013220"
+                        },
+                        {
+                            "range": [144, 155],
+                            "name": "purble 502"
+                        },
+                        {
+                            "range": [156, 159],
+                            "name": "purble 502"
+                        },
+                        {
+                            "range": [160, 163],
+                            "name": "dark green",
+                            "color": "#013220"
+                        },
+                        {
+                            "range": [164, 167],
+                            "name": "orange 306"
+                        },
+                        {
+                            "range": [168, 171],
+                            "name": "blue 101"
+                        },
+                        {
+                            "range": [172, 175],
+                            "name": "magenta 507"
+                        },
+                        {
+                            "range": [176, 179],
+                            "name": "red 301"
+                        },
+                        {
+                            "range": [180, 183],
+                            "name": "blue 108"
+                        },
+                        {
+                            "range": [184, 187],
+                            "name": "green 206"
+                        },
+                        {
+                            "range": [188, 191],
+                            "name": "pink 312"
+                        },
+                        {
+                            "range": [192, 195],
+                            "name": "blue 104"
+                        },
+                        {
+                            "range": [196, 199],
+                            "name": "yellow 603"
+                        },
+                        {
+                            "range": [200, 203],
+                            "name": "CTO"
+                        },
+                        {
+                            "range": [204, 207],
+                            "name": "open"
+                        },
+                        {
+                            "range": [208, 226],
+                            "name": ">>"
+                        },
+                        {
+                            "range": [227, 245],
+                            "name": "<<"
+                        },
+                        {
+                            "range": [246, 255],
+                            "name": "random"
+                        }
+                    ]
+                },
+                "Gobo": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 4],
+                            "name": "open"
+                        },
+                        {
+                            "range": [5, 9],
+                            "name": "slot1 ind"
+                        },
+                        {
+                            "range": [10, 14],
+                            "name": "slot2 ind"
+                        },
+                        {
+                            "range": [15, 19],
+                            "name": "slot3 ind"
+                        },
+                        {
+                            "range": [20, 24],
+                            "name": "slot4 ind"
+                        },
+                        {
+                            "range": [25, 29],
+                            "name": "slot5 ind"
+                        },
+                        {
+                            "range": [30, 34],
+                            "name": "slot6 ind"
+                        },
+                        {
+                            "range": [35, 39],
+                            "name": "slot7 ind"
+                        },
+                        {
+                            "range": [40, 44],
+                            "name": "slot8 ind"
+                        },
+                        {
+                            "range": [45, 49],
+                            "name": "open"
+                        },
+                        {
+                            "range": [50, 54],
+                            "name": "slot1 rot"
+                        },
+                        {
+                            "range": [55, 59],
+                            "name": "slot2 rot"
+                        },
+                        {
+                            "range": [60, 64],
+                            "name": "slot3 rot"
+                        },
+                        {
+                            "range": [65, 69],
+                            "name": "slot4 rot"
+                        },
+                        {
+                            "range": [70, 74],
+                            "name": "slot5 rot"
+                        },
+                        {
+                            "range": [75, 79],
+                            "name": "slot6 rot"
+                        },
+                        {
+                            "range": [80, 84],
+                            "name": "slot7 rot"
+                        },
+                        {
+                            "range": [85, 89],
+                            "name": "slot8 rot"
+                        },
+                        {
+                            "range": [90, 104],
+                            "name": "slot8 rot sh"
+                        },
+                        {
+                            "range": [105, 119],
+                            "name": "slot7 ind sh"
+                        },
+                        {
+                            "range": [120, 134],
+                            "name": "slot6 ind sh"
+                        },
+                        {
+                            "range": [135, 149],
+                            "name": "slot5 ind sh"
+                        },
+                        {
+                            "range": [150, 164],
+                            "name": "slot4 ind sh"
+                        },
+                        {
+                            "range": [165, 179],
+                            "name": "slot3 ind sh"
+                        },
+                        {
+                            "range": [180, 194],
+                            "name": "slot2 ind sh"
+                        },
+                        {
+                            "range": [195, 209],
+                            "name": "slot1 ind sh"
+                        },
+                        {
+                            "range": [210, 232],
+                            "name": ">>"
+                        },
+                        {
+                            "range": [233, 255],
+                            "name": "<<"
+                        }
+                    ]
+                },
+                "Gobo rot": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Focus": {
+                    "type": "Beam",
+                    "defaultValue": 32512,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Prisma": {
+                    "type": "Prism",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 19],
+                            "name": "open"
+                        },
+                        {
+                            "range": [20, 79],
+                            "name": "<<"
+                        },
+                        {
+                            "range": [80, 89],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [90, 149],
+                            "name": ">>"
+                        },
+                        {
+                            "range": [150, 215],
+                            "name": "open"
+                        },
+                        {
+                            "range": [216, 220],
+                            "name": "macro1"
+                        },
+                        {
+                            "range": [221, 225],
+                            "name": "macro2"
+                        },
+                        {
+                            "range": [226, 230],
+                            "name": "macro3"
+                        },
+                        {
+                            "range": [231, 235],
+                            "name": "macro4"
+                        },
+                        {
+                            "range": [236, 240],
+                            "name": "macro5"
+                        },
+                        {
+                            "range": [241, 245],
+                            "name": "marco6"
+                        },
+                        {
+                            "range": [246, 250],
+                            "name": "macro7"
+                        },
+                        {
+                            "range": [251, 255],
+                            "name": "macro8"
+                        }
+                    ]
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "P/T speed": {
+                    "type": "Speed",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 2],
+                            "name": "tracking"
+                        },
+                        {
+                            "range": [3, 245],
+                            "name": "speed"
+                        },
+                        {
+                            "range": [246, 251],
+                            "name": "tracking"
+                        },
+                        {
+                            "range": [252, 255],
+                            "name": "max speed"
+                        }
+                    ]
+                },
+                "FX speed": {
+                    "type": "Speed",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 2],
+                            "name": "tracking"
+                        },
+                        {
+                            "range": [3, 245],
+                            "name": "speed"
+                        },
+                        {
+                            "range": [252, 255],
+                            "name": "MIB"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "13-channel Mode",
+                    "shortName": "13ch",
+                    "channels": [
+                        "Shutter",
+                        "Intensity",
+                        "Color",
+                        "Gobo",
+                        "Gobo rot",
+                        "Focus",
+                        "Prisma",
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "P/T speed",
+                        "FX speed"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Martin",
+            "name": "Pal 1200 FX",
+            "shortName": "Pal1200FX",
+            "physical": {
+                "dimensions": [500, 500, 500]
+            },
+            "availableChannels": {
+                "Strobe": {
+                    "type": "Strobe",
+                    "capabilities": [
+                        {
+                            "range": [50, 177],
+                            "name": "Strobe"
+                        },
+                        {
+                            "range": [188, 197],
+                            "name": "Fan Low"
+                        },
+                        {
+                            "range": [208, 217],
+                            "name": "Reset",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [228, 237],
+                            "name": "Lamp On",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [248, 255],
+                            "name": "Lamp Off",
+                            "showInMenu": false
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Cyan": {
+                    "type": "SingleColor",
+                    "color": "Cyan",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Magenta": {
+                    "type": "SingleColor",
+                    "color": "Magenta",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Yellow": {
+                    "type": "SingleColor",
+                    "color": "Yellow",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Colour": {
+                    "type": "MultiColor",
+                    "capabilities": [
+                        {
+                            "range": [0, 32],
+                            "name": "White",
+                            "color": "#ffffff"
+                        },
+                        {
+                            "range": [33, 65],
+                            "name": "Colour 1"
+                        },
+                        {
+                            "range": [66, 98],
+                            "name": "Colour 2"
+                        },
+                        {
+                            "range": [99, 131],
+                            "name": "Colour 3"
+                        },
+                        {
+                            "range": [132, 166],
+                            "name": "Colour 4"
+                        },
+                        {
+                            "range": [167, 167],
+                            "name": "Colour 5"
+                        },
+                        {
+                            "range": [168, 181],
+                            "name": "Fixed Colour 5",
+                            "center": true
+                        },
+                        {
+                            "range": [182, 195],
+                            "name": "Fixed Colour 4",
+                            "center": true
+                        },
+                        {
+                            "range": [196, 209],
+                            "name": "Fixed Colour 3",
+                            "center": true
+                        },
+                        {
+                            "range": [210, 223],
+                            "name": "Fixed Colour 2",
+                            "center": true
+                        },
+                        {
+                            "range": [224, 237],
+                            "name": "Fixed Colour 1",
+                            "center": true
+                        },
+                        {
+                            "range": [238, 255],
+                            "name": "Fixed White",
+                            "center": true
+                        }
+                    ]
+                },
+                "Gobo Sel": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 22],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [23, 45],
+                            "name": "Ind Gobo 1",
+                            "center": true
+                        },
+                        {
+                            "range": [46, 68],
+                            "name": "Ind Gobo 2",
+                            "center": true
+                        },
+                        {
+                            "range": [69, 91],
+                            "name": "Fixed Gobo 3",
+                            "center": true
+                        },
+                        {
+                            "range": [92, 114],
+                            "name": "Ind Gobo 4",
+                            "center": true
+                        },
+                        {
+                            "range": [115, 137],
+                            "name": "Ind Gobo 5",
+                            "center": true
+                        },
+                        {
+                            "range": [138, 160],
+                            "name": "Rot Gobo 5",
+                            "center": true
+                        },
+                        {
+                            "range": [161, 183],
+                            "name": "Rot Gobo 4",
+                            "center": true
+                        },
+                        {
+                            "range": [184, 206],
+                            "name": "Fixed Gobo 3",
+                            "center": true
+                        },
+                        {
+                            "range": [207, 229],
+                            "name": "Rot Gobo 2",
+                            "center": true
+                        },
+                        {
+                            "range": [230, 255],
+                            "name": "Rot Gobo 1",
+                            "center": true
+                        }
+                    ]
+                },
+                "Gobo Rot": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 2],
+                            "name": "Static",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [3, 127],
+                            "name": "Rot Left",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [128, 252],
+                            "name": "Rot Right",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [253, 255],
+                            "name": "Static",
+                            "showInMenu": false
+                        }
+                    ]
+                },
+                "FX": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 22],
+                            "name": "Open",
+                            "center": true
+                        },
+                        {
+                            "range": [23, 45],
+                            "name": "Indexed FX 1",
+                            "center": true
+                        },
+                        {
+                            "range": [46, 68],
+                            "name": "Fixed FX 2",
+                            "center": true
+                        },
+                        {
+                            "range": [69, 91],
+                            "name": "Indexed FX 3",
+                            "center": true
+                        },
+                        {
+                            "range": [92, 114],
+                            "name": "Fixed FX 4",
+                            "center": true
+                        },
+                        {
+                            "range": [115, 137],
+                            "name": "Indexed FX 5",
+                            "center": true
+                        },
+                        {
+                            "range": [138, 160],
+                            "name": "Rot FX 5",
+                            "center": true
+                        },
+                        {
+                            "range": [161, 183],
+                            "name": "Fixed FX 4",
+                            "center": true
+                        },
+                        {
+                            "range": [184, 206],
+                            "name": "Rot FX 3",
+                            "center": true
+                        },
+                        {
+                            "range": [207, 229],
+                            "name": "Fixed FX 2",
+                            "center": true
+                        },
+                        {
+                            "range": [230, 255],
+                            "name": "Rot FX 1",
+                            "center": true
+                        }
+                    ]
+                },
+                "FX Rot": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 2],
+                            "name": "Static",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [3, 127],
+                            "name": "Rot Left",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [128, 252],
+                            "name": "Rot Right",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [253, 255],
+                            "name": "Static",
+                            "showInMenu": false
+                        }
+                    ]
+                },
+                "Focus": {
+                    "type": "Beam",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "Distance"
+                        }
+                    ]
+                },
+                "Zoom": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "Beam"
+                        }
+                    ]
+                },
+                "Iris": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "Iris",
+                            "color": "#5a4fcf"
+                        }
+                    ]
+                },
+                "Frost": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "Frost %"
+                        }
+                    ]
+                },
+                "Pan (*)": {
+                    "type": "Pan",
+                    "defaultValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Pan (*) fine": {
+                    "type": "Pan",
+                    "defaultValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Tilt (*)": {
+                    "type": "Tilt",
+                    "defaultValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Tilt (*) fine": {
+                    "type": "Tilt",
+                    "defaultValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "*Pan Speed": {
+                    "type": "Speed",
+                    "capabilities": [
+                        {
+                            "range": [0, 2],
+                            "name": "Tracking",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [3, 251],
+                            "name": "Speed",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [252, 255],
+                            "name": "Blackout",
+                            "showInMenu": false
+                        }
+                    ]
+                },
+                "Control": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 2],
+                            "name": "Tracking",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [3, 251],
+                            "name": "Speed",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [252, 255],
+                            "name": "Blackout",
+                            "showInMenu": false
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan (*)",
+                    "Pan (*) fine"
+                ],
+                [
+                    "Tilt (*)",
+                    "Tilt (*) fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "20-channel Mode",
+                    "shortName": "20ch",
+                    "channels": [
+                        "Strobe",
+                        "Intensity",
+                        "Cyan",
+                        "Magenta",
+                        "Yellow",
+                        "Colour",
+                        "Gobo Sel",
+                        "Gobo Rot",
+                        "FX",
+                        "FX Rot",
+                        "Focus",
+                        "Zoom",
+                        "Iris",
+                        "Frost",
+                        "Pan (*)",
+                        "Pan (*) fine",
+                        "Tilt (*)",
+                        "Tilt (*) fine",
+                        "*Pan Speed",
+                        "Control"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Martin",
+            "name": "Pal 1200E",
+            "shortName": "Pal1200",
+            "physical": {
+                "dimensions": [500, 500, 500]
+            },
+            "availableChannels": {
+                "Strobe": {
+                    "type": "Strobe",
+                    "capabilities": [
+                        {
+                            "range": [50, 177],
+                            "name": "Strobe"
+                        },
+                        {
+                            "range": [188, 197],
+                            "name": "Fan Low"
+                        },
+                        {
+                            "range": [208, 217],
+                            "name": "Reset",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [228, 237],
+                            "name": "Lamp On",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [248, 255],
+                            "name": "Lamp Off",
+                            "showInMenu": false
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Prf Shut 1a": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Prf Shut 1b": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Prf  Shut 2a": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Prf  Shut 2b": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Prf  Shut 3a": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Prf  Shut 3b": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Prf Shut 4a": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Prf Shut 4b": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Profile Ori": {
+                    "type": "Beam",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "Orientation"
+                        }
+                    ]
+                },
+                "Cyan": {
+                    "type": "SingleColor",
+                    "color": "Cyan",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Magenta": {
+                    "type": "SingleColor",
+                    "color": "Magenta",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Yellow": {
+                    "type": "SingleColor",
+                    "color": "Yellow",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Colour": {
+                    "type": "MultiColor",
+                    "capabilities": [
+                        {
+                            "range": [0, 32],
+                            "name": "White",
+                            "color": "#ffffff"
+                        },
+                        {
+                            "range": [33, 65],
+                            "name": "Colour 1"
+                        },
+                        {
+                            "range": [66, 98],
+                            "name": "Colour 2"
+                        },
+                        {
+                            "range": [99, 131],
+                            "name": "Colour 3"
+                        },
+                        {
+                            "range": [132, 166],
+                            "name": "Colour 4"
+                        },
+                        {
+                            "range": [167, 167],
+                            "name": "Colour 5"
+                        },
+                        {
+                            "range": [168, 181],
+                            "name": "Fixed Col 5",
+                            "center": true
+                        },
+                        {
+                            "range": [182, 195],
+                            "name": "Fixed Col 4",
+                            "center": true
+                        },
+                        {
+                            "range": [196, 209],
+                            "name": "Fixed Col 3",
+                            "center": true
+                        },
+                        {
+                            "range": [210, 223],
+                            "name": "Fixed Col 2",
+                            "center": true
+                        },
+                        {
+                            "range": [224, 237],
+                            "name": "Fixed Col 1",
+                            "center": true
+                        },
+                        {
+                            "range": [238, 255],
+                            "name": "Fixed White",
+                            "center": true
+                        }
+                    ]
+                },
+                "Gobo Sel": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 22],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [23, 45],
+                            "name": "Ind Gobo 1",
+                            "center": true
+                        },
+                        {
+                            "range": [46, 68],
+                            "name": "Ind Gobo 2",
+                            "center": true
+                        },
+                        {
+                            "range": [69, 91],
+                            "name": "Fixed Gobo 3",
+                            "center": true
+                        },
+                        {
+                            "range": [92, 114],
+                            "name": "Ind Gobo 4",
+                            "center": true
+                        },
+                        {
+                            "range": [115, 137],
+                            "name": "Ind Gobo 5",
+                            "center": true
+                        },
+                        {
+                            "range": [138, 160],
+                            "name": "Rot Gobo 5",
+                            "center": true
+                        },
+                        {
+                            "range": [161, 183],
+                            "name": "Rot Gobo 4",
+                            "center": true
+                        },
+                        {
+                            "range": [184, 206],
+                            "name": "Fixed Gobo 3",
+                            "center": true
+                        },
+                        {
+                            "range": [207, 229],
+                            "name": "Rot Gobo 2",
+                            "center": true
+                        },
+                        {
+                            "range": [230, 255],
+                            "name": "Rot Gobo 1",
+                            "center": true
+                        }
+                    ]
+                },
+                "Gobo Rot": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 2],
+                            "name": "Static",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [3, 127],
+                            "name": "Rot Left",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [128, 252],
+                            "name": "Rot Right",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [253, 255],
+                            "name": "Static",
+                            "showInMenu": false
+                        }
+                    ]
+                },
+                "Focus": {
+                    "type": "Beam",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "Distance"
+                        }
+                    ]
+                },
+                "Zoom": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "Beam"
+                        }
+                    ]
+                },
+                "Frost": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "Frost %"
+                        }
+                    ]
+                },
+                "Pan (*)": {
+                    "type": "Pan",
+                    "defaultValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Pan (*) fine": {
+                    "type": "Pan",
+                    "defaultValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Tilt (*)": {
+                    "type": "Tilt",
+                    "defaultValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Tilt (*) fine": {
+                    "type": "Tilt",
+                    "defaultValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "*Pan Speed": {
+                    "type": "Speed",
+                    "capabilities": [
+                        {
+                            "range": [0, 2],
+                            "name": "Tracking",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [3, 251],
+                            "name": "Speed",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [252, 255],
+                            "name": "Blackout",
+                            "showInMenu": false
+                        }
+                    ]
+                },
+                "Control": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 2],
+                            "name": "Tracking",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [3, 251],
+                            "name": "Speed",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [252, 255],
+                            "name": "Blackout",
+                            "showInMenu": false
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan (*)",
+                    "Pan (*) fine"
+                ],
+                [
+                    "Tilt (*)",
+                    "Tilt (*) fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "26-channel Mode",
+                    "shortName": "26ch",
+                    "channels": [
+                        "Strobe",
+                        "Intensity",
+                        "Prf Shut 1a",
+                        "Prf Shut 1b",
+                        "Prf  Shut 2a",
+                        "Prf  Shut 2b",
+                        "Prf  Shut 3a",
+                        "Prf  Shut 3b",
+                        "Prf Shut 4a",
+                        "Prf Shut 4b",
+                        "Profile Ori",
+                        "Cyan",
+                        "Magenta",
+                        "Yellow",
+                        "Colour",
+                        "Gobo Sel",
+                        "Gobo Rot",
+                        "Focus",
+                        "Zoom",
+                        "Frost",
+                        "Pan (*)",
+                        "Pan (*) fine",
+                        "Tilt (*)",
+                        "Tilt (*) fine",
+                        "*Pan Speed",
+                        "Control"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Martin",
+            "name": "QFX 150",
+            "shortName": "QFX 150",
+            "physical": {
+                "dimensions": [500, 500, 500]
+            },
+            "availableChannels": {
+                "Lamp": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 89],
+                            "name": "Idle"
+                        },
+                        {
+                            "range": [90, 119],
+                            "name": "Reset"
+                        },
+                        {
+                            "range": [120, 149],
+                            "name": "Idle"
+                        },
+                        {
+                            "range": [150, 199],
+                            "name": "Lamp On"
+                        },
+                        {
+                            "range": [200, 249],
+                            "name": "Idle"
+                        },
+                        {
+                            "range": [250, 255],
+                            "name": "Lamp Off"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Color": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [16, 16],
+                            "name": "Blue 108"
+                        },
+                        {
+                            "range": [32, 32],
+                            "name": "Green 206"
+                        },
+                        {
+                            "range": [48, 48],
+                            "name": "Yellow 203"
+                        },
+                        {
+                            "range": [64, 64],
+                            "name": "Red 308"
+                        },
+                        {
+                            "range": [80, 80],
+                            "name": "Color 5"
+                        },
+                        {
+                            "range": [96, 96],
+                            "name": "Color 6"
+                        },
+                        {
+                            "range": [112, 112],
+                            "name": "Color 7"
+                        },
+                        {
+                            "range": [128, 128],
+                            "name": "Color 8"
+                        },
+                        {
+                            "range": [144, 144],
+                            "name": "Color 9"
+                        },
+                        {
+                            "range": [145, 148],
+                            "name": "Fixed C.9"
+                        },
+                        {
+                            "range": [149, 152],
+                            "name": "Fixed C8"
+                        },
+                        {
+                            "range": [153, 156],
+                            "name": "Fixed C7"
+                        },
+                        {
+                            "range": [157, 160],
+                            "name": "Fixed C6"
+                        },
+                        {
+                            "range": [161, 164],
+                            "name": "Fixed C5"
+                        },
+                        {
+                            "range": [165, 168],
+                            "name": "Fixed Red"
+                        },
+                        {
+                            "range": [169, 172],
+                            "name": "Fixed Yellow"
+                        },
+                        {
+                            "range": [173, 176],
+                            "name": "Fixed Green"
+                        },
+                        {
+                            "range": [177, 180],
+                            "name": "Fixed Blue"
+                        },
+                        {
+                            "range": [181, 185],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [186, 220],
+                            "name": "Cont. Rot."
+                        },
+                        {
+                            "range": [221, 255],
+                            "name": "CCW"
+                        }
+                    ]
+                },
+                "Twinkle": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 1],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [2, 125],
+                            "name": "Slow-Fast"
+                        },
+                        {
+                            "range": [126, 131],
+                            "name": "Stop"
+                        },
+                        {
+                            "range": [132, 255],
+                            "name": "CCW Fast-Slow"
+                        }
+                    ]
+                },
+                "CSpeed": {
+                    "type": "Speed",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 2],
+                            "name": "Tracking"
+                        },
+                        {
+                            "range": [3, 5],
+                            "name": "Fast-Slow"
+                        },
+                        {
+                            "range": [6, 255],
+                            "name": "Slow-Fast"
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "5-channel Mode",
+                    "shortName": "5ch",
+                    "channels": [
+                        "Lamp",
+                        "Intensity",
+                        "Color",
+                        "Twinkle",
+                        "CSpeed"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Martin",
+            "name": "RoboColor Pro 400",
+            "shortName": "Pro",
+            "physical": {
+                "dimensions": [500, 500, 500],
+                "weight": 12,
+                "power": 270
+            },
+            "availableChannels": {
+                "Strobe": {
+                    "type": "Strobe",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 7],
+                            "name": "Strobe Off"
+                        },
+                        {
+                            "range": [8, 199],
+                            "name": "fast -> slow"
+                        },
+                        {
+                            "range": [200, 219],
+                            "name": "Music Trigger"
+                        },
+                        {
+                            "range": [220, 239],
+                            "name": "Auto Trigger"
+                        },
+                        {
+                            "range": [240, 249],
+                            "name": "Reset Fixture"
+                        },
+                        {
+                            "range": [250, 255],
+                            "name": "Open"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 10],
+                            "name": "OFF"
+                        },
+                        {
+                            "range": [11, 237],
+                            "name": "Intensity"
+                        },
+                        {
+                            "range": [238, 255],
+                            "name": "ON"
+                        }
+                    ]
+                },
+                "Color 1": {
+                    "type": "MultiColor",
+                    "capabilities": [
+                        {
+                            "range": [0, 1],
+                            "name": "White",
+                            "color": "#ffffff"
+                        },
+                        {
+                            "range": [25, 27],
+                            "name": "Yellow",
+                            "color": "#ffff00",
+                            "center": true
+                        },
+                        {
+                            "range": [51, 53],
+                            "name": "Fern Green",
+                            "color": "#4f7942",
+                            "center": true
+                        },
+                        {
+                            "range": [77, 79],
+                            "name": "Flame Red",
+                            "center": true
+                        },
+                        {
+                            "range": [103, 105],
+                            "name": "Cyan Blue",
+                            "center": true
+                        },
+                        {
+                            "range": [129, 131],
+                            "name": "Turquoise",
+                            "color": "#40e0d0",
+                            "center": true
+                        },
+                        {
+                            "range": [155, 157],
+                            "name": "Purple",
+                            "color": "#800080",
+                            "center": true
+                        },
+                        {
+                            "range": [157, 171],
+                            "name": "Purple",
+                            "color": "#800080",
+                            "center": true
+                        },
+                        {
+                            "range": [172, 185],
+                            "name": "Turquoise",
+                            "color": "#40e0d0"
+                        },
+                        {
+                            "range": [186, 199],
+                            "name": "Cyan Blue"
+                        },
+                        {
+                            "range": [200, 214],
+                            "name": "Flame Red"
+                        },
+                        {
+                            "range": [215, 227],
+                            "name": "Fern Green",
+                            "color": "#4f7942"
+                        },
+                        {
+                            "range": [242, 255],
+                            "name": "White",
+                            "color": "#ffffff"
+                        },
+                        {
+                            "range": [228, 241],
+                            "name": "Yellow",
+                            "color": "#ffff00"
+                        }
+                    ]
+                },
+                "Color 2": {
+                    "type": "MultiColor",
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "White",
+                            "color": "#ffffff",
+                            "center": true
+                        },
+                        {
+                            "range": [25, 27],
+                            "name": "Pink",
+                            "color": "#ffc0cb",
+                            "center": true
+                        },
+                        {
+                            "range": [51, 53],
+                            "name": "Light Green",
+                            "color": "#90ee90",
+                            "center": true
+                        },
+                        {
+                            "range": [77, 79],
+                            "name": "Magenta",
+                            "color": "#ca1f7b",
+                            "center": true
+                        },
+                        {
+                            "range": [103, 105],
+                            "name": "Dark Lavender",
+                            "color": "#734f96",
+                            "center": true
+                        },
+                        {
+                            "range": [129, 131],
+                            "name": "CC 5500-3400",
+                            "center": true
+                        },
+                        {
+                            "range": [155, 156],
+                            "name": "CC 3500-5600",
+                            "center": true
+                        },
+                        {
+                            "range": [157, 171],
+                            "name": "CC 3500-5600"
+                        },
+                        {
+                            "range": [172, 185],
+                            "name": "CC 5500-3400"
+                        },
+                        {
+                            "range": [186, 199],
+                            "name": "Violett"
+                        },
+                        {
+                            "range": [200, 214],
+                            "name": "Magenta",
+                            "color": "#ca1f7b"
+                        },
+                        {
+                            "range": [215, 227],
+                            "name": "Light Green",
+                            "color": "#90ee90"
+                        },
+                        {
+                            "range": [228, 241],
+                            "name": "Pink",
+                            "color": "#ffc0cb"
+                        },
+                        {
+                            "range": [242, 255],
+                            "name": "White",
+                            "color": "#ffffff"
+                        }
+                    ]
+                },
+                "Beam": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 50],
+                            "name": "Wash"
+                        },
+                        {
+                            "range": [51, 101],
+                            "name": "Wide beam"
+                        },
+                        {
+                            "range": [102, 152],
+                            "name": "Medium beam"
+                        },
+                        {
+                            "range": [153, 203],
+                            "name": "Narrow beam"
+                        },
+                        {
+                            "range": [204, 255],
+                            "name": "Black Out"
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "5-channel Mode",
+                    "shortName": "5ch",
+                    "channels": [
+                        "Strobe",
+                        "Intensity",
+                        "Color 1",
+                        "Color 2",
+                        "Beam"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Martin",
+            "name": "Roboscan 1220 CMYR",
+            "shortName": "1220CMYR",
+            "comment": "cd",
+            "physical": {
+                "dimensions": [500, 500, 500]
+            },
+            "availableChannels": {
+                "Strobe": {
+                    "type": "Strobe",
+                    "capabilities": [
+                        {
+                            "range": [0, 49],
+                            "name": "idle"
+                        },
+                        {
+                            "range": [50, 177],
+                            "name": "strobe"
+                        },
+                        {
+                            "range": [178, 199],
+                            "name": "idle"
+                        },
+                        {
+                            "range": [200, 243],
+                            "name": "fan low"
+                        },
+                        {
+                            "range": [244, 247],
+                            "name": "lamp off"
+                        },
+                        {
+                            "range": [248, 251],
+                            "name": "reset"
+                        },
+                        {
+                            "range": [252, 255],
+                            "name": "lamp on"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Color1": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 9],
+                            "name": "open"
+                        },
+                        {
+                            "range": [10, 19],
+                            "name": "amber",
+                            "color": "#ffbf00"
+                        },
+                        {
+                            "range": [20, 29],
+                            "name": "fern green",
+                            "color": "#4f7942"
+                        },
+                        {
+                            "range": [30, 39],
+                            "name": "light blue",
+                            "color": "#add8e6"
+                        },
+                        {
+                            "range": [40, 49],
+                            "name": "flame red"
+                        },
+                        {
+                            "range": [50, 59],
+                            "name": "primary green"
+                        },
+                        {
+                            "range": [60, 69],
+                            "name": "blue",
+                            "color": "#0000ff"
+                        },
+                        {
+                            "range": [70, 79],
+                            "name": "orange",
+                            "color": "#ff7f00"
+                        },
+                        {
+                            "range": [80, 89],
+                            "name": "turquoise",
+                            "color": "#40e0d0"
+                        },
+                        {
+                            "range": [90, 97],
+                            "name": "purple",
+                            "color": "#800080"
+                        },
+                        {
+                            "range": [98, 105],
+                            "name": "turquoise",
+                            "color": "#40e0d0"
+                        },
+                        {
+                            "range": [106, 113],
+                            "name": "orange",
+                            "color": "#ff7f00"
+                        },
+                        {
+                            "range": [114, 121],
+                            "name": "blue",
+                            "color": "#0000ff"
+                        },
+                        {
+                            "range": [122, 129],
+                            "name": "primary green"
+                        },
+                        {
+                            "range": [130, 137],
+                            "name": "flame red"
+                        },
+                        {
+                            "range": [138, 145],
+                            "name": "light blue",
+                            "color": "#add8e6"
+                        },
+                        {
+                            "range": [146, 153],
+                            "name": "fern green",
+                            "color": "#4f7942"
+                        },
+                        {
+                            "range": [154, 161],
+                            "name": "amber",
+                            "color": "#ffbf00"
+                        },
+                        {
+                            "range": [162, 208],
+                            "name": ">>"
+                        },
+                        {
+                            "range": [209, 255],
+                            "name": "<<"
+                        }
+                    ]
+                },
+                "Color2": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 9],
+                            "name": "open"
+                        },
+                        {
+                            "range": [10, 19],
+                            "name": "CTO"
+                        },
+                        {
+                            "range": [20, 29],
+                            "name": "CTB"
+                        },
+                        {
+                            "range": [30, 39],
+                            "name": "dark orange",
+                            "color": "#ff8c00"
+                        },
+                        {
+                            "range": [40, 49],
+                            "name": "primary red"
+                        },
+                        {
+                            "range": [50, 59],
+                            "name": "UV"
+                        },
+                        {
+                            "range": [60, 69],
+                            "name": "dark blue",
+                            "color": "#00008b"
+                        },
+                        {
+                            "range": [70, 79],
+                            "name": "dark lavender",
+                            "color": "#734f96"
+                        },
+                        {
+                            "range": [80, 89],
+                            "name": "pink",
+                            "color": "#ffc0cb"
+                        },
+                        {
+                            "range": [90, 97],
+                            "name": "light green",
+                            "color": "#90ee90"
+                        },
+                        {
+                            "range": [98, 105],
+                            "name": "pink",
+                            "color": "#ffc0cb"
+                        },
+                        {
+                            "range": [106, 113],
+                            "name": "dark lavender",
+                            "color": "#734f96"
+                        },
+                        {
+                            "range": [114, 121],
+                            "name": "dark blue",
+                            "color": "#00008b"
+                        },
+                        {
+                            "range": [122, 129],
+                            "name": "UV"
+                        },
+                        {
+                            "range": [130, 137],
+                            "name": "primary red"
+                        },
+                        {
+                            "range": [138, 145],
+                            "name": "dark orange",
+                            "color": "#ff8c00"
+                        },
+                        {
+                            "range": [146, 153],
+                            "name": "CTB"
+                        },
+                        {
+                            "range": [154, 161],
+                            "name": "CTO"
+                        },
+                        {
+                            "range": [162, 208],
+                            "name": ">>"
+                        },
+                        {
+                            "range": [209, 255],
+                            "name": "<<"
+                        }
+                    ]
+                },
+                "Cyan": {
+                    "type": "SingleColor",
+                    "color": "Cyan",
+                    "crossfade": true
+                },
+                "Magenta": {
+                    "type": "SingleColor",
+                    "color": "Magenta",
+                    "crossfade": true
+                },
+                "Yellow": {
+                    "type": "SingleColor",
+                    "color": "Yellow",
+                    "crossfade": true
+                },
+                "Gobo1": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 19],
+                            "name": "open"
+                        },
+                        {
+                            "range": [20, 39],
+                            "name": "slot1"
+                        },
+                        {
+                            "range": [40, 59],
+                            "name": "slot2"
+                        },
+                        {
+                            "range": [60, 79],
+                            "name": "slot3"
+                        },
+                        {
+                            "range": [80, 99],
+                            "name": "slot4"
+                        },
+                        {
+                            "range": [100, 119],
+                            "name": "slot5"
+                        },
+                        {
+                            "range": [120, 139],
+                            "name": "slot6"
+                        },
+                        {
+                            "range": [140, 159],
+                            "name": "slot7"
+                        },
+                        {
+                            "range": [160, 179],
+                            "name": "slot8"
+                        },
+                        {
+                            "range": [180, 188],
+                            "name": "slot9"
+                        },
+                        {
+                            "range": [189, 196],
+                            "name": "slot8"
+                        },
+                        {
+                            "range": [197, 204],
+                            "name": "slot7"
+                        },
+                        {
+                            "range": [205, 212],
+                            "name": "slot6"
+                        },
+                        {
+                            "range": [213, 220],
+                            "name": "slot5"
+                        },
+                        {
+                            "range": [221, 228],
+                            "name": "slot4"
+                        },
+                        {
+                            "range": [229, 236],
+                            "name": "slot3"
+                        },
+                        {
+                            "range": [237, 244],
+                            "name": "slot2"
+                        },
+                        {
+                            "range": [245, 255],
+                            "name": "slot1"
+                        }
+                    ]
+                },
+                "Gobo2": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 24],
+                            "name": "open"
+                        },
+                        {
+                            "range": [25, 49],
+                            "name": "slot1 ind"
+                        },
+                        {
+                            "range": [50, 74],
+                            "name": "slot2 ind"
+                        },
+                        {
+                            "range": [75, 99],
+                            "name": "slot3 ind"
+                        },
+                        {
+                            "range": [100, 125],
+                            "name": "slot4 ind"
+                        },
+                        {
+                            "range": [126, 157],
+                            "name": "slot4 rot"
+                        },
+                        {
+                            "range": [158, 189],
+                            "name": "slot3"
+                        },
+                        {
+                            "range": [190, 221],
+                            "name": "slot2 rot"
+                        },
+                        {
+                            "range": [222, 255],
+                            "name": "slot1 rot"
+                        }
+                    ]
+                },
+                "Gobo2 rot": {
+                    "type": "Gobo",
+                    "crossfade": true
+                },
+                "Focus": {
+                    "type": "Beam",
+                    "defaultValue": 128,
+                    "crossfade": true
+                },
+                "Iris": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Prisma": {
+                    "type": "Prism",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 49],
+                            "name": "open"
+                        },
+                        {
+                            "range": [50, 99],
+                            "name": "3 facet"
+                        },
+                        {
+                            "range": [100, 149],
+                            "name": "frost",
+                            "color": "#edf5dd"
+                        },
+                        {
+                            "range": [150, 255],
+                            "name": "5 facet"
+                        }
+                    ]
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "17-channel Mode",
+                    "shortName": "17ch",
+                    "channels": [
+                        "Strobe",
+                        "Intensity",
+                        "Color1",
+                        "Color2",
+                        "Cyan",
+                        "Magenta",
+                        "Yellow",
+                        "Gobo1",
+                        "Gobo2",
+                        "Gobo2 rot",
+                        "Focus",
+                        "Iris",
+                        "Prisma",
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Martin",
+            "name": "Roboscan 218",
+            "shortName": "Robo218",
+            "physical": {
+                "dimensions": [500, 500, 500]
+            },
+            "availableChannels": {
+                "Strobe": {
+                    "type": "Strobe",
+                    "defaultValue": 37,
+                    "highlightValue": 37,
+                    "capabilities": [
+                        {
+                            "range": [0, 36],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [37, 80],
+                            "name": "open"
+                        },
+                        {
+                            "range": [81, 208],
+                            "name": "strobe"
+                        },
+                        {
+                            "range": [219, 240],
+                            "name": "autotrig",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [241, 254],
+                            "name": "musictri",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "reset",
+                            "showInMenu": false
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Color": {
+                    "type": "MultiColor",
+                    "capabilities": [
+                        {
+                            "range": [0, 11],
+                            "name": "White+"
+                        },
+                        {
+                            "range": [12, 22],
+                            "name": "Flame Red+"
+                        },
+                        {
+                            "range": [23, 33],
+                            "name": "Light Blue+"
+                        },
+                        {
+                            "range": [34, 44],
+                            "name": "Frn. Green+"
+                        },
+                        {
+                            "range": [45, 55],
+                            "name": "Yellow+"
+                        },
+                        {
+                            "range": [56, 66],
+                            "name": "Primary+"
+                        },
+                        {
+                            "range": [67, 77],
+                            "name": "Mauve+"
+                        },
+                        {
+                            "range": [78, 88],
+                            "name": "Dark Blue+"
+                        },
+                        {
+                            "range": [89, 99],
+                            "name": "Cyan Blue+"
+                        },
+                        {
+                            "range": [100, 110],
+                            "name": "Primary Red+"
+                        },
+                        {
+                            "range": [111, 121],
+                            "name": "Light Orange"
+                        },
+                        {
+                            "range": [122, 132],
+                            "name": "Light Green+"
+                        },
+                        {
+                            "range": [133, 143],
+                            "name": "Amber+"
+                        },
+                        {
+                            "range": [144, 154],
+                            "name": "Pink+"
+                        },
+                        {
+                            "range": [155, 165],
+                            "name": "D. Lavender+"
+                        },
+                        {
+                            "range": [166, 176],
+                            "name": "Dark O    range+"
+                        },
+                        {
+                            "range": [177, 187],
+                            "name": "Multicolor1+"
+                        },
+                        {
+                            "range": [189, 191],
+                            "name": "Multicolor 2"
+                        },
+                        {
+                            "range": [192, 194],
+                            "name": "Multicolor 1"
+                        },
+                        {
+                            "range": [195, 197],
+                            "name": "Dark O"
+                        },
+                        {
+                            "range": [198, 200],
+                            "name": "Dark Lavender",
+                            "color": "#734f96"
+                        },
+                        {
+                            "range": [201, 203],
+                            "name": "Pink",
+                            "color": "#ffc0cb"
+                        },
+                        {
+                            "range": [204, 206],
+                            "name": "Amber",
+                            "color": "#ffbf00"
+                        },
+                        {
+                            "range": [207, 209],
+                            "name": "Light Green",
+                            "color": "#90ee90"
+                        },
+                        {
+                            "range": [210, 212],
+                            "name": "Light Orange"
+                        },
+                        {
+                            "range": [213, 215],
+                            "name": "Primary Red"
+                        },
+                        {
+                            "range": [216, 218],
+                            "name": "Cyan Blue"
+                        },
+                        {
+                            "range": [219, 221],
+                            "name": "Dark Blue",
+                            "color": "#00008b"
+                        },
+                        {
+                            "range": [222, 224],
+                            "name": "Mauve",
+                            "color": "#e0b0ff"
+                        },
+                        {
+                            "range": [225, 227],
+                            "name": "Primary Green"
+                        },
+                        {
+                            "range": [228, 230],
+                            "name": "Yellow",
+                            "color": "#ffff00"
+                        },
+                        {
+                            "range": [231, 233],
+                            "name": "Frn. Green"
+                        },
+                        {
+                            "range": [234, 236],
+                            "name": "Light Blue",
+                            "color": "#add8e6"
+                        },
+                        {
+                            "range": [237, 239],
+                            "name": "Flame Red"
+                        },
+                        {
+                            "range": [240, 255],
+                            "name": "White",
+                            "color": "#ffffff"
+                        }
+                    ]
+                },
+                "Gobo": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 44],
+                            "name": "open",
+                            "center": true
+                        },
+                        {
+                            "range": [45, 55],
+                            "name": "half"
+                        },
+                        {
+                            "range": [56, 66],
+                            "name": "dot"
+                        },
+                        {
+                            "range": [67, 77],
+                            "name": "vertbar"
+                        },
+                        {
+                            "range": [78, 88],
+                            "name": "bar"
+                        },
+                        {
+                            "range": [89, 99],
+                            "name": "arrow"
+                        },
+                        {
+                            "range": [100, 110],
+                            "name": "fatcone"
+                        },
+                        {
+                            "range": [111, 121],
+                            "name": "triangle"
+                        },
+                        {
+                            "range": [122, 132],
+                            "name": "star"
+                        },
+                        {
+                            "range": [133, 143],
+                            "name": "dots"
+                        },
+                        {
+                            "range": [144, 154],
+                            "name": "bells"
+                        },
+                        {
+                            "range": [155, 165],
+                            "name": "cone"
+                        },
+                        {
+                            "range": [166, 176],
+                            "name": "flash"
+                        },
+                        {
+                            "range": [177, 187],
+                            "name": "raster"
+                        },
+                        {
+                            "range": [188, 198],
+                            "name": "hole"
+                        },
+                        {
+                            "range": [199, 209],
+                            "name": "bars"
+                        },
+                        {
+                            "range": [210, 254],
+                            "name": "window"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "turbine"
+                        }
+                    ]
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "invert": true,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "invert": true,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Speed": {
+                    "type": "Speed",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "9-channel Mode",
+                    "shortName": "9ch",
+                    "channels": [
+                        "Strobe",
+                        "Intensity",
+                        "Color",
+                        "Gobo",
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "Speed"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Martin",
+            "name": "Roboscan 518",
+            "shortName": "RoboSc518",
+            "physical": {
+                "dimensions": [500, 500, 500]
+            },
+            "availableChannels": {
+                "Strobe": {
+                    "type": "Strobe",
+                    "capabilities": [
+                        {
+                            "range": [0, 10],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [11, 138],
+                            "name": "Strobe"
+                        },
+                        {
+                            "range": [150, 189],
+                            "name": "Autotrigger",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [190, 219],
+                            "name": "Musictrigger",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [220, 235],
+                            "name": "Reset",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [236, 252],
+                            "name": "Lamp On",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [253, 255],
+                            "name": "Lamp Off",
+                            "showInMenu": false
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Colour": {
+                    "type": "MultiColor",
+                    "capabilities": [
+                        {
+                            "range": [0, 3],
+                            "name": "White",
+                            "color": "#ffffff"
+                        },
+                        {
+                            "range": [4, 7],
+                            "name": "White/Pink",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [8, 11],
+                            "name": "Pink",
+                            "color": "#ffc0cb"
+                        },
+                        {
+                            "range": [12, 15],
+                            "name": "Pink/Magenta",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [16, 19],
+                            "name": "Magenta",
+                            "color": "#ca1f7b"
+                        },
+                        {
+                            "range": [20, 23],
+                            "name": "Magenta/Red",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [24, 27],
+                            "name": "Red",
+                            "color": "#ff0000"
+                        },
+                        {
+                            "range": [28, 31],
+                            "name": "Red/Flame Red",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [32, 35],
+                            "name": "Flame Red"
+                        },
+                        {
+                            "range": [36, 39],
+                            "name": "Fl Red/Orange",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [40, 43],
+                            "name": "Dark Orange",
+                            "color": "#ff8c00"
+                        },
+                        {
+                            "range": [44, 47],
+                            "name": "Dk Orng/Orng",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [48, 51],
+                            "name": "Orange",
+                            "color": "#ff7f00"
+                        },
+                        {
+                            "range": [52, 55],
+                            "name": "Orange/Yellow",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [56, 59],
+                            "name": "Yellow",
+                            "color": "#ffff00"
+                        },
+                        {
+                            "range": [60, 64],
+                            "name": "Yellow/Lt Green",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [65, 67],
+                            "name": "Light Green",
+                            "color": "#90ee90"
+                        },
+                        {
+                            "range": [68, 71],
+                            "name": "Lt Green/Frn Gr",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [72, 75],
+                            "name": "Fern Green",
+                            "color": "#4f7942"
+                        },
+                        {
+                            "range": [76, 79],
+                            "name": "Frn Green/Turqu",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [80, 83],
+                            "name": "Turquois"
+                        },
+                        {
+                            "range": [84, 87],
+                            "name": "Turq/Cyan",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [88, 91],
+                            "name": "Cyan",
+                            "color": "#00ffff"
+                        },
+                        {
+                            "range": [92, 95],
+                            "name": "Cyan/Lt Blue",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [96, 99],
+                            "name": "Light Blue",
+                            "color": "#add8e6"
+                        },
+                        {
+                            "range": [100, 103],
+                            "name": "Lt Blue/Dk Lav",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [104, 107],
+                            "name": "Dk Lavender"
+                        },
+                        {
+                            "range": [108, 111],
+                            "name": "Dk Lav/Dk Blue",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [112, 115],
+                            "name": "Dk Blue"
+                        },
+                        {
+                            "range": [116, 119],
+                            "name": "Dk Blue/UV",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [120, 123],
+                            "name": "UV"
+                        },
+                        {
+                            "range": [124, 127],
+                            "name": "UV/MultiCol",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [128, 131],
+                            "name": "Multi 1"
+                        },
+                        {
+                            "range": [132, 135],
+                            "name": "Multi 1/Multi 2",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [136, 139],
+                            "name": "Multi 2"
+                        },
+                        {
+                            "range": [140, 197],
+                            "name": "Rot Right",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [198, 255],
+                            "name": "Rot Left",
+                            "showInMenu": false,
+                            "center": true
+                        }
+                    ]
+                },
+                "Gobo": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "Open",
+                            "center": true
+                        },
+                        {
+                            "range": [1, 51],
+                            "name": "Gobo 1",
+                            "center": true
+                        },
+                        {
+                            "range": [52, 102],
+                            "name": "Gobo 2",
+                            "center": true
+                        },
+                        {
+                            "range": [103, 153],
+                            "name": "Gobo 3",
+                            "center": true
+                        },
+                        {
+                            "range": [154, 204],
+                            "name": "Gobo 4",
+                            "center": true
+                        },
+                        {
+                            "range": [205, 255],
+                            "name": "Gobo 5",
+                            "center": true
+                        }
+                    ]
+                },
+                "Fx/Prism": {
+                    "type": "Prism",
+                    "capabilities": [
+                        {
+                            "range": [0, 63],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [64, 127],
+                            "name": "CTC"
+                        },
+                        {
+                            "range": [128, 191],
+                            "name": "Frost",
+                            "color": "#edf5dd"
+                        },
+                        {
+                            "range": [192, 255],
+                            "name": "Prism"
+                        }
+                    ]
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 127,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "9-channel Mode",
+                    "shortName": "9ch",
+                    "channels": [
+                        "Strobe",
+                        "Intensity",
+                        "Colour",
+                        "Gobo",
+                        "Fx/Prism",
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Martin",
+            "name": "Roboscan 812",
+            "shortName": "RoboSc812",
+            "physical": {
+                "dimensions": [500, 500, 500]
+            },
+            "availableChannels": {
+                "Strobe": {
+                    "type": "Strobe",
+                    "capabilities": [
+                        {
+                            "range": [0, 10],
+                            "name": "No Strobe"
+                        },
+                        {
+                            "range": [11, 138],
+                            "name": "Strobe"
+                        },
+                        {
+                            "range": [139, 170],
+                            "name": "Autotrigger",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [171, 202],
+                            "name": "Musictrigger",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [203, 235],
+                            "name": "Reset",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [236, 255],
+                            "name": "Lamp On",
+                            "showInMenu": false
+                        }
+                    ]
+                },
+                "Colour(*)": {
+                    "type": "MultiColor",
+                    "defaultValue": 15,
+                    "highlightValue": 15,
+                    "capabilities": [
+                        {
+                            "range": [0, 8],
+                            "name": "Black",
+                            "color": "#000000",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [9, 22],
+                            "name": "White",
+                            "color": "#ffffff",
+                            "center": true
+                        },
+                        {
+                            "range": [23, 37],
+                            "name": "Magenta",
+                            "color": "#ca1f7b",
+                            "center": true
+                        },
+                        {
+                            "range": [38, 52],
+                            "name": "Pink",
+                            "color": "#ffc0cb",
+                            "center": true
+                        },
+                        {
+                            "range": [53, 67],
+                            "name": "Red",
+                            "color": "#ff0000",
+                            "center": true
+                        },
+                        {
+                            "range": [68, 82],
+                            "name": "Orange",
+                            "color": "#ff7f00",
+                            "center": true
+                        },
+                        {
+                            "range": [83, 97],
+                            "name": "Amber",
+                            "color": "#ffbf00",
+                            "center": true
+                        },
+                        {
+                            "range": [98, 112],
+                            "name": "Yellow",
+                            "color": "#ffff00",
+                            "center": true
+                        },
+                        {
+                            "range": [113, 127],
+                            "name": "Light Green",
+                            "color": "#90ee90",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 142],
+                            "name": "Green",
+                            "color": "#00ff00",
+                            "center": true
+                        },
+                        {
+                            "range": [143, 157],
+                            "name": "Cyan",
+                            "color": "#00ffff",
+                            "center": true
+                        },
+                        {
+                            "range": [158, 172],
+                            "name": "Blue",
+                            "color": "#0000ff",
+                            "center": true
+                        },
+                        {
+                            "range": [181, 255],
+                            "name": "Dark Blue",
+                            "color": "#00008b"
+                        }
+                    ]
+                },
+                "Gobo(*)": {
+                    "type": "Gobo",
+                    "highlightValue": 15,
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "Dimmer"
+                        },
+                        {
+                            "range": [23, 37],
+                            "name": "Dot",
+                            "center": true
+                        },
+                        {
+                            "range": [38, 52],
+                            "name": "Line",
+                            "center": true
+                        },
+                        {
+                            "range": [53, 67],
+                            "name": "Stars",
+                            "center": true
+                        },
+                        {
+                            "range": [68, 82],
+                            "name": "Triangles",
+                            "center": true
+                        },
+                        {
+                            "range": [83, 97],
+                            "name": "Star",
+                            "center": true
+                        },
+                        {
+                            "range": [98, 112],
+                            "name": "Dots",
+                            "center": true
+                        },
+                        {
+                            "range": [113, 127],
+                            "name": "Bells",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 142],
+                            "name": "Cone",
+                            "center": true
+                        },
+                        {
+                            "range": [143, 157],
+                            "name": "Phone",
+                            "center": true
+                        },
+                        {
+                            "range": [158, 172],
+                            "name": "Window",
+                            "center": true
+                        },
+                        {
+                            "range": [181, 255],
+                            "name": "Triangle"
+                        }
+                    ]
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "MSpeed": {
+                    "type": "Speed",
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "Tracking enable"
+                        },
+                        {
+                            "range": [1, 255],
+                            "name": "Speed"
+                        }
+                    ]
+                },
+                "*Speed": {
+                    "type": "Speed",
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "Tracking enable"
+                        },
+                        {
+                            "range": [1, 255],
+                            "name": "Speed"
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "7-channel Mode",
+                    "shortName": "7ch",
+                    "channels": [
+                        "Strobe",
+                        "Colour(*)",
+                        "Gobo(*)",
+                        "Pan",
+                        "Tilt",
+                        "MSpeed",
+                        "*Speed"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Martin",
+            "name": "RoboScan Pro 1220 XR",
+            "shortName": "1220XR",
+            "comment": "Mode4                                                     cd",
+            "physical": {
+                "dimensions": [500, 500, 500]
+            },
+            "availableChannels": {
+                "Strobe": {
+                    "type": "Strobe",
+                    "capabilities": [
+                        {
+                            "range": [0, 49],
+                            "name": "idle"
+                        },
+                        {
+                            "range": [50, 177],
+                            "name": "strobe"
+                        },
+                        {
+                            "range": [178, 199],
+                            "name": "idle"
+                        },
+                        {
+                            "range": [200, 243],
+                            "name": "fan low"
+                        },
+                        {
+                            "range": [244, 247],
+                            "name": "lamp off"
+                        },
+                        {
+                            "range": [248, 251],
+                            "name": "reset"
+                        },
+                        {
+                            "range": [252, 255],
+                            "name": "lamp on"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Color": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 9],
+                            "name": "pen"
+                        },
+                        {
+                            "range": [10, 19],
+                            "name": "amber",
+                            "color": "#ffbf00"
+                        },
+                        {
+                            "range": [20, 29],
+                            "name": "fern green",
+                            "color": "#4f7942"
+                        },
+                        {
+                            "range": [30, 39],
+                            "name": "light blue",
+                            "color": "#add8e6"
+                        },
+                        {
+                            "range": [40, 49],
+                            "name": "flame red"
+                        },
+                        {
+                            "range": [50, 59],
+                            "name": "primary green"
+                        },
+                        {
+                            "range": [60, 69],
+                            "name": "blue",
+                            "color": "#0000ff"
+                        },
+                        {
+                            "range": [70, 79],
+                            "name": "orange",
+                            "color": "#ff7f00"
+                        },
+                        {
+                            "range": [80, 89],
+                            "name": "turquoise",
+                            "color": "#40e0d0"
+                        },
+                        {
+                            "range": [90, 97],
+                            "name": "purple",
+                            "color": "#800080"
+                        },
+                        {
+                            "range": [98, 105],
+                            "name": "turquoise",
+                            "color": "#40e0d0"
+                        },
+                        {
+                            "range": [106, 113],
+                            "name": "orange",
+                            "color": "#ff7f00"
+                        },
+                        {
+                            "range": [114, 121],
+                            "name": "blue",
+                            "color": "#0000ff"
+                        },
+                        {
+                            "range": [122, 129],
+                            "name": "primary green"
+                        },
+                        {
+                            "range": [130, 137],
+                            "name": "flame red"
+                        },
+                        {
+                            "range": [138, 145],
+                            "name": "light blue",
+                            "color": "#add8e6"
+                        },
+                        {
+                            "range": [146, 153],
+                            "name": "fern green",
+                            "color": "#4f7942"
+                        },
+                        {
+                            "range": [154, 161],
+                            "name": "amber",
+                            "color": "#ffbf00"
+                        },
+                        {
+                            "range": [162, 208],
+                            "name": ">>"
+                        },
+                        {
+                            "range": [209, 255],
+                            "name": "<<"
+                        }
+                    ]
+                },
+                "Gobo1": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 19],
+                            "name": "open"
+                        },
+                        {
+                            "range": [20, 39],
+                            "name": "stars"
+                        },
+                        {
+                            "range": [40, 59],
+                            "name": "star"
+                        },
+                        {
+                            "range": [60, 79],
+                            "name": "dots"
+                        },
+                        {
+                            "range": [80, 99],
+                            "name": "cone"
+                        },
+                        {
+                            "range": [100, 119],
+                            "name": "pling"
+                        },
+                        {
+                            "range": [120, 139],
+                            "name": "dot-circle"
+                        },
+                        {
+                            "range": [140, 159],
+                            "name": "bells"
+                        },
+                        {
+                            "range": [160, 179],
+                            "name": "flower"
+                        },
+                        {
+                            "range": [180, 188],
+                            "name": "turbine"
+                        },
+                        {
+                            "range": [189, 196],
+                            "name": "flower"
+                        },
+                        {
+                            "range": [197, 204],
+                            "name": "bells"
+                        },
+                        {
+                            "range": [205, 212],
+                            "name": "dot-circle"
+                        },
+                        {
+                            "range": [213, 220],
+                            "name": "pling"
+                        },
+                        {
+                            "range": [221, 228],
+                            "name": "cone"
+                        },
+                        {
+                            "range": [229, 236],
+                            "name": "dots"
+                        },
+                        {
+                            "range": [237, 244],
+                            "name": "star"
+                        },
+                        {
+                            "range": [245, 255],
+                            "name": "stars"
+                        }
+                    ]
+                },
+                "Gobo2": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 24],
+                            "name": "open"
+                        },
+                        {
+                            "range": [25, 49],
+                            "name": "slot1 ind"
+                        },
+                        {
+                            "range": [50, 74],
+                            "name": "slot2 ind"
+                        },
+                        {
+                            "range": [75, 99],
+                            "name": "slot3 ind"
+                        },
+                        {
+                            "range": [100, 125],
+                            "name": "slot4 ind"
+                        },
+                        {
+                            "range": [126, 157],
+                            "name": "slot4 rot"
+                        },
+                        {
+                            "range": [158, 189],
+                            "name": "slot3 rot"
+                        },
+                        {
+                            "range": [190, 221],
+                            "name": "slot2 rot"
+                        },
+                        {
+                            "range": [222, 255],
+                            "name": "slot1 rot"
+                        }
+                    ]
+                },
+                "Gobo2 rot": {
+                    "type": "Gobo",
+                    "crossfade": true
+                },
+                "Focus": {
+                    "type": "Beam",
+                    "defaultValue": 128,
+                    "crossfade": true
+                },
+                "Iris": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Effect": {
+                    "type": "Effect",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 42],
+                            "name": "open"
+                        },
+                        {
+                            "range": [43, 84],
+                            "name": "CTO"
+                        },
+                        {
+                            "range": [85, 127],
+                            "name": "frost",
+                            "color": "#edf5dd"
+                        },
+                        {
+                            "range": [128, 170],
+                            "name": "prisma3"
+                        },
+                        {
+                            "range": [171, 212],
+                            "name": "open"
+                        },
+                        {
+                            "range": [213, 255],
+                            "name": "prisma5"
+                        }
+                    ]
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 0,
+                    "highlightValue": 0,
+                    "crossfade": true
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 0,
+                    "highlightValue": 0,
+                    "crossfade": true
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true
+                },
+                "P/T speed": {
+                    "type": "Speed",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "track"
+                        },
+                        {
+                            "range": [1, 251],
+                            "name": "speed"
+                        },
+                        {
+                            "range": [252, 255],
+                            "name": "MIB"
+                        }
+                    ]
+                },
+                "I/C/G speed": {
+                    "type": "Speed",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "track"
+                        },
+                        {
+                            "range": [1, 251],
+                            "name": "speed"
+                        },
+                        {
+                            "range": [252, 255],
+                            "name": "MIB"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "15-channel Mode",
+                    "shortName": "15ch",
+                    "channels": [
+                        "Strobe",
+                        "Intensity",
+                        "Color",
+                        "Gobo1",
+                        "Gobo2",
+                        "Gobo2 rot",
+                        "Focus",
+                        "Iris",
+                        "Effect",
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "P/T speed",
+                        "I/C/G speed"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Martin",
+            "name": "Roboscan Pro 918",
+            "shortName": "RoboP918",
+            "physical": {
+                "dimensions": [500, 500, 500]
+            },
+            "availableChannels": {
+                "Strobe": {
+                    "type": "Strobe",
+                    "defaultValue": 20,
+                    "highlightValue": 20,
+                    "capabilities": [
+                        {
+                            "range": [0, 19],
+                            "name": "Closed"
+                        },
+                        {
+                            "range": [20, 49],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [50, 72],
+                            "name": "Strobe"
+                        },
+                        {
+                            "range": [80, 99],
+                            "name": "Open Pulse"
+                        },
+                        {
+                            "range": [100, 119],
+                            "name": "Close Pulse"
+                        },
+                        {
+                            "range": [128, 187],
+                            "name": "Random",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [191, 196],
+                            "name": "Rand Open Pulse",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [197, 202],
+                            "name": "Rand Cl Pulse",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [208, 217],
+                            "name": "Reset",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [228, 237],
+                            "name": "Lamp On",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [248, 255],
+                            "name": "Lamp Off",
+                            "showInMenu": false
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Colour": {
+                    "type": "MultiColor",
+                    "defaultValue": 183,
+                    "highlightValue": 183,
+                    "capabilities": [
+                        {
+                            "range": [0, 8],
+                            "name": "White",
+                            "color": "#ffffff",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [24, 39],
+                            "name": "Blue->Red",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [40, 55],
+                            "name": "Red->Mag",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [56, 71],
+                            "name": "Mag->Green",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [72, 87],
+                            "name": "Green->Yell",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [88, 103],
+                            "name": "Yell->Purple",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [104, 119],
+                            "name": "Purple->Blue",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [120, 135],
+                            "name": "Blue->Pink",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [136, 144],
+                            "name": "Pink->Cyan",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [145, 148],
+                            "name": "Cyan",
+                            "color": "#00ffff",
+                            "center": true
+                        },
+                        {
+                            "range": [149, 152],
+                            "name": "Pink",
+                            "color": "#ffc0cb",
+                            "center": true
+                        },
+                        {
+                            "range": [153, 156],
+                            "name": "Light Blue",
+                            "color": "#add8e6",
+                            "center": true
+                        },
+                        {
+                            "range": [157, 160],
+                            "name": "Purple",
+                            "color": "#800080",
+                            "center": true
+                        },
+                        {
+                            "range": [161, 164],
+                            "name": "Yellow",
+                            "color": "#ffff00",
+                            "center": true
+                        },
+                        {
+                            "range": [165, 168],
+                            "name": "Green",
+                            "color": "#00ff00",
+                            "center": true
+                        },
+                        {
+                            "range": [169, 172],
+                            "name": "Magenta",
+                            "color": "#ca1f7b",
+                            "center": true
+                        },
+                        {
+                            "range": [173, 176],
+                            "name": "Red",
+                            "color": "#ff0000",
+                            "center": true
+                        },
+                        {
+                            "range": [177, 180],
+                            "name": "Blue",
+                            "color": "#0000ff",
+                            "center": true
+                        },
+                        {
+                            "range": [181, 184],
+                            "name": "White",
+                            "color": "#ffffff",
+                            "center": true
+                        },
+                        {
+                            "range": [185, 215],
+                            "name": "Rot Right",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [216, 245],
+                            "name": "Rot Left",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [246, 255],
+                            "name": "Add Funcs",
+                            "showInMenu": false
+                        }
+                    ]
+                },
+                "Colour 2": {
+                    "type": "MultiColor",
+                    "defaultValue": 183,
+                    "highlightValue": 183,
+                    "capabilities": [
+                        {
+                            "range": [0, 8],
+                            "name": "White",
+                            "color": "#ffffff",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [24, 39],
+                            "name": "CTC1->CTC2",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [40, 55],
+                            "name": "CTC2->Blue",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [56, 71],
+                            "name": "Blue1->Blue2",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [72, 87],
+                            "name": "Blue->Green",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [88, 103],
+                            "name": "Green->Red",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [104, 119],
+                            "name": "Red->Yell",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [120, 135],
+                            "name": "Yell->CTC3",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [136, 144],
+                            "name": "CTC3->CTC4",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [145, 148],
+                            "name": "CTC 4",
+                            "center": true
+                        },
+                        {
+                            "range": [149, 152],
+                            "name": "CTC 3",
+                            "center": true
+                        },
+                        {
+                            "range": [153, 156],
+                            "name": "Yellow",
+                            "color": "#ffff00",
+                            "center": true
+                        },
+                        {
+                            "range": [157, 160],
+                            "name": "Red",
+                            "color": "#ff0000",
+                            "center": true
+                        },
+                        {
+                            "range": [161, 164],
+                            "name": "Green",
+                            "color": "#00ff00",
+                            "center": true
+                        },
+                        {
+                            "range": [165, 168],
+                            "name": "Blue 1",
+                            "center": true
+                        },
+                        {
+                            "range": [169, 172],
+                            "name": "Blue 2",
+                            "center": true
+                        },
+                        {
+                            "range": [173, 176],
+                            "name": "CTC 2",
+                            "center": true
+                        },
+                        {
+                            "range": [177, 180],
+                            "name": "CTC 1",
+                            "center": true
+                        },
+                        {
+                            "range": [181, 184],
+                            "name": "White",
+                            "color": "#ffffff",
+                            "center": true
+                        },
+                        {
+                            "range": [185, 215],
+                            "name": "Rot Right",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [216, 245],
+                            "name": "Rot Left",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [246, 255],
+                            "name": "Rand Colour",
+                            "showInMenu": false
+                        }
+                    ]
+                },
+                "Gobo": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 55],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [56, 75],
+                            "name": "Gobo 1"
+                        },
+                        {
+                            "range": [76, 95],
+                            "name": "Gobo 2"
+                        },
+                        {
+                            "range": [96, 115],
+                            "name": "Gobo 3"
+                        },
+                        {
+                            "range": [116, 135],
+                            "name": "Gobo 4"
+                        },
+                        {
+                            "range": [136, 155],
+                            "name": "Gobo 5"
+                        },
+                        {
+                            "range": [156, 175],
+                            "name": "Rot Gobo 5"
+                        },
+                        {
+                            "range": [176, 195],
+                            "name": "Rot Gobo 4"
+                        },
+                        {
+                            "range": [196, 215],
+                            "name": "Rot Gobo 3"
+                        },
+                        {
+                            "range": [216, 235],
+                            "name": "Rot Gobo 2"
+                        },
+                        {
+                            "range": [236, 255],
+                            "name": "Rot Gobo 1"
+                        }
+                    ]
+                },
+                "Gobo Rot": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 2],
+                            "name": "Static",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [3, 127],
+                            "name": "Rot Left",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [128, 252],
+                            "name": "Rot Right",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [253, 255],
+                            "name": "Static",
+                            "showInMenu": false
+                        }
+                    ]
+                },
+                "Gobo 2": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 10],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [11, 30],
+                            "name": "Gobo 2.1",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [31, 50],
+                            "name": "Gobo 2.2",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [51, 70],
+                            "name": "Gobo 2.3",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [71, 90],
+                            "name": "Gobo 2.4",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [91, 110],
+                            "name": "Gobo 2.5",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [111, 130],
+                            "name": "Gobo 2.6",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [131, 150],
+                            "name": "Gobo 2.7",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [151, 170],
+                            "name": "Gobo 2.8",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [171, 180],
+                            "name": "Gobo 2.9",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [181, 183],
+                            "name": "Shake 9",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [184, 186],
+                            "name": "Shake 8",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [187, 189],
+                            "name": "Shake 7",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [190, 192],
+                            "name": "Shake 6",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [193, 195],
+                            "name": "Shake 5",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [196, 198],
+                            "name": "Shake 4",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [199, 201],
+                            "name": "Shake 3",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [202, 204],
+                            "name": "Shake 2",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [205, 207],
+                            "name": "Shake 1",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [208, 231],
+                            "name": "Rot Right",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [232, 255],
+                            "name": "Rot Left",
+                            "showInMenu": false,
+                            "center": true
+                        }
+                    ]
+                },
+                "Focus": {
+                    "type": "Beam",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "Distance"
+                        }
+                    ]
+                },
+                "Iris": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 215],
+                            "name": "Open->Close"
+                        },
+                        {
+                            "range": [216, 255],
+                            "name": "Pulse",
+                            "showInMenu": false
+                        }
+                    ]
+                },
+                "Prism": {
+                    "type": "Prism",
+                    "capabilities": [
+                        {
+                            "range": [0, 19],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [20, 149],
+                            "name": "Prim Rotation",
+                            "center": true
+                        },
+                        {
+                            "range": [215, 215],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [216, 220],
+                            "name": "Macro 1",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [221, 225],
+                            "name": "Macro 2",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [226, 230],
+                            "name": "Macro 3",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [231, 235],
+                            "name": "Macro 4",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [236, 240],
+                            "name": "Macro 5",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [241, 245],
+                            "name": "Macro 6",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [246, 250],
+                            "name": "Macro 7",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [251, 255],
+                            "name": "Macro 8",
+                            "showInMenu": false
+                        }
+                    ]
+                },
+                "Pan (*)": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Pan (*) fine": {
+                    "type": "Pan",
+                    "defaultValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Tilt (*)": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Tilt (*) fine": {
+                    "type": "Tilt",
+                    "defaultValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "*Pan Speed": {
+                    "type": "Speed",
+                    "capabilities": [
+                        {
+                            "range": [0, 2],
+                            "name": "Tracking",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [3, 245],
+                            "name": "Speed",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [246, 248],
+                            "name": "PTSPnorm",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [249, 251],
+                            "name": "PTSPfast",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [252, 255],
+                            "name": "Blackout",
+                            "showInMenu": false
+                        }
+                    ]
+                },
+                "Control": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 2],
+                            "name": "Tracking",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [3, 245],
+                            "name": "Speed",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [246, 248],
+                            "name": "Shortcuts On",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [249, 254],
+                            "name": "Shortcuts Off",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "Blackout",
+                            "showInMenu": false
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan (*)",
+                    "Pan (*) fine"
+                ],
+                [
+                    "Tilt (*)",
+                    "Tilt (*) fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "16-channel Mode",
+                    "shortName": "16ch",
+                    "channels": [
+                        "Strobe",
+                        "Intensity",
+                        "Colour",
+                        "Colour 2",
+                        "Gobo",
+                        "Gobo Rot",
+                        "Gobo 2",
+                        "Focus",
+                        "Iris",
+                        "Prism",
+                        "Pan (*)",
+                        "Pan (*) fine",
+                        "Tilt (*)",
+                        "Tilt (*) fine",
+                        "*Pan Speed",
+                        "Control"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Martin",
+            "name": "SmartMAC 16bit",
+            "shortName": "smartMAC16bit",
+            "comment": "16bit   cd",
+            "physical": {
+                "dimensions": [500, 500, 500]
+            },
+            "availableChannels": {
+                "Shutter": {
+                    "type": "Shutter",
+                    "highlightValue": 20,
+                    "capabilities": [
+                        {
+                            "range": [0, 14],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [15, 29],
+                            "name": "open"
+                        },
+                        {
+                            "range": [30, 39],
+                            "name": "fade in"
+                        },
+                        {
+                            "range": [40, 49],
+                            "name": "fade out"
+                        },
+                        {
+                            "range": [50, 72],
+                            "name": "strobe"
+                        },
+                        {
+                            "range": [73, 79],
+                            "name": "open"
+                        },
+                        {
+                            "range": [80, 99],
+                            "name": "pulse open"
+                        },
+                        {
+                            "range": [100, 119],
+                            "name": "pulse close"
+                        },
+                        {
+                            "range": [120, 123],
+                            "name": "open"
+                        },
+                        {
+                            "range": [124, 127],
+                            "name": "music trigger"
+                        },
+                        {
+                            "range": [128, 187],
+                            "name": "random strobe"
+                        },
+                        {
+                            "range": [188, 190],
+                            "name": "open"
+                        },
+                        {
+                            "range": [191, 202],
+                            "name": "random pulse"
+                        },
+                        {
+                            "range": [203, 207],
+                            "name": "open"
+                        },
+                        {
+                            "range": [208, 217],
+                            "name": "reset"
+                        },
+                        {
+                            "range": [218, 227],
+                            "name": "open"
+                        },
+                        {
+                            "range": [228, 237],
+                            "name": "lamp on"
+                        },
+                        {
+                            "range": [238, 247],
+                            "name": "open"
+                        },
+                        {
+                            "range": [248, 255],
+                            "name": "lamp off"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Color": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "open"
+                        },
+                        {
+                            "range": [16, 31],
+                            "name": "blue",
+                            "color": "#0000ff"
+                        },
+                        {
+                            "range": [32, 47],
+                            "name": "green",
+                            "color": "#00ff00"
+                        },
+                        {
+                            "range": [48, 63],
+                            "name": "orange",
+                            "color": "#ff7f00"
+                        },
+                        {
+                            "range": [64, 79],
+                            "name": "yellow",
+                            "color": "#ffff00"
+                        },
+                        {
+                            "range": [80, 95],
+                            "name": "pink",
+                            "color": "#ffc0cb"
+                        },
+                        {
+                            "range": [96, 111],
+                            "name": "magenta",
+                            "color": "#ca1f7b"
+                        },
+                        {
+                            "range": [112, 127],
+                            "name": "congo"
+                        },
+                        {
+                            "range": [128, 143],
+                            "name": "red",
+                            "color": "#ff0000"
+                        },
+                        {
+                            "range": [144, 144],
+                            "name": "open"
+                        },
+                        {
+                            "range": [145, 148],
+                            "name": "red",
+                            "color": "#ff0000"
+                        },
+                        {
+                            "range": [149, 152],
+                            "name": "congo"
+                        },
+                        {
+                            "range": [153, 156],
+                            "name": "magenta",
+                            "color": "#ca1f7b"
+                        },
+                        {
+                            "range": [157, 160],
+                            "name": "pink",
+                            "color": "#ffc0cb"
+                        },
+                        {
+                            "range": [161, 164],
+                            "name": "yellow",
+                            "color": "#ffff00"
+                        },
+                        {
+                            "range": [165, 168],
+                            "name": "orange",
+                            "color": "#ff7f00"
+                        },
+                        {
+                            "range": [169, 172],
+                            "name": "green",
+                            "color": "#00ff00"
+                        },
+                        {
+                            "range": [173, 176],
+                            "name": "blue",
+                            "color": "#0000ff"
+                        },
+                        {
+                            "range": [177, 180],
+                            "name": "open"
+                        },
+                        {
+                            "range": [181, 203],
+                            "name": ">>"
+                        },
+                        {
+                            "range": [204, 207],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [208, 230],
+                            "name": "<<"
+                        },
+                        {
+                            "range": [231, 243],
+                            "name": "music trigger"
+                        },
+                        {
+                            "range": [244, 255],
+                            "name": "random"
+                        }
+                    ]
+                },
+                "Gobo": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 3],
+                            "name": "open"
+                        },
+                        {
+                            "range": [4, 7],
+                            "name": "slot1 ind."
+                        },
+                        {
+                            "range": [8, 11],
+                            "name": "slot2 ind."
+                        },
+                        {
+                            "range": [12, 15],
+                            "name": "slot3 ind."
+                        },
+                        {
+                            "range": [16, 19],
+                            "name": "slot4 ind."
+                        },
+                        {
+                            "range": [20, 23],
+                            "name": "slot5 ind."
+                        },
+                        {
+                            "range": [24, 27],
+                            "name": "slot6 ind."
+                        },
+                        {
+                            "range": [28, 31],
+                            "name": "open"
+                        },
+                        {
+                            "range": [32, 35],
+                            "name": "slot1 rot."
+                        },
+                        {
+                            "range": [36, 39],
+                            "name": "slot2 rot."
+                        },
+                        {
+                            "range": [40, 43],
+                            "name": "slot3 rot."
+                        },
+                        {
+                            "range": [44, 47],
+                            "name": "slot4 rot."
+                        },
+                        {
+                            "range": [48, 51],
+                            "name": "slot5 rot."
+                        },
+                        {
+                            "range": [52, 55],
+                            "name": "slot6 rot."
+                        },
+                        {
+                            "range": [56, 66],
+                            "name": "slot1 ind. sh."
+                        },
+                        {
+                            "range": [67, 77],
+                            "name": "slot2 ind. sh."
+                        },
+                        {
+                            "range": [78, 88],
+                            "name": "slot3 ind. sh."
+                        },
+                        {
+                            "range": [89, 99],
+                            "name": "slot4 ind. sh."
+                        },
+                        {
+                            "range": [100, 110],
+                            "name": "slot5 ind. sh."
+                        },
+                        {
+                            "range": [111, 121],
+                            "name": "slot6 ind. sh."
+                        },
+                        {
+                            "range": [122, 132],
+                            "name": "slot6 rot. sh."
+                        },
+                        {
+                            "range": [133, 143],
+                            "name": "slot5 rot. sh."
+                        },
+                        {
+                            "range": [144, 154],
+                            "name": "slot4 rot. sh."
+                        },
+                        {
+                            "range": [155, 165],
+                            "name": "slot3 rot. sh."
+                        },
+                        {
+                            "range": [166, 176],
+                            "name": "slot2 rot. sh."
+                        },
+                        {
+                            "range": [177, 187],
+                            "name": "slot1 rot. sh."
+                        },
+                        {
+                            "range": [188, 215],
+                            "name": ">>"
+                        },
+                        {
+                            "range": [216, 243],
+                            "name": "<<"
+                        },
+                        {
+                            "range": [244, 255],
+                            "name": "music trigger"
+                        }
+                    ]
+                },
+                "Gobo rot.": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "Gobo rot. fine": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "Focus": {
+                    "type": "Beam",
+                    "defaultValue": 128,
+                    "crossfade": true
+                },
+                "P/T Macro": {
+                    "type": "Beam"
+                },
+                "Effect Macro": {
+                    "type": "Effect"
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "highlightValue": null
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 0,
+                    "crossfade": true,
+                    "highlightValue": null
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "highlightValue": null
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 0,
+                    "crossfade": true,
+                    "highlightValue": null
+                },
+                "P/T speed": {
+                    "type": "Speed",
+                    "capabilities": [
+                        {
+                            "range": [0, 2],
+                            "name": "tracking"
+                        },
+                        {
+                            "range": [3, 245],
+                            "name": "speed"
+                        },
+                        {
+                            "range": [246, 251],
+                            "name": "tracking"
+                        },
+                        {
+                            "range": [252, 255],
+                            "name": "MIB"
+                        }
+                    ]
+                },
+                "FX speed": {
+                    "type": "Speed",
+                    "capabilities": [
+                        {
+                            "range": [0, 2],
+                            "name": "tracking"
+                        },
+                        {
+                            "range": [3, 245],
+                            "name": "speed"
+                        },
+                        {
+                            "range": [246, 251],
+                            "name": "tracking"
+                        },
+                        {
+                            "range": [252, 255],
+                            "name": "MIB"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Gobo rot.",
+                    "Gobo rot. fine"
+                ],
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "15-channel Mode",
+                    "shortName": "15ch",
+                    "channels": [
+                        "Shutter",
+                        "Intensity",
+                        "Color",
+                        "Gobo",
+                        "Gobo rot.",
+                        "Gobo rot. fine",
+                        "Focus",
+                        "P/T Macro",
+                        "Effect Macro",
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "P/T speed",
+                        "FX speed"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Martin",
+            "name": "Wizard Extreme",
+            "shortName": "Wizard",
+            "comment": "cd",
+            "physical": {
+                "dimensions": [500, 500, 500]
+            },
+            "availableChannels": {
+                "Shutter": {
+                    "type": "Shutter",
+                    "highlightValue": 129,
+                    "capabilities": [
+                        {
+                            "range": [0, 1],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [2, 129],
+                            "name": "intensity"
+                        },
+                        {
+                            "range": [130, 189],
+                            "name": "strobe"
+                        },
+                        {
+                            "range": [190, 199],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [200, 209],
+                            "name": "random strobe"
+                        },
+                        {
+                            "range": [210, 219],
+                            "name": "random music"
+                        },
+                        {
+                            "range": [220, 229],
+                            "name": "random auto"
+                        },
+                        {
+                            "range": [230, 239],
+                            "name": "lamp on"
+                        },
+                        {
+                            "range": [240, 249],
+                            "name": "reset"
+                        },
+                        {
+                            "range": [250, 255],
+                            "name": "lamp off"
+                        }
+                    ]
+                },
+                "Mirror dish": {
+                    "type": "Beam",
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 1],
+                            "name": "idle"
+                        },
+                        {
+                            "range": [2, 63],
+                            "name": ">>"
+                        },
+                        {
+                            "range": [64, 65],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [66, 129],
+                            "name": "<<"
+                        },
+                        {
+                            "range": [130, 190],
+                            "name": "narrow shake"
+                        },
+                        {
+                            "range": [191, 254],
+                            "name": "wide shake"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "random"
+                        }
+                    ]
+                },
+                "Color": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 11],
+                            "name": "open"
+                        },
+                        {
+                            "range": [12, 23],
+                            "name": "blue 108"
+                        },
+                        {
+                            "range": [24, 35],
+                            "name": "orange 306"
+                        },
+                        {
+                            "range": [36, 47],
+                            "name": "purple 502"
+                        },
+                        {
+                            "range": [48, 59],
+                            "name": "green 206"
+                        },
+                        {
+                            "range": [60, 71],
+                            "name": "blue 101"
+                        },
+                        {
+                            "range": [72, 83],
+                            "name": "yellow 603"
+                        },
+                        {
+                            "range": [84, 95],
+                            "name": "magenta 507"
+                        },
+                        {
+                            "range": [96, 101],
+                            "name": "open"
+                        },
+                        {
+                            "range": [102, 169],
+                            "name": ">>"
+                        },
+                        {
+                            "range": [170, 175],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [176, 243],
+                            "name": "twinkle"
+                        },
+                        {
+                            "range": [244, 249],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [250, 255],
+                            "name": "random"
+                        }
+                    ]
+                },
+                "Color sh.": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 1],
+                            "name": "idle"
+                        },
+                        {
+                            "range": [2, 128],
+                            "name": "narrow"
+                        },
+                        {
+                            "range": [129, 255],
+                            "name": "wide"
+                        }
+                    ]
+                },
+                "Gobo": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 10],
+                            "name": "open"
+                        },
+                        {
+                            "range": [11, 22],
+                            "name": "starz"
+                        },
+                        {
+                            "range": [23, 34],
+                            "name": "zapp"
+                        },
+                        {
+                            "range": [35, 46],
+                            "name": "pipes"
+                        },
+                        {
+                            "range": [47, 58],
+                            "name": "trible dot"
+                        },
+                        {
+                            "range": [59, 70],
+                            "name": "crazy circles"
+                        },
+                        {
+                            "range": [71, 82],
+                            "name": "cone"
+                        },
+                        {
+                            "range": [83, 94],
+                            "name": "sun",
+                            "color": "#fbac13"
+                        },
+                        {
+                            "range": [95, 106],
+                            "name": "spokes"
+                        },
+                        {
+                            "range": [107, 118],
+                            "name": "bars"
+                        },
+                        {
+                            "range": [119, 130],
+                            "name": "gyroblast"
+                        },
+                        {
+                            "range": [131, 142],
+                            "name": "happy yins"
+                        },
+                        {
+                            "range": [143, 154],
+                            "name": "dot"
+                        },
+                        {
+                            "range": [155, 169],
+                            "name": "weave"
+                        },
+                        {
+                            "range": [170, 239],
+                            "name": ">>"
+                        },
+                        {
+                            "range": [240, 249],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [250, 255],
+                            "name": "trigger"
+                        }
+                    ]
+                },
+                "Gobo sh.": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 1],
+                            "name": "idle"
+                        },
+                        {
+                            "range": [2, 128],
+                            "name": "narrow"
+                        },
+                        {
+                            "range": [129, 255],
+                            "name": "wide"
+                        }
+                    ]
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "left"
+                        },
+                        {
+                            "range": [63, 63],
+                            "name": "neutral"
+                        },
+                        {
+                            "range": [127, 127],
+                            "name": "right"
+                        },
+                        {
+                            "range": [128, 191],
+                            "name": "narrow sh."
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "wide sh."
+                        }
+                    ]
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 1],
+                            "name": "idle"
+                        },
+                        {
+                            "range": [2, 63],
+                            "name": ">>"
+                        },
+                        {
+                            "range": [64, 65],
+                            "name": "idle"
+                        },
+                        {
+                            "range": [66, 127],
+                            "name": "<<"
+                        },
+                        {
+                            "range": [128, 129],
+                            "name": "idle"
+                        },
+                        {
+                            "range": [130, 191],
+                            "name": "narrow sh."
+                        },
+                        {
+                            "range": [192, 255],
+                            "name": "wide sh."
+                        }
+                    ]
+                },
+                "Macro": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "macro1"
+                        },
+                        {
+                            "range": [16, 31],
+                            "name": "macro2"
+                        },
+                        {
+                            "range": [32, 47],
+                            "name": "macro3"
+                        },
+                        {
+                            "range": [48, 63],
+                            "name": "macro4"
+                        },
+                        {
+                            "range": [64, 79],
+                            "name": "macro5"
+                        },
+                        {
+                            "range": [80, 95],
+                            "name": "macro6"
+                        },
+                        {
+                            "range": [96, 111],
+                            "name": "macro7"
+                        },
+                        {
+                            "range": [112, 127],
+                            "name": "macro8"
+                        },
+                        {
+                            "range": [128, 143],
+                            "name": "macro9"
+                        },
+                        {
+                            "range": [144, 159],
+                            "name": "macro10"
+                        },
+                        {
+                            "range": [160, 175],
+                            "name": "macro11"
+                        },
+                        {
+                            "range": [176, 191],
+                            "name": "macro12"
+                        },
+                        {
+                            "range": [192, 255],
+                            "name": "reserved"
+                        }
+                    ]
+                },
+                "Pan speed": {
+                    "type": "Speed",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 1],
+                            "name": "track"
+                        },
+                        {
+                            "range": [2, 255],
+                            "name": "speed"
+                        }
+                    ]
+                },
+                "C/G speed": {
+                    "type": "Speed",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "speed"
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "11-channel Mode",
+                    "shortName": "11ch",
+                    "channels": [
+                        "Shutter",
+                        "Mirror dish",
+                        "Color",
+                        "Color sh.",
+                        "Gobo",
+                        "Gobo sh.",
+                        "Pan",
+                        "Tilt",
+                        "Macro",
+                        "Pan speed",
+                        "C/G speed"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Martin",
+            "name": "ZR 247",
+            "shortName": "ZR 24/7",
+            "comment": "cd",
+            "physical": {
+                "dimensions": [500, 500, 500]
+            },
+            "availableChannels": {
+                "Haze level": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Fan speed": {
+                    "type": "Speed",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "2-channel Mode",
+                    "shortName": "2ch",
+                    "channels": [
+                        "Haze level",
+                        "Fan speed"
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/fixtures/imports/ecue-MainLibrary/MediaLas.json
+++ b/fixtures/imports/ecue-MainLibrary/MediaLas.json
@@ -1,0 +1,123 @@
+{
+    "manufacturers": {
+        "MediaLas": {
+            "name": "MediaLas",
+            "website": "http://www.medialas.de/"
+        }
+    },
+    "fixtures": [
+        {
+            "manufacturer": "MediaLas",
+            "name": "Tweety",
+            "shortName": "Tweety",
+            "comment": "cd",
+            "physical": {
+                "dimensions": [300, 300, 300]
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "crossfade": true
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "crossfade": true
+                },
+                "Gobo": {
+                    "type": "Gobo"
+                },
+                "Strobe": {
+                    "type": "Strobe",
+                    "capabilities": [
+                        {
+                            "range": [0, 9],
+                            "name": "off"
+                        },
+                        {
+                            "range": [10, 120],
+                            "name": "on"
+                        },
+                        {
+                            "range": [138, 255],
+                            "name": "strobe"
+                        }
+                    ]
+                },
+                "Zoom": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 120],
+                            "name": "static"
+                        },
+                        {
+                            "range": [138, 255],
+                            "name": "auto"
+                        }
+                    ]
+                },
+                "Gobo rot.": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 120],
+                            "name": "ind."
+                        },
+                        {
+                            "range": [138, 255],
+                            "name": "rot."
+                        }
+                    ]
+                },
+                "Wave": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 120],
+                            "name": "move"
+                        },
+                        {
+                            "range": [138, 255],
+                            "name": "static"
+                        }
+                    ]
+                },
+                "Blanking": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 60],
+                            "name": "static"
+                        },
+                        {
+                            "range": [68, 120],
+                            "name": "dyn."
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "8-channel Mode",
+                    "shortName": "8ch",
+                    "channels": [
+                        "Pan",
+                        "Tilt",
+                        "Gobo",
+                        "Strobe",
+                        "Zoom",
+                        "Gobo rot.",
+                        "Wave",
+                        "Blanking"
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/fixtures/imports/ecue-MainLibrary/Meteor-KLS.json
+++ b/fixtures/imports/ecue-MainLibrary/Meteor-KLS.json
@@ -1,0 +1,82 @@
+{
+    "manufacturers": {
+        "Meteor-KLS": {
+            "name": "Meteor-KLS",
+            "website": "http://www.meteor-global.com"
+        }
+    },
+    "fixtures": [
+        {
+            "manufacturer": "Meteor-KLS",
+            "name": "HPL 575 Mover",
+            "shortName": "HPL Mover",
+            "physical": {
+                "dimensions": [300, 300, 1000],
+                "weight": 13,
+                "power": 700
+            },
+            "availableChannels": {
+                "Dimmer": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Strobe": {
+                    "type": "Strobe",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 127,
+                    "crossfade": true,
+                    "highlightValue": null
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 255,
+                    "crossfade": true,
+                    "highlightValue": null
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 127,
+                    "crossfade": true,
+                    "highlightValue": null
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 255,
+                    "crossfade": true,
+                    "highlightValue": null
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "6-channel Mode",
+                    "shortName": "6ch",
+                    "channels": [
+                        "Dimmer",
+                        "Strobe",
+                        "Pan",
+                        "Tilt",
+                        "Pan fine",
+                        "Tilt fine"
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/fixtures/imports/ecue-MainLibrary/Mobolazer.json
+++ b/fixtures/imports/ecue-MainLibrary/Mobolazer.json
@@ -1,0 +1,183 @@
+{
+    "manufacturers": {
+        "Mobolazer": {
+            "name": "Mobolazer",
+            "website": "http://www.lumalaser.com/m-redirect.htm"
+        }
+    },
+    "fixtures": [
+        {
+            "manufacturer": "Mobolazer",
+            "name": "ML-10",
+            "shortName": "ML-10",
+            "comment": "http://www.onestoplasershop.com/specials.htm",
+            "physical": {
+                "dimensions": [800, 300, 300],
+                "weight": 15
+            },
+            "availableChannels": {
+                "#1": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "#2": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "#3": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "#4": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "#5": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "#6": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "#7": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "#8": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "#9": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "#10": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "No Func": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "crossfade": true
+                },
+                "No Func-vu9q2": {
+                    "name": "No Func",
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "crossfade": true
+                },
+                "Mag": {
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "crossfade": true
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "crossfade": true
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "crossfade": true
+                },
+                "Dimmer": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "crossfade": true
+                }
+            },
+            "modes": [
+                {
+                    "name": "16-channel Mode",
+                    "shortName": "16ch",
+                    "channels": [
+                        "#1",
+                        "#2",
+                        "#3",
+                        "#4",
+                        "#5",
+                        "#6",
+                        "#7",
+                        "#8",
+                        "#9",
+                        "#10",
+                        "No Func",
+                        "No Func-vu9q2",
+                        "Mag",
+                        "Blue",
+                        "Green",
+                        "Dimmer"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Mobolazer",
+            "name": "SC-DMX",
+            "shortName": "SC DMX",
+            "physical": {
+                "dimensions": [800, 300, 300],
+                "weight": 15
+            },
+            "availableChannels": {
+                "Scan Rate": {
+                    "type": "Beam",
+                    "defaultValue": 255,
+                    "crossfade": true
+                },
+                "Zoom": {
+                    "type": "Beam",
+                    "defaultValue": 127,
+                    "crossfade": true
+                },
+                "X Gain": {
+                    "type": "Beam",
+                    "defaultValue": 255,
+                    "crossfade": true
+                },
+                "Mod Rate": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Modulation": {
+                    "type": "Beam",
+                    "defaultValue": 127,
+                    "crossfade": true
+                },
+                "Y Gain": {
+                    "type": "Beam",
+                    "defaultValue": 255,
+                    "crossfade": true
+                },
+                "X Position": {
+                    "type": "Beam",
+                    "defaultValue": 127,
+                    "crossfade": true
+                },
+                "Y Position": {
+                    "type": "Beam",
+                    "defaultValue": 127,
+                    "crossfade": true
+                }
+            },
+            "modes": [
+                {
+                    "name": "8-channel Mode",
+                    "shortName": "8ch",
+                    "channels": [
+                        "Scan Rate",
+                        "Zoom",
+                        "X Gain",
+                        "Mod Rate",
+                        "Modulation",
+                        "Y Gain",
+                        "X Position",
+                        "Y Position"
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/fixtures/imports/ecue-MainLibrary/Movitec.json
+++ b/fixtures/imports/ecue-MainLibrary/Movitec.json
@@ -1,0 +1,2987 @@
+{
+    "manufacturers": {
+        "Movitec": {
+            "name": "Movitec",
+            "comment": "???",
+            "website": "http://"
+        }
+    },
+    "fixtures": [
+        {
+            "manufacturer": "Movitec",
+            "name": "SL-250",
+            "shortName": "SL-250",
+            "physical": {
+                "dimensions": [430, 430, 550]
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "highlightValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 0,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "highlightValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 0,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Move": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "Tracking"
+                        },
+                        {
+                            "range": [1, 249],
+                            "name": "Speed"
+                        },
+                        {
+                            "range": [250, 255],
+                            "name": "dbo_change",
+                            "center": true
+                        }
+                    ]
+                },
+                "Control": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "fan_speed"
+                        },
+                        {
+                            "range": [128, 139],
+                            "name": "Lamp_on",
+                            "center": true
+                        },
+                        {
+                            "range": [140, 229],
+                            "name": "nofunction",
+                            "center": true
+                        },
+                        {
+                            "range": [230, 239],
+                            "name": "Lamp_off",
+                            "center": true
+                        },
+                        {
+                            "range": [240, 255],
+                            "name": "nofunction"
+                        }
+                    ]
+                },
+                "Color1": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 9],
+                            "name": "white",
+                            "color": "#ffffff"
+                        },
+                        {
+                            "range": [10, 20],
+                            "name": "UV"
+                        },
+                        {
+                            "range": [21, 31],
+                            "name": "Red",
+                            "color": "#ff0000"
+                        },
+                        {
+                            "range": [32, 41],
+                            "name": "Cyan",
+                            "color": "#00ffff"
+                        },
+                        {
+                            "range": [42, 52],
+                            "name": "Green",
+                            "color": "#00ff00"
+                        },
+                        {
+                            "range": [53, 63],
+                            "name": "Magenta",
+                            "color": "#ca1f7b"
+                        },
+                        {
+                            "range": [64, 73],
+                            "name": "LightBlue",
+                            "color": "#add8e6"
+                        },
+                        {
+                            "range": [74, 84],
+                            "name": "Yellow",
+                            "color": "#ffff00"
+                        },
+                        {
+                            "range": [85, 95],
+                            "name": "Green",
+                            "color": "#00ff00"
+                        },
+                        {
+                            "range": [96, 105],
+                            "name": "Pink",
+                            "color": "#ffc0cb"
+                        },
+                        {
+                            "range": [106, 116],
+                            "name": "Blue",
+                            "color": "#0000ff"
+                        },
+                        {
+                            "range": [117, 127],
+                            "name": "Orange",
+                            "color": "#ff7f00"
+                        },
+                        {
+                            "range": [128, 189],
+                            "name": "rainbow_fw"
+                        },
+                        {
+                            "range": [190, 193],
+                            "name": "no_rot"
+                        },
+                        {
+                            "range": [194, 255],
+                            "name": "rainbow_bw"
+                        }
+                    ]
+                },
+                "Effect": {
+                    "type": "Effect",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 95],
+                            "name": "open"
+                        },
+                        {
+                            "range": [96, 159],
+                            "name": "rot_facet"
+                        },
+                        {
+                            "range": [160, 167],
+                            "name": "macro1"
+                        },
+                        {
+                            "range": [168, 175],
+                            "name": "macro2"
+                        },
+                        {
+                            "range": [176, 183],
+                            "name": "macro3"
+                        },
+                        {
+                            "range": [184, 191],
+                            "name": "macro4"
+                        },
+                        {
+                            "range": [192, 199],
+                            "name": "macro5"
+                        },
+                        {
+                            "range": [200, 207],
+                            "name": "macro6"
+                        },
+                        {
+                            "range": [208, 215],
+                            "name": "macro7"
+                        },
+                        {
+                            "range": [216, 223],
+                            "name": "macro8"
+                        },
+                        {
+                            "range": [224, 231],
+                            "name": "macro9"
+                        },
+                        {
+                            "range": [232, 239],
+                            "name": "macro10"
+                        },
+                        {
+                            "range": [240, 247],
+                            "name": "macro11"
+                        },
+                        {
+                            "range": [248, 255],
+                            "name": "macro12"
+                        }
+                    ]
+                },
+                "Prism": {
+                    "type": "Prism",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "ro_rot"
+                        },
+                        {
+                            "range": [1, 126],
+                            "name": "rot_fw"
+                        },
+                        {
+                            "range": [127, 128],
+                            "name": "no_rot"
+                        },
+                        {
+                            "range": [129, 255],
+                            "name": "rot_bw"
+                        }
+                    ]
+                },
+                "Rot_Gobo": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 31],
+                            "name": "open"
+                        },
+                        {
+                            "range": [32, 63],
+                            "name": "gobo1"
+                        },
+                        {
+                            "range": [64, 95],
+                            "name": "gobo2"
+                        },
+                        {
+                            "range": [96, 127],
+                            "name": "gobo3"
+                        },
+                        {
+                            "range": [160, 191],
+                            "name": "gobo5"
+                        },
+                        {
+                            "range": [192, 223],
+                            "name": "gobo6"
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "cont"
+                        }
+                    ]
+                },
+                "index": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "indexing"
+                        },
+                        {
+                            "range": [128, 190],
+                            "name": "rot_fw"
+                        },
+                        {
+                            "range": [191, 192],
+                            "name": "no_rot"
+                        },
+                        {
+                            "range": [193, 255],
+                            "name": "rot_bw"
+                        }
+                    ]
+                },
+                "Focus": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Shutter": {
+                    "type": "Shutter",
+                    "defaultValue": 40,
+                    "highlightValue": 40,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 31],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [32, 63],
+                            "name": "open"
+                        },
+                        {
+                            "range": [64, 95],
+                            "name": "strobe"
+                        },
+                        {
+                            "range": [96, 127],
+                            "name": "open"
+                        },
+                        {
+                            "range": [128, 159],
+                            "name": "pulse"
+                        },
+                        {
+                            "range": [160, 191],
+                            "name": "open"
+                        },
+                        {
+                            "range": [192, 223],
+                            "name": "random"
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "open"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "16-channel Mode",
+                    "shortName": "16ch",
+                    "channels": [
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "Move",
+                        "Control",
+                        "Color1",
+                        null,
+                        "Effect",
+                        "Prism",
+                        "Rot_Gobo",
+                        "index",
+                        null,
+                        "Focus",
+                        "Shutter",
+                        "Intensity"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Movitec",
+            "name": "SL-300",
+            "shortName": "SL-300",
+            "physical": {
+                "dimensions": [430, 430, 550]
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "highlightValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 0,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "highlightValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 0,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Move": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "Tracking"
+                        },
+                        {
+                            "range": [1, 249],
+                            "name": "Speed"
+                        },
+                        {
+                            "range": [250, 252],
+                            "name": "dbo_change",
+                            "center": true
+                        },
+                        {
+                            "range": [253, 255],
+                            "name": "dbo_move"
+                        }
+                    ]
+                },
+                "Control": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "fan_speed"
+                        },
+                        {
+                            "range": [128, 139],
+                            "name": "Lamp_on",
+                            "center": true
+                        },
+                        {
+                            "range": [140, 229],
+                            "name": "nofunction",
+                            "center": true
+                        },
+                        {
+                            "range": [230, 239],
+                            "name": "Lamp_off",
+                            "center": true
+                        },
+                        {
+                            "range": [240, 255],
+                            "name": "nofunction"
+                        }
+                    ]
+                },
+                "Color1": {
+                    "type": "MultiColor",
+                    "capabilities": [
+                        {
+                            "range": [0, 16],
+                            "name": "white",
+                            "color": "#ffffff"
+                        },
+                        {
+                            "range": [16, 32],
+                            "name": "blue",
+                            "color": "#0000ff"
+                        },
+                        {
+                            "range": [32, 48],
+                            "name": "red",
+                            "color": "#ff0000"
+                        },
+                        {
+                            "range": [48, 64],
+                            "name": "green",
+                            "color": "#00ff00"
+                        },
+                        {
+                            "range": [64, 80],
+                            "name": "yellow",
+                            "color": "#ffff00"
+                        },
+                        {
+                            "range": [80, 96],
+                            "name": "magenta",
+                            "color": "#ca1f7b"
+                        },
+                        {
+                            "range": [112, 128],
+                            "name": "light_green"
+                        },
+                        {
+                            "range": [128, 189],
+                            "name": "rainbow_ff"
+                        },
+                        {
+                            "range": [190, 193],
+                            "name": "no_rot",
+                            "center": true
+                        },
+                        {
+                            "range": [194, 255],
+                            "name": "rainbow_bw"
+                        }
+                    ]
+                },
+                "Color2": {
+                    "type": "MultiColor",
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "white",
+                            "color": "#ffffff"
+                        },
+                        {
+                            "range": [16, 35],
+                            "name": "light_blue",
+                            "center": true
+                        },
+                        {
+                            "range": [36, 51],
+                            "name": "pink",
+                            "color": "#ffc0cb",
+                            "center": true
+                        },
+                        {
+                            "range": [52, 71],
+                            "name": "umber",
+                            "color": "#635147",
+                            "center": true
+                        },
+                        {
+                            "range": [72, 87],
+                            "name": "gobo1",
+                            "center": true
+                        },
+                        {
+                            "range": [88, 107],
+                            "name": "gobo2",
+                            "center": true
+                        },
+                        {
+                            "range": [108, 127],
+                            "name": "gobo3",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 191],
+                            "name": "enable_macro",
+                            "center": true
+                        },
+                        {
+                            "range": [192, 193],
+                            "name": "no_rot"
+                        },
+                        {
+                            "range": [194, 255],
+                            "name": "rainbow"
+                        }
+                    ]
+                },
+                "Effect": {
+                    "type": "Effect",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 95],
+                            "name": "open"
+                        },
+                        {
+                            "range": [96, 159],
+                            "name": "rot_facet"
+                        },
+                        {
+                            "range": [160, 167],
+                            "name": "macro1"
+                        },
+                        {
+                            "range": [168, 175],
+                            "name": "macro2"
+                        },
+                        {
+                            "range": [176, 183],
+                            "name": "macro3"
+                        },
+                        {
+                            "range": [184, 191],
+                            "name": "macro4"
+                        },
+                        {
+                            "range": [192, 199],
+                            "name": "macro5"
+                        },
+                        {
+                            "range": [200, 207],
+                            "name": "macro6"
+                        },
+                        {
+                            "range": [208, 215],
+                            "name": "macro7"
+                        },
+                        {
+                            "range": [216, 223],
+                            "name": "macro8"
+                        },
+                        {
+                            "range": [224, 231],
+                            "name": "macro9"
+                        },
+                        {
+                            "range": [232, 239],
+                            "name": "macro10"
+                        },
+                        {
+                            "range": [240, 247],
+                            "name": "macro11"
+                        },
+                        {
+                            "range": [248, 255],
+                            "name": "macro12"
+                        }
+                    ]
+                },
+                "Prism": {
+                    "type": "Prism",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "ro_rot"
+                        },
+                        {
+                            "range": [1, 126],
+                            "name": "rot_fw"
+                        },
+                        {
+                            "range": [127, 128],
+                            "name": "no_rot"
+                        },
+                        {
+                            "range": [129, 255],
+                            "name": "rot_bw"
+                        }
+                    ]
+                },
+                "Rot_Gobo": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 31],
+                            "name": "open"
+                        },
+                        {
+                            "range": [32, 63],
+                            "name": "gobo1"
+                        },
+                        {
+                            "range": [64, 95],
+                            "name": "gobo2"
+                        },
+                        {
+                            "range": [96, 127],
+                            "name": "gobo3"
+                        },
+                        {
+                            "range": [160, 191],
+                            "name": "gobo5"
+                        },
+                        {
+                            "range": [192, 223],
+                            "name": "gobo6"
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "cont"
+                        }
+                    ]
+                },
+                "index": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "indexing"
+                        },
+                        {
+                            "range": [128, 190],
+                            "name": "rot_fw"
+                        },
+                        {
+                            "range": [191, 192],
+                            "name": "no_rot"
+                        },
+                        {
+                            "range": [193, 255],
+                            "name": "rot_bw"
+                        }
+                    ]
+                },
+                "Zoom": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 95],
+                            "name": "without_focus"
+                        },
+                        {
+                            "range": [96, 111],
+                            "name": "frost",
+                            "color": "#edf5dd"
+                        },
+                        {
+                            "range": [112, 127],
+                            "name": "UV"
+                        },
+                        {
+                            "range": [128, 223],
+                            "name": "with_focus"
+                        },
+                        {
+                            "range": [224, 239],
+                            "name": "frost",
+                            "color": "#edf5dd"
+                        },
+                        {
+                            "range": [240, 255],
+                            "name": "UV"
+                        }
+                    ]
+                },
+                "Focus": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Shutter": {
+                    "type": "Shutter",
+                    "defaultValue": 40,
+                    "highlightValue": 40,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 31],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [32, 63],
+                            "name": "open"
+                        },
+                        {
+                            "range": [64, 95],
+                            "name": "strobe"
+                        },
+                        {
+                            "range": [96, 127],
+                            "name": "open"
+                        },
+                        {
+                            "range": [128, 159],
+                            "name": "pulse"
+                        },
+                        {
+                            "range": [160, 191],
+                            "name": "open"
+                        },
+                        {
+                            "range": [192, 223],
+                            "name": "random"
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "open"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "16-channel Mode",
+                    "shortName": "16ch",
+                    "channels": [
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "Move",
+                        "Control",
+                        "Color1",
+                        "Color2",
+                        "Effect",
+                        "Prism",
+                        "Rot_Gobo",
+                        "index",
+                        "Zoom",
+                        "Focus",
+                        "Shutter",
+                        "Intensity"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Movitec",
+            "name": "SL-350",
+            "shortName": "SL-350",
+            "physical": {
+                "dimensions": [430, 430, 550]
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "highlightValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 0,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "highlightValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 0,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Move": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "Tracking"
+                        },
+                        {
+                            "range": [1, 249],
+                            "name": "Speed"
+                        },
+                        {
+                            "range": [250, 252],
+                            "name": "dbo_change",
+                            "center": true
+                        },
+                        {
+                            "range": [253, 255],
+                            "name": "dbo_move"
+                        }
+                    ]
+                },
+                "Control": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "fan_speed"
+                        },
+                        {
+                            "range": [128, 139],
+                            "name": "Lamp_on",
+                            "center": true
+                        },
+                        {
+                            "range": [140, 229],
+                            "name": "nofunction",
+                            "center": true
+                        },
+                        {
+                            "range": [230, 239],
+                            "name": "Lamp_off",
+                            "center": true
+                        },
+                        {
+                            "range": [240, 255],
+                            "name": "nofunction"
+                        }
+                    ]
+                },
+                "Color1": {
+                    "type": "MultiColor",
+                    "capabilities": [
+                        {
+                            "range": [0, 16],
+                            "name": "white",
+                            "color": "#ffffff"
+                        },
+                        {
+                            "range": [16, 32],
+                            "name": "blue",
+                            "color": "#0000ff"
+                        },
+                        {
+                            "range": [32, 48],
+                            "name": "red",
+                            "color": "#ff0000"
+                        },
+                        {
+                            "range": [48, 64],
+                            "name": "green",
+                            "color": "#00ff00"
+                        },
+                        {
+                            "range": [64, 80],
+                            "name": "yellow",
+                            "color": "#ffff00"
+                        },
+                        {
+                            "range": [80, 96],
+                            "name": "magenta",
+                            "color": "#ca1f7b"
+                        },
+                        {
+                            "range": [112, 128],
+                            "name": "light_green"
+                        },
+                        {
+                            "range": [128, 189],
+                            "name": "rainbow_ff"
+                        },
+                        {
+                            "range": [190, 193],
+                            "name": "no_rot",
+                            "center": true
+                        },
+                        {
+                            "range": [194, 255],
+                            "name": "rainbow_bw"
+                        }
+                    ]
+                },
+                "Color2": {
+                    "type": "MultiColor",
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "white",
+                            "color": "#ffffff"
+                        },
+                        {
+                            "range": [16, 35],
+                            "name": "light_blue",
+                            "center": true
+                        },
+                        {
+                            "range": [36, 51],
+                            "name": "pink",
+                            "color": "#ffc0cb",
+                            "center": true
+                        },
+                        {
+                            "range": [52, 71],
+                            "name": "umber",
+                            "color": "#635147",
+                            "center": true
+                        },
+                        {
+                            "range": [72, 87],
+                            "name": "gobo1",
+                            "center": true
+                        },
+                        {
+                            "range": [88, 107],
+                            "name": "gobo2",
+                            "center": true
+                        },
+                        {
+                            "range": [108, 127],
+                            "name": "gobo3",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 191],
+                            "name": "enable_macro",
+                            "center": true
+                        },
+                        {
+                            "range": [192, 193],
+                            "name": "no_rot"
+                        },
+                        {
+                            "range": [194, 255],
+                            "name": "rainbow"
+                        }
+                    ]
+                },
+                "Effect": {
+                    "type": "Effect",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 95],
+                            "name": "open"
+                        },
+                        {
+                            "range": [96, 159],
+                            "name": "rot_facet"
+                        },
+                        {
+                            "range": [160, 167],
+                            "name": "macro1"
+                        },
+                        {
+                            "range": [168, 175],
+                            "name": "macro2"
+                        },
+                        {
+                            "range": [176, 183],
+                            "name": "macro3"
+                        },
+                        {
+                            "range": [184, 191],
+                            "name": "macro4"
+                        },
+                        {
+                            "range": [192, 199],
+                            "name": "macro5"
+                        },
+                        {
+                            "range": [200, 207],
+                            "name": "macro6"
+                        },
+                        {
+                            "range": [208, 215],
+                            "name": "macro7"
+                        },
+                        {
+                            "range": [216, 223],
+                            "name": "macro8"
+                        },
+                        {
+                            "range": [224, 231],
+                            "name": "macro9"
+                        },
+                        {
+                            "range": [232, 239],
+                            "name": "macro10"
+                        },
+                        {
+                            "range": [240, 247],
+                            "name": "macro11"
+                        },
+                        {
+                            "range": [248, 255],
+                            "name": "macro12"
+                        }
+                    ]
+                },
+                "Prism": {
+                    "type": "Prism",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "ro_rot"
+                        },
+                        {
+                            "range": [1, 126],
+                            "name": "rot_fw"
+                        },
+                        {
+                            "range": [127, 128],
+                            "name": "no_rot"
+                        },
+                        {
+                            "range": [129, 255],
+                            "name": "rot_bw"
+                        }
+                    ]
+                },
+                "Rot_Gobo": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 31],
+                            "name": "open"
+                        },
+                        {
+                            "range": [32, 63],
+                            "name": "gobo1"
+                        },
+                        {
+                            "range": [64, 95],
+                            "name": "gobo2"
+                        },
+                        {
+                            "range": [96, 127],
+                            "name": "gobo3"
+                        },
+                        {
+                            "range": [160, 191],
+                            "name": "gobo5"
+                        },
+                        {
+                            "range": [192, 223],
+                            "name": "gobo6"
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "cont"
+                        }
+                    ]
+                },
+                "index": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "indexing"
+                        },
+                        {
+                            "range": [128, 190],
+                            "name": "rot_fw"
+                        },
+                        {
+                            "range": [191, 192],
+                            "name": "no_rot"
+                        },
+                        {
+                            "range": [193, 255],
+                            "name": "rot_bw"
+                        }
+                    ]
+                },
+                "Zoom": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 95],
+                            "name": "without_focus"
+                        },
+                        {
+                            "range": [96, 111],
+                            "name": "frost",
+                            "color": "#edf5dd"
+                        },
+                        {
+                            "range": [112, 127],
+                            "name": "UV"
+                        },
+                        {
+                            "range": [128, 223],
+                            "name": "with_focus"
+                        },
+                        {
+                            "range": [224, 239],
+                            "name": "frost",
+                            "color": "#edf5dd"
+                        },
+                        {
+                            "range": [240, 255],
+                            "name": "UV"
+                        }
+                    ]
+                },
+                "Focus": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Shutter": {
+                    "type": "Shutter",
+                    "defaultValue": 40,
+                    "highlightValue": 40,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 31],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [32, 63],
+                            "name": "open"
+                        },
+                        {
+                            "range": [64, 95],
+                            "name": "strobe"
+                        },
+                        {
+                            "range": [96, 127],
+                            "name": "open"
+                        },
+                        {
+                            "range": [128, 159],
+                            "name": "pulse"
+                        },
+                        {
+                            "range": [160, 191],
+                            "name": "open"
+                        },
+                        {
+                            "range": [192, 223],
+                            "name": "random"
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "open"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "16-channel Mode",
+                    "shortName": "16ch",
+                    "channels": [
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "Move",
+                        "Control",
+                        "Color1",
+                        "Color2",
+                        "Effect",
+                        "Prism",
+                        "Rot_Gobo",
+                        "index",
+                        "Zoom",
+                        "Focus",
+                        "Shutter",
+                        "Intensity"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Movitec",
+            "name": "SL-575",
+            "shortName": "SL-575",
+            "physical": {
+                "dimensions": [550, 550, 700],
+                "weight": 33
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "highlightValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 0,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "highlightValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 0,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Move": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "Tracking"
+                        },
+                        {
+                            "range": [1, 249],
+                            "name": "Speed"
+                        },
+                        {
+                            "range": [250, 252],
+                            "name": "dbo_color_ch",
+                            "center": true
+                        },
+                        {
+                            "range": [253, 255],
+                            "name": "dbo_change",
+                            "center": true
+                        }
+                    ]
+                },
+                "Control": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "fan_speed"
+                        },
+                        {
+                            "range": [128, 139],
+                            "name": "Lamp_on",
+                            "center": true
+                        },
+                        {
+                            "range": [140, 229],
+                            "name": "nofunction",
+                            "center": true
+                        },
+                        {
+                            "range": [230, 239],
+                            "name": "Lamp_off",
+                            "center": true
+                        },
+                        {
+                            "range": [240, 255],
+                            "name": "nofunction"
+                        }
+                    ]
+                },
+                "Color1": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 12],
+                            "name": "white",
+                            "color": "#ffffff"
+                        },
+                        {
+                            "range": [13, 25],
+                            "name": "lightblue",
+                            "color": "#add8e6"
+                        },
+                        {
+                            "range": [26, 37],
+                            "name": "red",
+                            "color": "#ff0000"
+                        },
+                        {
+                            "range": [38, 50],
+                            "name": "blue",
+                            "color": "#0000ff"
+                        },
+                        {
+                            "range": [51, 63],
+                            "name": "lightgreen",
+                            "color": "#90ee90"
+                        },
+                        {
+                            "range": [64, 76],
+                            "name": "yellow",
+                            "color": "#ffff00"
+                        },
+                        {
+                            "range": [77, 89],
+                            "name": "magenta",
+                            "color": "#ca1f7b"
+                        },
+                        {
+                            "range": [90, 101],
+                            "name": "cyan",
+                            "color": "#00ffff"
+                        },
+                        {
+                            "range": [102, 114],
+                            "name": "green",
+                            "color": "#00ff00"
+                        },
+                        {
+                            "range": [115, 127],
+                            "name": "orange",
+                            "color": "#ff7f00"
+                        },
+                        {
+                            "range": [128, 190],
+                            "name": "rainbow_fw"
+                        },
+                        {
+                            "range": [191, 193],
+                            "name": "no_rot"
+                        },
+                        {
+                            "range": [194, 255],
+                            "name": "rainbow_bw"
+                        }
+                    ]
+                },
+                "Color2": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [12, 23],
+                            "name": "red",
+                            "color": "#ff0000"
+                        },
+                        {
+                            "range": [24, 35],
+                            "name": "blue",
+                            "color": "#0000ff"
+                        },
+                        {
+                            "range": [36, 47],
+                            "name": "pink",
+                            "color": "#ffc0cb"
+                        },
+                        {
+                            "range": [48, 59],
+                            "name": "cyan",
+                            "color": "#00ffff"
+                        },
+                        {
+                            "range": [60, 71],
+                            "name": "magenta",
+                            "color": "#ca1f7b"
+                        },
+                        {
+                            "range": [72, 83],
+                            "name": "yellow",
+                            "color": "#ffff00"
+                        },
+                        {
+                            "range": [84, 95],
+                            "name": "5600k"
+                        },
+                        {
+                            "range": [96, 107],
+                            "name": "3200k"
+                        },
+                        {
+                            "range": [108, 119],
+                            "name": "UV"
+                        },
+                        {
+                            "range": [128, 255],
+                            "name": "macro_col"
+                        },
+                        {
+                            "range": [0, 11],
+                            "name": "white",
+                            "color": "#ffffff"
+                        }
+                    ]
+                },
+                "Gobo": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "open"
+                        },
+                        {
+                            "range": [1, 63],
+                            "name": "rot_fw"
+                        },
+                        {
+                            "range": [64, 64],
+                            "name": "no_rot"
+                        },
+                        {
+                            "range": [65, 127],
+                            "name": "rot_bw"
+                        },
+                        {
+                            "range": [128, 135],
+                            "name": "macro1"
+                        },
+                        {
+                            "range": [136, 143],
+                            "name": "macro2"
+                        },
+                        {
+                            "range": [144, 151],
+                            "name": "macro3"
+                        },
+                        {
+                            "range": [152, 159],
+                            "name": "macro4"
+                        },
+                        {
+                            "range": [160, 167],
+                            "name": "macro5"
+                        },
+                        {
+                            "range": [168, 175],
+                            "name": "macro6"
+                        },
+                        {
+                            "range": [176, 183],
+                            "name": "macro7"
+                        },
+                        {
+                            "range": [184, 191],
+                            "name": "macro8"
+                        },
+                        {
+                            "range": [192, 199],
+                            "name": "macro9"
+                        },
+                        {
+                            "range": [200, 207],
+                            "name": "macro10"
+                        },
+                        {
+                            "range": [208, 215],
+                            "name": "macro11"
+                        },
+                        {
+                            "range": [216, 223],
+                            "name": "macro12"
+                        },
+                        {
+                            "range": [224, 231],
+                            "name": "macro13"
+                        },
+                        {
+                            "range": [232, 239],
+                            "name": "macro14"
+                        },
+                        {
+                            "range": [240, 247],
+                            "name": "macro15"
+                        },
+                        {
+                            "range": [248, 255],
+                            "name": "macro16"
+                        }
+                    ]
+                },
+                "static": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 7],
+                            "name": "open"
+                        },
+                        {
+                            "range": [8, 15],
+                            "name": "gobo1"
+                        },
+                        {
+                            "range": [16, 23],
+                            "name": "gobo2"
+                        },
+                        {
+                            "range": [24, 31],
+                            "name": "gobo3"
+                        },
+                        {
+                            "range": [32, 39],
+                            "name": "gobo4"
+                        },
+                        {
+                            "range": [40, 47],
+                            "name": "gobo5"
+                        },
+                        {
+                            "range": [48, 55],
+                            "name": "gobo6"
+                        },
+                        {
+                            "range": [56, 63],
+                            "name": "gobo7"
+                        },
+                        {
+                            "range": [64, 71],
+                            "name": "gobo8"
+                        },
+                        {
+                            "range": [72, 79],
+                            "name": "gobo9"
+                        },
+                        {
+                            "range": [80, 95],
+                            "name": "gobo1_sh"
+                        },
+                        {
+                            "range": [96, 111],
+                            "name": "gobo2_sh"
+                        },
+                        {
+                            "range": [112, 127],
+                            "name": "gobo3_sh"
+                        },
+                        {
+                            "range": [128, 143],
+                            "name": "gobo4_sh"
+                        },
+                        {
+                            "range": [144, 159],
+                            "name": "gobo5_sh"
+                        },
+                        {
+                            "range": [160, 175],
+                            "name": "gobo6_sh"
+                        },
+                        {
+                            "range": [176, 191],
+                            "name": "gobo7_sh"
+                        },
+                        {
+                            "range": [192, 207],
+                            "name": "gobo8_sh"
+                        },
+                        {
+                            "range": [208, 223],
+                            "name": "gobo9_sh"
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "rot"
+                        }
+                    ]
+                },
+                "Rot_Gobo": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 31],
+                            "name": "open"
+                        },
+                        {
+                            "range": [32, 63],
+                            "name": "gobo1"
+                        },
+                        {
+                            "range": [64, 95],
+                            "name": "gobo2"
+                        },
+                        {
+                            "range": [96, 127],
+                            "name": "gobo3"
+                        },
+                        {
+                            "range": [128, 159],
+                            "name": "gobo4"
+                        },
+                        {
+                            "range": [160, 191],
+                            "name": "gobo5"
+                        },
+                        {
+                            "range": [192, 223],
+                            "name": "gobo6"
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "cont"
+                        }
+                    ]
+                },
+                "index": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "indexing"
+                        },
+                        {
+                            "range": [128, 190],
+                            "name": "rot_fw"
+                        },
+                        {
+                            "range": [191, 192],
+                            "name": "no_rot"
+                        },
+                        {
+                            "range": [193, 255],
+                            "name": "rot_bw"
+                        }
+                    ]
+                },
+                "Iris": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "open"
+                        },
+                        {
+                            "range": [1, 179],
+                            "name": "diameter"
+                        },
+                        {
+                            "range": [180, 191],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [192, 223],
+                            "name": "pulse_cl"
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "pulse_op"
+                        }
+                    ]
+                },
+                "Zoom": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Shutter": {
+                    "type": "Shutter",
+                    "defaultValue": 40,
+                    "highlightValue": 40,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 31],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [32, 63],
+                            "name": "open"
+                        },
+                        {
+                            "range": [64, 95],
+                            "name": "strobe"
+                        },
+                        {
+                            "range": [96, 127],
+                            "name": "open"
+                        },
+                        {
+                            "range": [128, 159],
+                            "name": "pulse"
+                        },
+                        {
+                            "range": [160, 191],
+                            "name": "open"
+                        },
+                        {
+                            "range": [192, 223],
+                            "name": "random"
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "open"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "16-channel Mode",
+                    "shortName": "16ch",
+                    "channels": [
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "Move",
+                        "Control",
+                        "Color1",
+                        "Color2",
+                        "Gobo",
+                        "static",
+                        "Rot_Gobo",
+                        "index",
+                        "Iris",
+                        "Zoom",
+                        "Shutter",
+                        "Intensity"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Movitec",
+            "name": "Washlight 250",
+            "shortName": "WL-250",
+            "comment": "http://www.esl-france.com/SHARED/TELECHARGEMENT/MANUELS/ANGLAIS/MOVITEC/WL250_USER_UK.PDF",
+            "physical": {
+                "dimensions": [430, 430, 550]
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "highlightValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 0,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "highlightValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 0,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Move": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "Tracking"
+                        },
+                        {
+                            "range": [1, 249],
+                            "name": "Speed"
+                        },
+                        {
+                            "range": [250, 252],
+                            "name": "dbo_color_ch",
+                            "center": true
+                        },
+                        {
+                            "range": [253, 255],
+                            "name": "dbo_change",
+                            "center": true
+                        }
+                    ]
+                },
+                "Control": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "fan_speed"
+                        },
+                        {
+                            "range": [128, 139],
+                            "name": "Lamp_on",
+                            "center": true
+                        },
+                        {
+                            "range": [140, 229],
+                            "name": "nofunction",
+                            "center": true
+                        },
+                        {
+                            "range": [230, 239],
+                            "name": "Lamp_off",
+                            "center": true
+                        },
+                        {
+                            "range": [240, 255],
+                            "name": "nofunction",
+                            "center": true
+                        }
+                    ]
+                },
+                "Color": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 17],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [18, 35],
+                            "name": "Red",
+                            "color": "#ff0000"
+                        },
+                        {
+                            "range": [36, 53],
+                            "name": "Blue",
+                            "color": "#0000ff"
+                        },
+                        {
+                            "range": [54, 72],
+                            "name": "Green",
+                            "color": "#00ff00"
+                        },
+                        {
+                            "range": [73, 90],
+                            "name": "3200k"
+                        },
+                        {
+                            "range": [91, 108],
+                            "name": "5600k"
+                        },
+                        {
+                            "range": [109, 127],
+                            "name": "UV"
+                        },
+                        {
+                            "range": [128, 190],
+                            "name": "Rainbow_fw"
+                        },
+                        {
+                            "range": [191, 192],
+                            "name": "no_rot"
+                        },
+                        {
+                            "range": [193, 255],
+                            "name": "Rainbow_rv"
+                        }
+                    ]
+                },
+                "Cyan": {
+                    "type": "SingleColor",
+                    "color": "Cyan",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Magenta": {
+                    "type": "SingleColor",
+                    "color": "Magenta",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Yellow": {
+                    "type": "SingleColor",
+                    "color": "Yellow",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Speed": {
+                    "type": "Speed",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "macro": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 7],
+                            "name": "off",
+                            "center": true
+                        },
+                        {
+                            "range": [8, 15],
+                            "name": "macro1",
+                            "center": true
+                        },
+                        {
+                            "range": [16, 23],
+                            "name": "macro2",
+                            "center": true
+                        },
+                        {
+                            "range": [24, 31],
+                            "name": "macro3",
+                            "center": true
+                        },
+                        {
+                            "range": [32, 39],
+                            "name": "macro4",
+                            "center": true
+                        },
+                        {
+                            "range": [40, 47],
+                            "name": "macro5",
+                            "center": true
+                        },
+                        {
+                            "range": [48, 55],
+                            "name": "macro6",
+                            "center": true
+                        },
+                        {
+                            "range": [56, 63],
+                            "name": "macro7",
+                            "center": true
+                        },
+                        {
+                            "range": [64, 71],
+                            "name": "macro8",
+                            "center": true
+                        },
+                        {
+                            "range": [72, 79],
+                            "name": "macro9",
+                            "center": true
+                        },
+                        {
+                            "range": [80, 87],
+                            "name": "macro10",
+                            "center": true
+                        },
+                        {
+                            "range": [88, 95],
+                            "name": "macro11",
+                            "center": true
+                        },
+                        {
+                            "range": [96, 103],
+                            "name": "macro12",
+                            "center": true
+                        },
+                        {
+                            "range": [104, 111],
+                            "name": "macro13",
+                            "center": true
+                        },
+                        {
+                            "range": [112, 119],
+                            "name": "macro14",
+                            "center": true
+                        },
+                        {
+                            "range": [120, 127],
+                            "name": "macro15",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 135],
+                            "name": "macro16",
+                            "center": true
+                        },
+                        {
+                            "range": [136, 143],
+                            "name": "macro17",
+                            "center": true
+                        },
+                        {
+                            "range": [144, 151],
+                            "name": "macro18",
+                            "center": true
+                        },
+                        {
+                            "range": [152, 159],
+                            "name": "macro19",
+                            "center": true
+                        },
+                        {
+                            "range": [160, 167],
+                            "name": "macro20",
+                            "center": true
+                        },
+                        {
+                            "range": [168, 175],
+                            "name": "macro21",
+                            "center": true
+                        },
+                        {
+                            "range": [176, 183],
+                            "name": "macro22",
+                            "center": true
+                        },
+                        {
+                            "range": [184, 191],
+                            "name": "macro23",
+                            "center": true
+                        },
+                        {
+                            "range": [192, 199],
+                            "name": "macro24",
+                            "center": true
+                        },
+                        {
+                            "range": [200, 207],
+                            "name": "macro25",
+                            "center": true
+                        },
+                        {
+                            "range": [208, 215],
+                            "name": "macro26",
+                            "center": true
+                        },
+                        {
+                            "range": [216, 223],
+                            "name": "macro27",
+                            "center": true
+                        },
+                        {
+                            "range": [224, 231],
+                            "name": "macro28",
+                            "center": true
+                        },
+                        {
+                            "range": [232, 239],
+                            "name": "macro29",
+                            "center": true
+                        },
+                        {
+                            "range": [240, 247],
+                            "name": "macro30",
+                            "center": true
+                        },
+                        {
+                            "range": [248, 255],
+                            "name": "macro31",
+                            "center": true
+                        }
+                    ]
+                },
+                "Effects": {
+                    "type": "Effect",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 70],
+                            "name": "Fullbeam"
+                        },
+                        {
+                            "range": [71, 230],
+                            "name": "Beam shaper"
+                        },
+                        {
+                            "range": [231, 255],
+                            "name": "Frost",
+                            "color": "#edf5dd"
+                        }
+                    ]
+                },
+                "Shutter": {
+                    "type": "Shutter",
+                    "defaultValue": 40,
+                    "highlightValue": 40,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 31],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [32, 63],
+                            "name": "open"
+                        },
+                        {
+                            "range": [64, 95],
+                            "name": "effect"
+                        },
+                        {
+                            "range": [96, 127],
+                            "name": "open"
+                        },
+                        {
+                            "range": [128, 159],
+                            "name": "pulse"
+                        },
+                        {
+                            "range": [160, 191],
+                            "name": "open"
+                        },
+                        {
+                            "range": [192, 223],
+                            "name": "random"
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "open"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "16-channel Mode",
+                    "shortName": "16ch",
+                    "channels": [
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "Move",
+                        "Control",
+                        "Color",
+                        "Cyan",
+                        "Magenta",
+                        "Yellow",
+                        "Speed",
+                        "macro",
+                        "Effects",
+                        null,
+                        "Shutter",
+                        "Intensity"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Movitec",
+            "name": "Washlight 575",
+            "shortName": "WL-575",
+            "physical": {
+                "dimensions": [550, 550, 700]
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Move": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "Tracking"
+                        },
+                        {
+                            "range": [1, 249],
+                            "name": "Speed"
+                        },
+                        {
+                            "range": [250, 252],
+                            "name": "dbo_color_ch",
+                            "center": true
+                        },
+                        {
+                            "range": [253, 255],
+                            "name": "dbo_change",
+                            "center": true
+                        }
+                    ]
+                },
+                "Control": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "fan_speed"
+                        },
+                        {
+                            "range": [128, 139],
+                            "name": "Lamp_on",
+                            "center": true
+                        },
+                        {
+                            "range": [140, 229],
+                            "name": "nofunction",
+                            "center": true
+                        },
+                        {
+                            "range": [230, 239],
+                            "name": "Lamp_off",
+                            "center": true
+                        },
+                        {
+                            "range": [240, 255],
+                            "name": "nofunction",
+                            "center": true
+                        }
+                    ]
+                },
+                "Color": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [16, 31],
+                            "name": "Red",
+                            "color": "#ff0000"
+                        },
+                        {
+                            "range": [32, 47],
+                            "name": "Blue",
+                            "color": "#0000ff"
+                        },
+                        {
+                            "range": [48, 63],
+                            "name": "Green",
+                            "color": "#00ff00"
+                        },
+                        {
+                            "range": [64, 79],
+                            "name": "Orange",
+                            "color": "#ff7f00"
+                        },
+                        {
+                            "range": [80, 95],
+                            "name": "3200k"
+                        },
+                        {
+                            "range": [96, 111],
+                            "name": "5600k"
+                        },
+                        {
+                            "range": [112, 127],
+                            "name": "UV"
+                        },
+                        {
+                            "range": [128, 190],
+                            "name": "Rainbow_fw"
+                        },
+                        {
+                            "range": [191, 192],
+                            "name": "no_rot"
+                        },
+                        {
+                            "range": [193, 255],
+                            "name": "Rainbow_rv"
+                        }
+                    ]
+                },
+                "Cyan": {
+                    "type": "SingleColor",
+                    "color": "Cyan",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Magenta": {
+                    "type": "SingleColor",
+                    "color": "Magenta",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Yellow": {
+                    "type": "SingleColor",
+                    "color": "Yellow",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Speed": {
+                    "type": "Speed",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "macro": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 7],
+                            "name": "off",
+                            "center": true
+                        },
+                        {
+                            "range": [8, 15],
+                            "name": "macro1",
+                            "center": true
+                        },
+                        {
+                            "range": [16, 23],
+                            "name": "macro2",
+                            "center": true
+                        },
+                        {
+                            "range": [24, 31],
+                            "name": "macro3",
+                            "center": true
+                        },
+                        {
+                            "range": [32, 39],
+                            "name": "macro4",
+                            "center": true
+                        },
+                        {
+                            "range": [40, 47],
+                            "name": "macro5",
+                            "center": true
+                        },
+                        {
+                            "range": [48, 55],
+                            "name": "macro6",
+                            "center": true
+                        },
+                        {
+                            "range": [56, 63],
+                            "name": "macro7",
+                            "center": true
+                        },
+                        {
+                            "range": [64, 71],
+                            "name": "macro8",
+                            "center": true
+                        },
+                        {
+                            "range": [72, 79],
+                            "name": "macro9",
+                            "center": true
+                        },
+                        {
+                            "range": [80, 87],
+                            "name": "macro10",
+                            "center": true
+                        },
+                        {
+                            "range": [88, 95],
+                            "name": "macro11",
+                            "center": true
+                        },
+                        {
+                            "range": [96, 103],
+                            "name": "macro12",
+                            "center": true
+                        },
+                        {
+                            "range": [104, 111],
+                            "name": "macro13",
+                            "center": true
+                        },
+                        {
+                            "range": [112, 119],
+                            "name": "macro14",
+                            "center": true
+                        },
+                        {
+                            "range": [120, 127],
+                            "name": "macro15",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 135],
+                            "name": "macro16",
+                            "center": true
+                        },
+                        {
+                            "range": [136, 143],
+                            "name": "macro17",
+                            "center": true
+                        },
+                        {
+                            "range": [144, 151],
+                            "name": "macro18",
+                            "center": true
+                        },
+                        {
+                            "range": [152, 159],
+                            "name": "macro19",
+                            "center": true
+                        },
+                        {
+                            "range": [160, 167],
+                            "name": "macro20",
+                            "center": true
+                        },
+                        {
+                            "range": [168, 175],
+                            "name": "macro21",
+                            "center": true
+                        },
+                        {
+                            "range": [176, 183],
+                            "name": "macro22",
+                            "center": true
+                        },
+                        {
+                            "range": [184, 191],
+                            "name": "macro23",
+                            "center": true
+                        },
+                        {
+                            "range": [192, 199],
+                            "name": "macro24",
+                            "center": true
+                        },
+                        {
+                            "range": [200, 207],
+                            "name": "macro25",
+                            "center": true
+                        },
+                        {
+                            "range": [208, 215],
+                            "name": "macro26",
+                            "center": true
+                        },
+                        {
+                            "range": [216, 223],
+                            "name": "macro27",
+                            "center": true
+                        },
+                        {
+                            "range": [224, 231],
+                            "name": "macro28",
+                            "center": true
+                        },
+                        {
+                            "range": [232, 239],
+                            "name": "macro29",
+                            "center": true
+                        },
+                        {
+                            "range": [240, 247],
+                            "name": "macro30",
+                            "center": true
+                        },
+                        {
+                            "range": [248, 255],
+                            "name": "macro31",
+                            "center": true
+                        }
+                    ]
+                },
+                "Effects": {
+                    "type": "Effect",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 70],
+                            "name": "Fullbeam"
+                        },
+                        {
+                            "range": [71, 180],
+                            "name": "Beam shaper"
+                        },
+                        {
+                            "range": [181, 255],
+                            "name": "Frost",
+                            "color": "#edf5dd"
+                        }
+                    ]
+                },
+                "Zoom": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Shutter": {
+                    "type": "Shutter",
+                    "defaultValue": 40,
+                    "highlightValue": 40,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 31],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [32, 63],
+                            "name": "open"
+                        },
+                        {
+                            "range": [64, 95],
+                            "name": "effect"
+                        },
+                        {
+                            "range": [96, 127],
+                            "name": "open"
+                        },
+                        {
+                            "range": [128, 159],
+                            "name": "pulse"
+                        },
+                        {
+                            "range": [160, 191],
+                            "name": "open"
+                        },
+                        {
+                            "range": [192, 223],
+                            "name": "random"
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "open"
+                        }
+                    ]
+                },
+                "Intensitiy": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "16-channel Mode",
+                    "shortName": "16ch",
+                    "channels": [
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "Move",
+                        "Control",
+                        "Color",
+                        "Cyan",
+                        "Magenta",
+                        "Yellow",
+                        "Speed",
+                        "macro",
+                        "Effects",
+                        "Zoom",
+                        "Shutter",
+                        "Intensitiy"
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/fixtures/imports/ecue-MainLibrary/NSI.json
+++ b/fixtures/imports/ecue-MainLibrary/NSI.json
@@ -1,0 +1,84 @@
+{
+    "manufacturers": {
+        "NSI": {
+            "name": "NSI",
+            "website": "http://www.leviton.com"
+        }
+    },
+    "fixtures": [
+        {
+            "manufacturer": "NSI",
+            "name": "MLC 16",
+            "shortName": "MLC16",
+            "comment": "DMX In control of Console http://www.leviton.com",
+            "physical": {
+                "dimensions": [600, 400, 12],
+                "weight": 10.5
+            },
+            "availableChannels": {
+                "Bit 1": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "crossfade": true
+                },
+                "Bit 2": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "crossfade": true
+                },
+                "Bit 3": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "crossfade": true
+                },
+                "Bit 4": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "crossfade": true
+                },
+                "Bit 5": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "crossfade": true
+                },
+                "Bit 6": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "crossfade": true
+                },
+                "Bit 7": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "crossfade": true
+                },
+                "Bit 8": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "crossfade": true
+                },
+                "Show Off Bit": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "crossfade": true
+                }
+            },
+            "modes": [
+                {
+                    "name": "9-channel Mode",
+                    "shortName": "9ch",
+                    "channels": [
+                        "Bit 1",
+                        "Bit 2",
+                        "Bit 3",
+                        "Bit 4",
+                        "Bit 5",
+                        "Bit 6",
+                        "Bit 7",
+                        "Bit 8",
+                        "Show Off Bit"
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/fixtures/imports/ecue-MainLibrary/Neo-Neon.json
+++ b/fixtures/imports/ecue-MainLibrary/Neo-Neon.json
@@ -1,0 +1,345 @@
+{
+    "manufacturers": {
+        "Neo-Neon": {
+            "name": "Neo-Neon",
+            "website": "http://www.neo-neon.com/"
+        }
+    },
+    "fixtures": [
+        {
+            "manufacturer": "Neo-Neon",
+            "name": "Mech 5",
+            "shortName": "Mech5",
+            "comment": "cd Moving Head Spot 575",
+            "physical": {
+                "dimensions": [400, 400, 600]
+            },
+            "availableChannels": {
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Shutter": {
+                    "type": "Shutter",
+                    "highlightValue": 255,
+                    "capabilities": [
+                        {
+                            "range": [0, 1],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [2, 7],
+                            "name": "open"
+                        },
+                        {
+                            "range": [8, 63],
+                            "name": "strobe"
+                        },
+                        {
+                            "range": [64, 71],
+                            "name": "open"
+                        },
+                        {
+                            "range": [72, 127],
+                            "name": "pulse"
+                        },
+                        {
+                            "range": [128, 135],
+                            "name": "open"
+                        },
+                        {
+                            "range": [136, 191],
+                            "name": "pulse"
+                        },
+                        {
+                            "range": [192, 199],
+                            "name": "open"
+                        },
+                        {
+                            "range": [200, 253],
+                            "name": "random"
+                        },
+                        {
+                            "range": [254, 255],
+                            "name": "open"
+                        }
+                    ]
+                },
+                "Color": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 13],
+                            "name": "open"
+                        },
+                        {
+                            "range": [14, 27],
+                            "name": "steel blue",
+                            "color": "#4682b4"
+                        },
+                        {
+                            "range": [28, 41],
+                            "name": "orange",
+                            "color": "#ff7f00"
+                        },
+                        {
+                            "range": [42, 55],
+                            "name": "green blue",
+                            "color": "#1164b4"
+                        },
+                        {
+                            "range": [56, 69],
+                            "name": "bright blue"
+                        },
+                        {
+                            "range": [70, 83],
+                            "name": "bright pink"
+                        },
+                        {
+                            "range": [84, 97],
+                            "name": "red",
+                            "color": "#ff0000"
+                        },
+                        {
+                            "range": [98, 111],
+                            "name": "deep blue",
+                            "color": "#220878"
+                        },
+                        {
+                            "range": [112, 125],
+                            "name": "yellow",
+                            "color": "#ffff00"
+                        },
+                        {
+                            "range": [126, 139],
+                            "name": "dark pink",
+                            "color": "#e75480"
+                        },
+                        {
+                            "range": [140, 153],
+                            "name": "moss green",
+                            "color": "#8a9a5b"
+                        },
+                        {
+                            "range": [154, 167],
+                            "name": "light blue",
+                            "color": "#add8e6"
+                        },
+                        {
+                            "range": [168, 255],
+                            "name": ">>"
+                        }
+                    ]
+                },
+                "Gobo": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 23],
+                            "name": "open"
+                        },
+                        {
+                            "range": [24, 47],
+                            "name": "slot1"
+                        },
+                        {
+                            "range": [48, 71],
+                            "name": "slot2"
+                        },
+                        {
+                            "range": [72, 95],
+                            "name": "slot3"
+                        },
+                        {
+                            "range": [96, 119],
+                            "name": "slot4"
+                        },
+                        {
+                            "range": [120, 143],
+                            "name": "slot5"
+                        },
+                        {
+                            "range": [144, 167],
+                            "name": "slot6"
+                        },
+                        {
+                            "range": [168, 255],
+                            "name": ">>"
+                        }
+                    ]
+                },
+                "Gobo rot.": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "index"
+                        },
+                        {
+                            "range": [128, 191],
+                            "name": ">>"
+                        },
+                        {
+                            "range": [192, 255],
+                            "name": "<<"
+                        }
+                    ]
+                },
+                "Prisma": {
+                    "type": "Prism",
+                    "capabilities": [
+                        {
+                            "range": [0, 1],
+                            "name": "open"
+                        },
+                        {
+                            "range": [2, 255],
+                            "name": "prisma"
+                        }
+                    ]
+                },
+                "Focus": {
+                    "type": "Beam",
+                    "defaultValue": 128,
+                    "crossfade": true
+                },
+                "Zoom": {
+                    "type": "Beam",
+                    "defaultValue": 128,
+                    "crossfade": true
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Control": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 5],
+                            "name": "track"
+                        },
+                        {
+                            "range": [6, 63],
+                            "name": "speed"
+                        },
+                        {
+                            "range": [64, 127],
+                            "name": "idle"
+                        },
+                        {
+                            "range": [128, 255],
+                            "name": "reset"
+                        }
+                    ]
+                },
+                "Lamp": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 47],
+                            "name": "idle"
+                        },
+                        {
+                            "range": [48, 95],
+                            "name": "lamp on"
+                        },
+                        {
+                            "range": [96, 159],
+                            "name": "idle"
+                        },
+                        {
+                            "range": [160, 255],
+                            "name": "lamp off"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "14-channel Mode",
+                    "shortName": "14ch",
+                    "channels": [
+                        "Intensity",
+                        "Shutter",
+                        "Color",
+                        "Gobo",
+                        "Gobo rot.",
+                        "Prisma",
+                        "Focus",
+                        "Zoom",
+                        "Pan",
+                        "Tilt",
+                        "Pan fine",
+                        "Tilt fine",
+                        "Control",
+                        "Lamp"
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/fixtures/imports/ecue-MainLibrary/Omnisistem.json
+++ b/fixtures/imports/ecue-MainLibrary/Omnisistem.json
@@ -1,0 +1,314 @@
+{
+    "manufacturers": {
+        "Omnisistem": {
+            "name": "Omnisistem",
+            "website": "http://www.omnisistem.com/"
+        }
+    },
+    "fixtures": [
+        {
+            "manufacturer": "Omnisistem",
+            "name": "PyroFog",
+            "shortName": "PyroFog",
+            "comment": "Smoke maschine",
+            "physical": {
+                "dimensions": [430, 350, 300],
+                "weight": 9,
+                "power": 1500
+            },
+            "availableChannels": {
+                "N/A": {
+                    "type": "Intensity",
+                    "warning": "Please check type!"
+                },
+                "Fog": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "Off",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 255],
+                            "name": "ON",
+                            "center": true
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "2-channel Mode",
+                    "shortName": "2ch",
+                    "channels": [
+                        "N/A",
+                        "Fog"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Omnisistem",
+            "name": "Stinger",
+            "shortName": "Stinger",
+            "comment": "Laser",
+            "physical": {
+                "dimensions": [300, 270, 610]
+            },
+            "availableChannels": {
+                "Beam": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 10],
+                            "name": "Off",
+                            "center": true
+                        },
+                        {
+                            "range": [11, 50],
+                            "name": "On",
+                            "center": true
+                        },
+                        {
+                            "range": [51, 90],
+                            "name": "GR/BL On",
+                            "center": true
+                        },
+                        {
+                            "range": [91, 130],
+                            "name": "Red",
+                            "color": "#ff0000",
+                            "center": true
+                        },
+                        {
+                            "range": [131, 170],
+                            "name": "Gr/Rd ON",
+                            "center": true
+                        },
+                        {
+                            "range": [171, 255],
+                            "name": "Off",
+                            "center": true
+                        }
+                    ]
+                },
+                "Clr Control": {
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "crossfade": true
+                },
+                "Pattern": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 8],
+                            "name": "Off",
+                            "center": true
+                        },
+                        {
+                            "range": [9, 17],
+                            "name": "Beam Chs 1",
+                            "center": true
+                        },
+                        {
+                            "range": [18, 26],
+                            "name": "Split Sky H",
+                            "center": true
+                        },
+                        {
+                            "range": [27, 35],
+                            "name": "Split Sky V",
+                            "center": true
+                        },
+                        {
+                            "range": [36, 44],
+                            "name": "Flat Beam Fan",
+                            "center": true
+                        },
+                        {
+                            "range": [45, 53],
+                            "name": "Beam Fan Rot",
+                            "center": true
+                        },
+                        {
+                            "range": [54, 62],
+                            "name": "2 Beam Fan R",
+                            "center": true
+                        },
+                        {
+                            "range": [63, 71],
+                            "name": "Tight Cone",
+                            "center": true
+                        },
+                        {
+                            "range": [72, 80],
+                            "name": "2 Beam Scan",
+                            "center": true
+                        },
+                        {
+                            "range": [81, 89],
+                            "name": "2 Sky",
+                            "center": true
+                        },
+                        {
+                            "range": [90, 98],
+                            "name": "Bounce Fan",
+                            "center": true
+                        },
+                        {
+                            "range": [99, 107],
+                            "name": "Box Tunnel",
+                            "center": true
+                        },
+                        {
+                            "range": [108, 115],
+                            "name": "Quad Tunnel",
+                            "center": true
+                        },
+                        {
+                            "range": [116, 125],
+                            "name": "Tri Tunnel",
+                            "center": true
+                        },
+                        {
+                            "range": [126, 134],
+                            "name": "V Sky",
+                            "center": true
+                        },
+                        {
+                            "range": [135, 143],
+                            "name": "2 Diag Fans1",
+                            "center": true
+                        },
+                        {
+                            "range": [144, 152],
+                            "name": "2 Diag Fans2",
+                            "center": true
+                        },
+                        {
+                            "range": [153, 161],
+                            "name": "Box Tunnel 2",
+                            "center": true
+                        },
+                        {
+                            "range": [161, 170],
+                            "name": "Quad Tunnel",
+                            "center": true
+                        },
+                        {
+                            "range": [171, 179],
+                            "name": "Rot Fans",
+                            "center": true
+                        },
+                        {
+                            "range": [180, 188],
+                            "name": "2 Cones",
+                            "center": true
+                        },
+                        {
+                            "range": [189, 197],
+                            "name": "Fan Rot",
+                            "center": true
+                        },
+                        {
+                            "range": [198, 206],
+                            "name": "2 Fans SM",
+                            "center": true
+                        },
+                        {
+                            "range": [207, 215],
+                            "name": "2 Fans",
+                            "center": true
+                        },
+                        {
+                            "range": [216, 224],
+                            "name": "Cone",
+                            "center": true
+                        },
+                        {
+                            "range": [225, 233],
+                            "name": "2 Square Rot",
+                            "center": true
+                        },
+                        {
+                            "range": [234, 242],
+                            "name": "Beams 2",
+                            "center": true
+                        },
+                        {
+                            "range": [243, 255],
+                            "name": "Beams 3",
+                            "center": true
+                        }
+                    ]
+                },
+                "Speed": {
+                    "type": "Speed",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 230],
+                            "name": "Slw-Fst"
+                        },
+                        {
+                            "range": [231, 255],
+                            "name": "Hold",
+                            "center": true
+                        }
+                    ]
+                },
+                "X size": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Y size": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Y offset": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "New Range"
+                        },
+                        {
+                            "range": [14, 53],
+                            "name": "Lower"
+                        },
+                        {
+                            "range": [54, 127],
+                            "name": "Raise"
+                        },
+                        {
+                            "range": [128, 255],
+                            "name": "255",
+                            "center": true
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "7-channel Mode",
+                    "shortName": "7ch",
+                    "channels": [
+                        "Beam",
+                        "Clr Control",
+                        "Pattern",
+                        "Speed",
+                        "X size",
+                        "Y size",
+                        "Y offset"
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/fixtures/imports/ecue-MainLibrary/Osram.json
+++ b/fixtures/imports/ecue-MainLibrary/Osram.json
@@ -1,0 +1,203 @@
+{
+    "manufacturers": {
+        "Osram": {
+            "name": "Osram",
+            "website": "www.Osram.com"
+        }
+    },
+    "fixtures": [
+        {
+            "manufacturer": "Osram",
+            "name": "Shed 12CH",
+            "shortName": "Shed 12CH",
+            "physical": {
+                "dimensions": [330, 100, 100]
+            },
+            "availableChannels": {
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Red-y402m": {
+                    "name": "Red",
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "CW": {
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "CW-1kk4u": {
+                    "name": "CW",
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "CW-hpke1": {
+                    "name": "CW",
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "WW": {
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "WW-uxwhj": {
+                    "name": "WW",
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "WW-vppvd": {
+                    "name": "WW",
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "WW-zls5f": {
+                    "name": "WW",
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "WW-afkxk": {
+                    "name": "WW",
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "12-channel Mode",
+                    "shortName": "12ch",
+                    "channels": [
+                        "Red",
+                        "Red-y402m",
+                        "Green",
+                        "Blue",
+                        "CW",
+                        "CW-1kk4u",
+                        "CW-hpke1",
+                        "WW",
+                        "WW-uxwhj",
+                        "WW-vppvd",
+                        "WW-zls5f",
+                        "WW-afkxk"
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/fixtures/imports/ecue-MainLibrary/PR-Lighting.json
+++ b/fixtures/imports/ecue-MainLibrary/PR-Lighting.json
@@ -1,0 +1,726 @@
+{
+    "manufacturers": {
+        "PR Lighting": {
+            "name": "PR Lighting",
+            "website": "www.pr-lighting.com"
+        }
+    },
+    "fixtures": [
+        {
+            "manufacturer": "PR Lighting",
+            "name": "Design 150 Pro",
+            "shortName": "design150pro",
+            "comment": "cd",
+            "physical": {
+                "dimensions": [300, 300, 300]
+            },
+            "availableChannels": {
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Color": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 16],
+                            "name": "open"
+                        },
+                        {
+                            "range": [17, 35],
+                            "name": "color1"
+                        },
+                        {
+                            "range": [36, 54],
+                            "name": "color2"
+                        },
+                        {
+                            "range": [55, 73],
+                            "name": "color3"
+                        },
+                        {
+                            "range": [74, 92],
+                            "name": "color4"
+                        },
+                        {
+                            "range": [93, 110],
+                            "name": "color5"
+                        },
+                        {
+                            "range": [111, 181],
+                            "name": "color6"
+                        },
+                        {
+                            "range": [182, 255],
+                            "name": "ColorMix"
+                        }
+                    ]
+                },
+                "Cyan": {
+                    "type": "SingleColor",
+                    "color": "Cyan",
+                    "crossfade": true
+                },
+                "Yellow": {
+                    "type": "SingleColor",
+                    "color": "Yellow",
+                    "crossfade": true
+                },
+                "Magenta": {
+                    "type": "SingleColor",
+                    "color": "Magenta",
+                    "crossfade": true
+                },
+                "Color speed": {
+                    "type": "Speed",
+                    "crossfade": true
+                },
+                "Control": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 48],
+                            "name": "idle"
+                        },
+                        {
+                            "range": [49, 80],
+                            "name": "reset"
+                        },
+                        {
+                            "range": [81, 112],
+                            "name": "idle"
+                        },
+                        {
+                            "range": [113, 144],
+                            "name": "lamp off"
+                        },
+                        {
+                            "range": [145, 223],
+                            "name": "idle"
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "lamp on"
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "7-channel Mode",
+                    "shortName": "7ch",
+                    "channels": [
+                        "Intensity",
+                        "Color",
+                        "Cyan",
+                        "Yellow",
+                        "Magenta",
+                        "Color speed",
+                        "Control"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "PR Lighting",
+            "name": "XLED-590 Extended Mode",
+            "shortName": "XLED-590 Ext. Mode",
+            "comment": "PR-8100",
+            "physical": {
+                "dimensions": [350, 350, 350],
+                "weight": 11,
+                "power": 480
+            },
+            "availableChannels": {
+                "Dimmer": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 0,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "defaultValue": null
+                },
+                "Dimmer fine": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "defaultValue": null
+                },
+                "_CT Adjust": {
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Macro": {
+                    "type": "MultiColor",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 16],
+                            "name": "RGB Channel"
+                        },
+                        {
+                            "range": [17, 24],
+                            "name": "White-10000K"
+                        },
+                        {
+                            "range": [25, 32],
+                            "name": "White-7200K"
+                        },
+                        {
+                            "range": [33, 40],
+                            "name": "White-5600"
+                        },
+                        {
+                            "range": [41, 48],
+                            "name": "White-3200"
+                        },
+                        {
+                            "range": [49, 56],
+                            "name": "Cyan",
+                            "color": "#00ffff"
+                        },
+                        {
+                            "range": [57, 64],
+                            "name": "Yellow",
+                            "color": "#ffff00"
+                        },
+                        {
+                            "range": [65, 72],
+                            "name": "Magenta",
+                            "color": "#ca1f7b"
+                        },
+                        {
+                            "range": [73, 80],
+                            "name": "Red",
+                            "color": "#ff0000"
+                        },
+                        {
+                            "range": [81, 88],
+                            "name": "Green",
+                            "color": "#00ff00"
+                        },
+                        {
+                            "range": [89, 96],
+                            "name": "Blue",
+                            "color": "#0000ff"
+                        },
+                        {
+                            "range": [97, 104],
+                            "name": "Aqua"
+                        },
+                        {
+                            "range": [105, 112],
+                            "name": "Amber",
+                            "color": "#ffbf00"
+                        },
+                        {
+                            "range": [113, 120],
+                            "name": "Orange",
+                            "color": "#ff7f00"
+                        },
+                        {
+                            "range": [121, 128],
+                            "name": "Pink",
+                            "color": "#ffc0cb"
+                        },
+                        {
+                            "range": [129, 255],
+                            "name": "RGB Color Cycle"
+                        }
+                    ]
+                },
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 0,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "defaultValue": null
+                },
+                "Red fine": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "defaultValue": null
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 0,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "defaultValue": null
+                },
+                "Green fine": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "defaultValue": null
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 0,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "defaultValue": null
+                },
+                "Blue fine": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "defaultValue": null
+                },
+                "Strobe": {
+                    "type": "Strobe",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 9],
+                            "name": "No Strobe"
+                        },
+                        {
+                            "range": [10, 255],
+                            "name": "Strobe"
+                        }
+                    ]
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "P/T speed": {
+                    "type": "Speed",
+                    "crossfade": true
+                },
+                "Control": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 47],
+                            "name": "Reserved"
+                        },
+                        {
+                            "range": [48, 80],
+                            "name": "Reset"
+                        },
+                        {
+                            "range": [81, 255],
+                            "name": "Reserved"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Dimmer",
+                    "Dimmer fine"
+                ],
+                [
+                    "Red",
+                    "Red fine"
+                ],
+                [
+                    "Green",
+                    "Green fine"
+                ],
+                [
+                    "Blue",
+                    "Blue fine"
+                ],
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "17-channel Mode",
+                    "shortName": "17ch",
+                    "channels": [
+                        "Dimmer",
+                        "Dimmer fine",
+                        "_CT Adjust",
+                        "Macro",
+                        "Red",
+                        "Red fine",
+                        "Green",
+                        "Green fine",
+                        "Blue",
+                        "Blue fine",
+                        "Strobe",
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "P/T speed",
+                        "Control"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "PR Lighting",
+            "name": "XLED-590 Short Mode",
+            "shortName": "XLED-590 Sh. Mode",
+            "comment": "PR-8100",
+            "physical": {
+                "dimensions": [350, 350, 350],
+                "weight": 11,
+                "power": 480
+            },
+            "availableChannels": {
+                "Dimmer": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Strobe": {
+                    "type": "Strobe",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 9],
+                            "name": "No Strobe"
+                        },
+                        {
+                            "range": [10, 255],
+                            "name": "Strobe"
+                        }
+                    ]
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 32767,
+                    "highlightValue": 32767,
+                    "crossfade": true
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 32767,
+                    "highlightValue": 32767,
+                    "crossfade": true
+                },
+                "Control": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 47],
+                            "name": "Reserved"
+                        },
+                        {
+                            "range": [48, 80],
+                            "name": "Reset"
+                        },
+                        {
+                            "range": [81, 255],
+                            "name": "Reserved"
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "8-channel Mode",
+                    "shortName": "8ch",
+                    "channels": [
+                        "Dimmer",
+                        "Red",
+                        "Green",
+                        "Blue",
+                        "Strobe",
+                        "Pan",
+                        "Tilt",
+                        "Control"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "PR Lighting",
+            "name": "XLED-590 Standard Mode",
+            "shortName": "XLED-590 Std. Mode",
+            "comment": "PR-8100",
+            "physical": {
+                "dimensions": [350, 350, 350],
+                "weight": 11,
+                "power": 480
+            },
+            "availableChannels": {
+                "Dimmer": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "_CT Adjust": {
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Macro": {
+                    "type": "MultiColor",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 16],
+                            "name": "RGB Channel"
+                        },
+                        {
+                            "range": [17, 24],
+                            "name": "White-10000K"
+                        },
+                        {
+                            "range": [25, 32],
+                            "name": "White-7200K"
+                        },
+                        {
+                            "range": [33, 40],
+                            "name": "White-5600"
+                        },
+                        {
+                            "range": [41, 48],
+                            "name": "White-3200"
+                        },
+                        {
+                            "range": [49, 56],
+                            "name": "Cyan",
+                            "color": "#00ffff"
+                        },
+                        {
+                            "range": [57, 64],
+                            "name": "Yellow",
+                            "color": "#ffff00"
+                        },
+                        {
+                            "range": [65, 72],
+                            "name": "Magenta",
+                            "color": "#ca1f7b"
+                        },
+                        {
+                            "range": [73, 80],
+                            "name": "Red",
+                            "color": "#ff0000"
+                        },
+                        {
+                            "range": [81, 88],
+                            "name": "Green",
+                            "color": "#00ff00"
+                        },
+                        {
+                            "range": [89, 96],
+                            "name": "Blue",
+                            "color": "#0000ff"
+                        },
+                        {
+                            "range": [97, 104],
+                            "name": "Aqua"
+                        },
+                        {
+                            "range": [105, 112],
+                            "name": "Amber",
+                            "color": "#ffbf00"
+                        },
+                        {
+                            "range": [113, 120],
+                            "name": "Orange",
+                            "color": "#ff7f00"
+                        },
+                        {
+                            "range": [121, 128],
+                            "name": "Pink",
+                            "color": "#ffc0cb"
+                        },
+                        {
+                            "range": [129, 255],
+                            "name": "RGB Color Cycle"
+                        }
+                    ]
+                },
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Strobe": {
+                    "type": "Strobe",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 9],
+                            "name": "No Strobe"
+                        },
+                        {
+                            "range": [10, 255],
+                            "name": "Strobe"
+                        }
+                    ]
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "P/T speed": {
+                    "type": "Speed",
+                    "defaultValue": 32767,
+                    "crossfade": true
+                },
+                "Control": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 47],
+                            "name": "Reserved"
+                        },
+                        {
+                            "range": [48, 80],
+                            "name": "Reset"
+                        },
+                        {
+                            "range": [81, 255],
+                            "name": "Reserved"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "13-channel Mode",
+                    "shortName": "13ch",
+                    "channels": [
+                        "Dimmer",
+                        "_CT Adjust",
+                        "Macro",
+                        "Red",
+                        "Green",
+                        "Blue",
+                        "Strobe",
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "P/T speed",
+                        "Control"
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/fixtures/imports/ecue-MainLibrary/Pandoras-Box.json
+++ b/fixtures/imports/ecue-MainLibrary/Pandoras-Box.json
@@ -1,0 +1,51 @@
+{
+    "manufacturers": {
+        "Pandoras Box": {
+            "name": "Pandoras Box",
+            "website": "http://www.coolux.de/"
+        }
+    },
+    "fixtures": [
+        {
+            "manufacturer": "Pandoras Box",
+            "name": "Pandoras Box 25",
+            "shortName": "PanBox",
+            "physical": {
+                "dimensions": [100, 100, 100]
+            },
+            "availableChannels": {
+                "Dimmer/Volume": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "trans. sound of",
+                            "center": true
+                        },
+                        {
+                            "range": [1, 254],
+                            "name": "%"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "full",
+                            "center": true
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "1-channel Mode",
+                    "shortName": "1ch",
+                    "channels": [
+                        "Dimmer/Volume"
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/fixtures/imports/ecue-MainLibrary/Pangolin.json
+++ b/fixtures/imports/ecue-MainLibrary/Pangolin.json
@@ -1,0 +1,229 @@
+{
+    "manufacturers": {
+        "Pangolin": {
+            "name": "Pangolin",
+            "website": "http://www.pangolin.com/"
+        }
+    },
+    "fixtures": [
+        {
+            "manufacturer": "Pangolin",
+            "name": "Flashback 3",
+            "shortName": "FB3",
+            "physical": {
+                "dimensions": [100, 100, 100]
+            },
+            "availableChannels": {
+                "Control": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "defaultValue": 255
+                },
+                "Cue": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 48],
+                            "name": "Cue #"
+                        }
+                    ]
+                },
+                "Page": {
+                    "type": "Beam",
+                    "defaultValue": 1,
+                    "capabilities": [
+                        {
+                            "range": [1, 9],
+                            "name": "Page #"
+                        }
+                    ]
+                },
+                "Fade": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "crossfade": true
+                },
+                "Zoom": {
+                    "type": "Beam",
+                    "defaultValue": 255,
+                    "crossfade": true
+                },
+                "X Scale": {
+                    "type": "Intensity",
+                    "defaultValue": 255
+                },
+                "Y Scale": {
+                    "type": "Intensity",
+                    "defaultValue": 255
+                },
+                "Z Rotation": {
+                    "type": "Intensity",
+                    "crossfade": true
+                },
+                "X Position": {
+                    "type": "Intensity",
+                    "defaultValue": 128,
+                    "crossfade": true
+                },
+                "Y Position": {
+                    "type": "Intensity",
+                    "defaultValue": 128,
+                    "crossfade": true
+                }
+            },
+            "modes": [
+                {
+                    "name": "10-channel Mode",
+                    "shortName": "10ch",
+                    "channels": [
+                        "Control",
+                        "Cue",
+                        "Page",
+                        "Fade",
+                        "Zoom",
+                        "X Scale",
+                        "Y Scale",
+                        "Z Rotation",
+                        "X Position",
+                        "Y Position"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Pangolin",
+            "name": "Live",
+            "shortName": "Live",
+            "physical": {
+                "dimensions": [100, 100, 100]
+            },
+            "availableChannels": {
+                "Control": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "capabilities": [
+                        {
+                            "range": [0, 31],
+                            "name": "Balckout"
+                        },
+                        {
+                            "range": [32, 255],
+                            "name": "ON"
+                        }
+                    ]
+                },
+                "Page": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "Page 1"
+                        },
+                        {
+                            "range": [16, 31],
+                            "name": "Page 2"
+                        },
+                        {
+                            "range": [32, 47],
+                            "name": "Page 3"
+                        },
+                        {
+                            "range": [48, 63],
+                            "name": "Page 4"
+                        },
+                        {
+                            "range": [64, 79],
+                            "name": "Page 5"
+                        },
+                        {
+                            "range": [80, 95],
+                            "name": "Page 6"
+                        },
+                        {
+                            "range": [96, 111],
+                            "name": "Page 7"
+                        },
+                        {
+                            "range": [112, 127],
+                            "name": "Page 8"
+                        },
+                        {
+                            "range": [0, 0],
+                            "name": "New Range"
+                        }
+                    ]
+                },
+                "Cue": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 31],
+                            "name": "Blackout"
+                        },
+                        {
+                            "range": [32, 223],
+                            "name": "Cues",
+                            "showInMenu": false
+                        }
+                    ]
+                },
+                "Speed": {
+                    "type": "Speed",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "100%"
+                        },
+                        {
+                            "range": [16, 31],
+                            "name": "Pause"
+                        },
+                        {
+                            "range": [32, 255],
+                            "name": "Variable"
+                        }
+                    ]
+                },
+                "Brightness": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "crossfade": true
+                },
+                "Size": {
+                    "type": "Beam",
+                    "defaultValue": 255,
+                    "crossfade": true
+                },
+                "X Position": {
+                    "type": "Intensity",
+                    "defaultValue": 127,
+                    "crossfade": true
+                },
+                "Y Position": {
+                    "type": "Intensity",
+                    "defaultValue": 127,
+                    "crossfade": true
+                }
+            },
+            "modes": [
+                {
+                    "name": "8-channel Mode",
+                    "shortName": "8ch",
+                    "channels": [
+                        "Control",
+                        "Page",
+                        "Cue",
+                        "Speed",
+                        "Brightness",
+                        "Size",
+                        "X Position",
+                        "Y Position"
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/fixtures/imports/ecue-MainLibrary/Philips.json
+++ b/fixtures/imports/ecue-MainLibrary/Philips.json
@@ -1,0 +1,1340 @@
+{
+    "manufacturers": {
+        "Philips": {
+            "name": "Philips"
+        }
+    },
+    "fixtures": [
+        {
+            "manufacturer": "Philips",
+            "name": "Selecon_PL3_16Bit",
+            "shortName": "Selecon_PL3",
+            "physical": {
+                "dimensions": [475, 475, 315]
+            },
+            "availableChannels": {
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 0,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ],
+                    "defaultValue": null
+                },
+                "Intensity fine": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ],
+                    "defaultValue": null
+                },
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ],
+                    "defaultValue": null
+                },
+                "Red fine": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ],
+                    "defaultValue": null
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ],
+                    "defaultValue": null
+                },
+                "Green fine": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ],
+                    "defaultValue": null
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ],
+                    "defaultValue": null
+                },
+                "Blue fine": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ],
+                    "defaultValue": null
+                },
+                "White": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ],
+                    "defaultValue": null
+                },
+                "White fine": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ],
+                    "defaultValue": null
+                },
+                "Pres Color sel": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Intensity Time": {
+                    "type": "Beam",
+                    "defaultValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Color Time": {
+                    "type": "Beam",
+                    "defaultValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Control": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "Control"
+                        }
+                    ]
+                },
+                "Beam Time": {
+                    "type": "Beam",
+                    "defaultValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 15],
+                            "name": "Motor stop"
+                        },
+                        {
+                            "range": [16, 49],
+                            "name": "Motor rev fast"
+                        },
+                        {
+                            "range": [50, 84],
+                            "name": "Motor rev med"
+                        },
+                        {
+                            "range": [85, 119],
+                            "name": "Motor rev slow"
+                        },
+                        {
+                            "range": [120, 135],
+                            "name": "Motor stop"
+                        },
+                        {
+                            "range": [136, 170],
+                            "name": "Motor fwd slow"
+                        },
+                        {
+                            "range": [171, 204],
+                            "name": "Motor fwd med"
+                        },
+                        {
+                            "range": [205, 238],
+                            "name": "Motor fwd fast"
+                        },
+                        {
+                            "range": [239, 255],
+                            "name": "Motor stop"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Intensity",
+                    "Intensity fine"
+                ],
+                [
+                    "Red",
+                    "Red fine"
+                ],
+                [
+                    "Green",
+                    "Green fine"
+                ],
+                [
+                    "Blue",
+                    "Blue fine"
+                ],
+                [
+                    "White",
+                    "White fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "18-channel Mode",
+                    "shortName": "18ch",
+                    "channels": [
+                        "Intensity",
+                        "Intensity fine",
+                        "Red",
+                        "Red fine",
+                        "Green",
+                        "Green fine",
+                        "Blue",
+                        "Blue fine",
+                        "White",
+                        "White fine",
+                        "Pres Color sel",
+                        null,
+                        "Intensity Time",
+                        "Color Time",
+                        "Control",
+                        "Beam Time"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Philips",
+            "name": "SL Wash 180 16Bit",
+            "shortName": "SLWash180,16Bit",
+            "comment": "Version: SL WASH 180 RGBW, IP20\nOptics: 12 - 45 degree Zoom, 54 high power LEDs",
+            "physical": {
+                "dimensions": [280, 370, 212],
+                "weight": 8,
+                "power": 180
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 0,
+                    "highlightValue": 0,
+                    "crossfade": true
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 0,
+                    "highlightValue": 0,
+                    "crossfade": true
+                },
+                "P+T Timing": {
+                    "type": "Beam",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 0,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ],
+                    "defaultValue": null
+                },
+                "Intensity fine": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ],
+                    "defaultValue": null
+                },
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ],
+                    "defaultValue": null
+                },
+                "Red fine": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ],
+                    "defaultValue": null
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ],
+                    "defaultValue": null
+                },
+                "Green fine": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ],
+                    "defaultValue": null
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ],
+                    "defaultValue": null
+                },
+                "Blue fine": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ],
+                    "defaultValue": null
+                },
+                "White": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ],
+                    "defaultValue": null
+                },
+                "White fine": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ],
+                    "defaultValue": null
+                },
+                "Pres Color": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Strobe": {
+                    "type": "Strobe",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 2],
+                            "name": "Open",
+                            "center": true
+                        },
+                        {
+                            "range": [3, 5],
+                            "name": "Closed",
+                            "center": true
+                        },
+                        {
+                            "range": [6, 7],
+                            "name": "Slow RND"
+                        },
+                        {
+                            "range": [8, 10],
+                            "name": "Med RND",
+                            "center": true
+                        },
+                        {
+                            "range": [11, 12],
+                            "name": "Fast RND",
+                            "center": true
+                        },
+                        {
+                            "range": [13, 127],
+                            "name": "Strobe Range",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 129],
+                            "name": "Pulse+slow RND",
+                            "center": true
+                        },
+                        {
+                            "range": [130, 131],
+                            "name": "Pulse+med RND",
+                            "center": true
+                        },
+                        {
+                            "range": [132, 133],
+                            "name": "Pulse+fast RND",
+                            "center": true
+                        },
+                        {
+                            "range": [134, 191],
+                            "name": "Pulse + Range",
+                            "center": true
+                        },
+                        {
+                            "range": [192, 193],
+                            "name": "Pulse-slow RND",
+                            "center": true
+                        },
+                        {
+                            "range": [194, 195],
+                            "name": "Pulse-med RND",
+                            "center": true
+                        },
+                        {
+                            "range": [196, 197],
+                            "name": "Pulse-fast RND",
+                            "center": true
+                        },
+                        {
+                            "range": [198, 255],
+                            "name": "Pulse - Range",
+                            "center": true
+                        }
+                    ]
+                },
+                "Strobe Duration": {
+                    "type": "Strobe",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Zoom": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Int+Col Timing": {
+                    "type": "Beam",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Color Time": {
+                    "type": "Beam",
+                    "defaultValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Zoom Time": {
+                    "type": "Beam",
+                    "defaultValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Control": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 4],
+                            "name": "Default"
+                        },
+                        {
+                            "range": [5, 9],
+                            "name": "DIM Res Norm"
+                        },
+                        {
+                            "range": [10, 14],
+                            "name": "DIM Res Incan"
+                        },
+                        {
+                            "range": [30, 34],
+                            "name": "DIM Cur Lin"
+                        },
+                        {
+                            "range": [35, 39],
+                            "name": "DIM Cur Squ"
+                        },
+                        {
+                            "range": [40, 44],
+                            "name": "DIM Cur S"
+                        },
+                        {
+                            "range": [45, 49],
+                            "name": "DIM Cur PL"
+                        },
+                        {
+                            "range": [70, 74],
+                            "name": "Calibr Off"
+                        },
+                        {
+                            "range": [75, 79],
+                            "name": "Calibr On"
+                        },
+                        {
+                            "range": [100, 104],
+                            "name": "Map RGBW 16Bit"
+                        },
+                        {
+                            "range": [105, 109],
+                            "name": "Map RGBW 8Bit"
+                        },
+                        {
+                            "range": [110, 114],
+                            "name": "Map HSIC"
+                        },
+                        {
+                            "range": [115, 255],
+                            "name": "Reserved"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ],
+                [
+                    "Intensity",
+                    "Intensity fine"
+                ],
+                [
+                    "Red",
+                    "Red fine"
+                ],
+                [
+                    "Green",
+                    "Green fine"
+                ],
+                [
+                    "Blue",
+                    "Blue fine"
+                ],
+                [
+                    "White",
+                    "White fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "23-channel Mode",
+                    "shortName": "23ch",
+                    "channels": [
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "P+T Timing",
+                        "Intensity",
+                        "Intensity fine",
+                        "Red",
+                        "Red fine",
+                        "Green",
+                        "Green fine",
+                        "Blue",
+                        "Blue fine",
+                        "White",
+                        "White fine",
+                        "Pres Color",
+                        "Strobe",
+                        "Strobe Duration",
+                        "Zoom",
+                        "Int+Col Timing",
+                        "Color Time",
+                        "Zoom Time",
+                        "Control"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Philips",
+            "name": "SL Wash 180 8Bit",
+            "shortName": "SLWash180,8Bit",
+            "comment": "Version: SL WASH 180 RGBW, IP20\nOptics: 12 - 45 degree Zoom, 54 high power LEDs",
+            "physical": {
+                "dimensions": [280, 370, 212],
+                "weight": 8,
+                "power": 180
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 0,
+                    "highlightValue": 0,
+                    "crossfade": true
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 0,
+                    "highlightValue": 0,
+                    "crossfade": true
+                },
+                "P+T Timing": {
+                    "type": "Beam",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "White": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Pres Color": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Strobe": {
+                    "type": "Strobe",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 2],
+                            "name": "Open",
+                            "center": true
+                        },
+                        {
+                            "range": [3, 5],
+                            "name": "Closed",
+                            "center": true
+                        },
+                        {
+                            "range": [6, 7],
+                            "name": "Slow RND"
+                        },
+                        {
+                            "range": [8, 10],
+                            "name": "Med RND",
+                            "center": true
+                        },
+                        {
+                            "range": [11, 12],
+                            "name": "Fast RND",
+                            "center": true
+                        },
+                        {
+                            "range": [13, 127],
+                            "name": "Strobe Range",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 129],
+                            "name": "Pulse+slow RND",
+                            "center": true
+                        },
+                        {
+                            "range": [130, 131],
+                            "name": "Pulse+med RND",
+                            "center": true
+                        },
+                        {
+                            "range": [132, 133],
+                            "name": "Pulse+fast RND",
+                            "center": true
+                        },
+                        {
+                            "range": [134, 191],
+                            "name": "Pulse + Range",
+                            "center": true
+                        },
+                        {
+                            "range": [192, 193],
+                            "name": "Pulse-slow RND",
+                            "center": true
+                        },
+                        {
+                            "range": [194, 195],
+                            "name": "Pulse-med RND",
+                            "center": true
+                        },
+                        {
+                            "range": [196, 197],
+                            "name": "Pulse-fast RND",
+                            "center": true
+                        },
+                        {
+                            "range": [198, 255],
+                            "name": "Pulse - Range",
+                            "center": true
+                        }
+                    ]
+                },
+                "Strobe Duration": {
+                    "type": "Strobe",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Zoom": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Int+Col Timing": {
+                    "type": "Beam",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Control": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 4],
+                            "name": "Default"
+                        },
+                        {
+                            "range": [5, 9],
+                            "name": "DIM Res Norm"
+                        },
+                        {
+                            "range": [10, 14],
+                            "name": "DIM Res Incan"
+                        },
+                        {
+                            "range": [30, 34],
+                            "name": "DIM Cur Lin"
+                        },
+                        {
+                            "range": [35, 39],
+                            "name": "DIM Cur Squ"
+                        },
+                        {
+                            "range": [40, 44],
+                            "name": "DIM Cur S"
+                        },
+                        {
+                            "range": [45, 49],
+                            "name": "DIM Cur PL"
+                        },
+                        {
+                            "range": [70, 74],
+                            "name": "Calibr Off"
+                        },
+                        {
+                            "range": [75, 79],
+                            "name": "Calibr On"
+                        },
+                        {
+                            "range": [100, 104],
+                            "name": "Map RGBW 16Bit"
+                        },
+                        {
+                            "range": [105, 109],
+                            "name": "Map RGBW 8Bit"
+                        },
+                        {
+                            "range": [110, 114],
+                            "name": "Map HSIC"
+                        },
+                        {
+                            "range": [115, 255],
+                            "name": "Reserved"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "16-channel Mode",
+                    "shortName": "16ch",
+                    "channels": [
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "P+T Timing",
+                        "Intensity",
+                        "Red",
+                        "Green",
+                        "Blue",
+                        "White",
+                        "Pres Color",
+                        "Strobe",
+                        "Strobe Duration",
+                        "Zoom",
+                        "Int+Col Timing",
+                        "Control"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Philips",
+            "name": "SL Wash 180 HSIC Mode",
+            "shortName": "SLWash180,HSIC",
+            "comment": "Version: SL WASH 180 RGBW, IP20\nOptics: 12 - 45 degree Zoom, 54 high power LEDs",
+            "physical": {
+                "dimensions": [280, 370, 212],
+                "weight": 8,
+                "power": 180
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 0,
+                    "highlightValue": 0,
+                    "crossfade": true
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 0,
+                    "highlightValue": 0,
+                    "crossfade": true
+                },
+                "P+T Timing": {
+                    "type": "Beam",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Hue High Low": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ],
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "Hue High Low fine": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ],
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "Saturation": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Intensity 8Bit": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "CCT": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Strobe": {
+                    "type": "Strobe",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 2],
+                            "name": "Open",
+                            "center": true
+                        },
+                        {
+                            "range": [3, 5],
+                            "name": "Closed",
+                            "center": true
+                        },
+                        {
+                            "range": [6, 7],
+                            "name": "Slow RND"
+                        },
+                        {
+                            "range": [8, 10],
+                            "name": "Med RND",
+                            "center": true
+                        },
+                        {
+                            "range": [11, 12],
+                            "name": "Fast RND",
+                            "center": true
+                        },
+                        {
+                            "range": [13, 127],
+                            "name": "Strobe Range",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 129],
+                            "name": "Pulse+slow RND",
+                            "center": true
+                        },
+                        {
+                            "range": [130, 131],
+                            "name": "Pulse+med RND",
+                            "center": true
+                        },
+                        {
+                            "range": [132, 133],
+                            "name": "Pulse+fast RND",
+                            "center": true
+                        },
+                        {
+                            "range": [134, 191],
+                            "name": "Pulse + Range",
+                            "center": true
+                        },
+                        {
+                            "range": [192, 193],
+                            "name": "Pulse-slow RND",
+                            "center": true
+                        },
+                        {
+                            "range": [194, 195],
+                            "name": "Pulse-med RND",
+                            "center": true
+                        },
+                        {
+                            "range": [196, 197],
+                            "name": "Pulse-fast RND",
+                            "center": true
+                        },
+                        {
+                            "range": [198, 255],
+                            "name": "Pulse - Range",
+                            "center": true
+                        }
+                    ]
+                },
+                "Strobe Duration": {
+                    "type": "Strobe",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Zoom": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Int+Col Timing": {
+                    "type": "Beam",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Control": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 4],
+                            "name": "Default"
+                        },
+                        {
+                            "range": [5, 9],
+                            "name": "DIM Res Norm"
+                        },
+                        {
+                            "range": [10, 14],
+                            "name": "DIM Res Incan"
+                        },
+                        {
+                            "range": [30, 34],
+                            "name": "DIM Cur Lin"
+                        },
+                        {
+                            "range": [35, 39],
+                            "name": "DIM Cur Squ"
+                        },
+                        {
+                            "range": [40, 44],
+                            "name": "DIM Cur S"
+                        },
+                        {
+                            "range": [45, 49],
+                            "name": "DIM Cur PL"
+                        },
+                        {
+                            "range": [70, 74],
+                            "name": "Calibr Off"
+                        },
+                        {
+                            "range": [75, 79],
+                            "name": "Calibr On"
+                        },
+                        {
+                            "range": [100, 104],
+                            "name": "Map RGBW 16Bit"
+                        },
+                        {
+                            "range": [105, 109],
+                            "name": "Map RGBW 8Bit"
+                        },
+                        {
+                            "range": [110, 114],
+                            "name": "Map HSIC"
+                        },
+                        {
+                            "range": [115, 255],
+                            "name": "Reserved"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ],
+                [
+                    "Hue High Low",
+                    "Hue High Low fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "16-channel Mode",
+                    "shortName": "16ch",
+                    "channels": [
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "P+T Timing",
+                        "Intensity",
+                        "Hue High Low",
+                        "Hue High Low fine",
+                        "Saturation",
+                        "Intensity 8Bit",
+                        "CCT",
+                        "Strobe",
+                        "Strobe Duration",
+                        "Zoom",
+                        "Int+Col Timing",
+                        "Control"
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/fixtures/imports/ecue-MainLibrary/Pixeon.json
+++ b/fixtures/imports/ecue-MainLibrary/Pixeon.json
@@ -1,0 +1,677 @@
+{
+    "manufacturers": {
+        "Pixeon": {
+            "name": "Pixeon",
+            "website": "www.pixeon.de"
+        }
+    },
+    "fixtures": [
+        {
+            "manufacturer": "Pixeon",
+            "name": "Color Tube",
+            "shortName": "ColorT",
+            "comment": "Program & Playback options",
+            "physical": {
+                "dimensions": [100, 100, 100]
+            },
+            "availableChannels": {
+                "mode": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 254],
+                            "name": "playback"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "store"
+                        }
+                    ]
+                },
+                "memloc": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [1, 1],
+                            "name": "memory1"
+                        },
+                        {
+                            "range": [2, 2],
+                            "name": "memory2"
+                        },
+                        {
+                            "range": [3, 3],
+                            "name": "memory3"
+                        },
+                        {
+                            "range": [4, 4],
+                            "name": "memory4"
+                        },
+                        {
+                            "range": [5, 5],
+                            "name": "memory5"
+                        },
+                        {
+                            "range": [6, 6],
+                            "name": "memory6"
+                        },
+                        {
+                            "range": [7, 7],
+                            "name": "memory7"
+                        },
+                        {
+                            "range": [8, 8],
+                            "name": "memory8"
+                        },
+                        {
+                            "range": [9, 9],
+                            "name": "memory9"
+                        },
+                        {
+                            "range": [10, 10],
+                            "name": "memory10"
+                        },
+                        {
+                            "range": [11, 11],
+                            "name": "memory11"
+                        },
+                        {
+                            "range": [12, 12],
+                            "name": "memory12"
+                        },
+                        {
+                            "range": [13, 13],
+                            "name": "memory13"
+                        },
+                        {
+                            "range": [14, 14],
+                            "name": "memory14"
+                        },
+                        {
+                            "range": [15, 15],
+                            "name": "memory15"
+                        }
+                    ]
+                },
+                "step": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [1, 1],
+                            "name": "step1"
+                        },
+                        {
+                            "range": [2, 2],
+                            "name": "step2"
+                        },
+                        {
+                            "range": [3, 3],
+                            "name": "step3"
+                        },
+                        {
+                            "range": [4, 4],
+                            "name": "step4"
+                        },
+                        {
+                            "range": [5, 5],
+                            "name": "step5"
+                        },
+                        {
+                            "range": [6, 6],
+                            "name": "step6"
+                        },
+                        {
+                            "range": [7, 7],
+                            "name": "step7"
+                        },
+                        {
+                            "range": [8, 8],
+                            "name": "step8"
+                        },
+                        {
+                            "range": [9, 9],
+                            "name": "step9"
+                        },
+                        {
+                            "range": [10, 10],
+                            "name": "step10"
+                        },
+                        {
+                            "range": [11, 11],
+                            "name": "step11"
+                        },
+                        {
+                            "range": [12, 12],
+                            "name": "step12"
+                        },
+                        {
+                            "range": [13, 13],
+                            "name": "step13"
+                        },
+                        {
+                            "range": [14, 14],
+                            "name": "step14"
+                        },
+                        {
+                            "range": [15, 15],
+                            "name": "step15"
+                        },
+                        {
+                            "range": [16, 16],
+                            "name": "step16"
+                        },
+                        {
+                            "range": [17, 17],
+                            "name": "step17"
+                        },
+                        {
+                            "range": [18, 18],
+                            "name": "step18"
+                        },
+                        {
+                            "range": [19, 19],
+                            "name": "step19"
+                        },
+                        {
+                            "range": [20, 20],
+                            "name": "step20"
+                        },
+                        {
+                            "range": [21, 21],
+                            "name": "step21"
+                        },
+                        {
+                            "range": [22, 22],
+                            "name": "step22"
+                        },
+                        {
+                            "range": [23, 23],
+                            "name": "step23"
+                        },
+                        {
+                            "range": [24, 24],
+                            "name": "step24"
+                        },
+                        {
+                            "range": [25, 25],
+                            "name": "step25"
+                        },
+                        {
+                            "range": [26, 26],
+                            "name": "step26"
+                        },
+                        {
+                            "range": [27, 27],
+                            "name": "step27"
+                        },
+                        {
+                            "range": [28, 28],
+                            "name": "step28"
+                        },
+                        {
+                            "range": [29, 29],
+                            "name": "step29"
+                        },
+                        {
+                            "range": [30, 30],
+                            "name": "step30"
+                        },
+                        {
+                            "range": [31, 31],
+                            "name": "step31"
+                        },
+                        {
+                            "range": [32, 32],
+                            "name": "step32"
+                        },
+                        {
+                            "range": [33, 33],
+                            "name": "step33"
+                        },
+                        {
+                            "range": [34, 34],
+                            "name": "step34"
+                        },
+                        {
+                            "range": [35, 35],
+                            "name": "step35"
+                        },
+                        {
+                            "range": [36, 36],
+                            "name": "step36"
+                        },
+                        {
+                            "range": [37, 37],
+                            "name": "step37"
+                        },
+                        {
+                            "range": [38, 38],
+                            "name": "step38"
+                        },
+                        {
+                            "range": [39, 39],
+                            "name": "step39"
+                        },
+                        {
+                            "range": [40, 40],
+                            "name": "step40"
+                        },
+                        {
+                            "range": [41, 41],
+                            "name": "step41"
+                        },
+                        {
+                            "range": [42, 42],
+                            "name": "step42"
+                        },
+                        {
+                            "range": [43, 43],
+                            "name": "step43"
+                        },
+                        {
+                            "range": [44, 44],
+                            "name": "step44"
+                        },
+                        {
+                            "range": [45, 45],
+                            "name": "step45"
+                        },
+                        {
+                            "range": [46, 46],
+                            "name": "step46"
+                        },
+                        {
+                            "range": [47, 47],
+                            "name": "step47"
+                        },
+                        {
+                            "range": [48, 48],
+                            "name": "step48"
+                        },
+                        {
+                            "range": [49, 49],
+                            "name": "step49"
+                        },
+                        {
+                            "range": [50, 50],
+                            "name": "step50"
+                        },
+                        {
+                            "range": [51, 51],
+                            "name": "step51"
+                        },
+                        {
+                            "range": [52, 52],
+                            "name": "step52"
+                        },
+                        {
+                            "range": [53, 53],
+                            "name": "step53"
+                        },
+                        {
+                            "range": [54, 54],
+                            "name": "step54"
+                        },
+                        {
+                            "range": [55, 55],
+                            "name": "step55"
+                        },
+                        {
+                            "range": [56, 56],
+                            "name": "step56"
+                        },
+                        {
+                            "range": [57, 57],
+                            "name": "step57"
+                        },
+                        {
+                            "range": [58, 58],
+                            "name": "step58"
+                        },
+                        {
+                            "range": [59, 59],
+                            "name": "step59"
+                        },
+                        {
+                            "range": [60, 60],
+                            "name": "step60"
+                        },
+                        {
+                            "range": [61, 61],
+                            "name": "step61"
+                        },
+                        {
+                            "range": [62, 62],
+                            "name": "step62"
+                        },
+                        {
+                            "range": [63, 63],
+                            "name": "step63"
+                        },
+                        {
+                            "range": [64, 64],
+                            "name": "step64"
+                        }
+                    ]
+                },
+                "go": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "noaction"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "step"
+                        }
+                    ]
+                },
+                "speed1": {
+                    "type": "Speed",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "fast"
+                        },
+                        {
+                            "range": [1, 254],
+                            "name": "%"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "slow"
+                        }
+                    ]
+                },
+                "speed2": {
+                    "type": "Speed",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "fast"
+                        },
+                        {
+                            "range": [1, 254],
+                            "name": "%"
+                        },
+                        {
+                            "range": [254, 254],
+                            "name": "slow"
+                        }
+                    ]
+                },
+                "color1": {
+                    "type": "MultiColor",
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "color1"
+                        },
+                        {
+                            "range": [1, 1],
+                            "name": "color2"
+                        },
+                        {
+                            "range": [2, 2],
+                            "name": "color3"
+                        },
+                        {
+                            "range": [3, 3],
+                            "name": "color4"
+                        },
+                        {
+                            "range": [4, 4],
+                            "name": "color5"
+                        },
+                        {
+                            "range": [5, 5],
+                            "name": "color6"
+                        },
+                        {
+                            "range": [6, 6],
+                            "name": "color7"
+                        },
+                        {
+                            "range": [7, 7],
+                            "name": "color8"
+                        }
+                    ]
+                },
+                "length1": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "ignore"
+                        },
+                        {
+                            "range": [1, 255],
+                            "name": "length"
+                        }
+                    ]
+                },
+                "color_fw": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "color_bw": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "color2": {
+                    "type": "MultiColor",
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "color1"
+                        },
+                        {
+                            "range": [1, 1],
+                            "name": "color2"
+                        },
+                        {
+                            "range": [2, 2],
+                            "name": "color3"
+                        },
+                        {
+                            "range": [3, 3],
+                            "name": "color4"
+                        },
+                        {
+                            "range": [4, 4],
+                            "name": "color5"
+                        },
+                        {
+                            "range": [5, 5],
+                            "name": "color6"
+                        },
+                        {
+                            "range": [6, 6],
+                            "name": "color7"
+                        },
+                        {
+                            "range": [7, 7],
+                            "name": "color8"
+                        }
+                    ]
+                },
+                "length2": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "ignore"
+                        },
+                        {
+                            "range": [1, 255],
+                            "name": "length"
+                        }
+                    ]
+                },
+                "endmark": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "noaction"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "endmark"
+                        }
+                    ]
+                },
+                "memsel": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [1, 1],
+                            "name": "memory1"
+                        },
+                        {
+                            "range": [2, 2],
+                            "name": "memory2"
+                        },
+                        {
+                            "range": [3, 3],
+                            "name": "memory3"
+                        },
+                        {
+                            "range": [4, 4],
+                            "name": "memory4"
+                        },
+                        {
+                            "range": [5, 5],
+                            "name": "memory5"
+                        },
+                        {
+                            "range": [6, 6],
+                            "name": "memory6"
+                        },
+                        {
+                            "range": [7, 7],
+                            "name": "memory7"
+                        },
+                        {
+                            "range": [8, 8],
+                            "name": "memory8"
+                        },
+                        {
+                            "range": [9, 9],
+                            "name": "memory9"
+                        },
+                        {
+                            "range": [10, 10],
+                            "name": "memory10"
+                        },
+                        {
+                            "range": [11, 11],
+                            "name": "memory11"
+                        },
+                        {
+                            "range": [12, 12],
+                            "name": "memory12"
+                        },
+                        {
+                            "range": [13, 13],
+                            "name": "memory13"
+                        },
+                        {
+                            "range": [14, 14],
+                            "name": "memory14"
+                        },
+                        {
+                            "range": [15, 15],
+                            "name": "memory15"
+                        }
+                    ]
+                },
+                "DBO": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "controller": {
+                    "type": "Beam",
+                    "defaultValue": 1,
+                    "highlightValue": 1,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [1, 1],
+                            "name": "controller1"
+                        },
+                        {
+                            "range": [2, 2],
+                            "name": "controller2"
+                        },
+                        {
+                            "range": [3, 3],
+                            "name": "controller3"
+                        },
+                        {
+                            "range": [4, 4],
+                            "name": "controller4"
+                        },
+                        {
+                            "range": [5, 5],
+                            "name": "controller5"
+                        },
+                        {
+                            "range": [6, 6],
+                            "name": "controller6"
+                        },
+                        {
+                            "range": [7, 7],
+                            "name": "controller7"
+                        },
+                        {
+                            "range": [8, 8],
+                            "name": "controller8"
+                        },
+                        {
+                            "range": [9, 9],
+                            "name": "controller9"
+                        },
+                        {
+                            "range": [10, 10],
+                            "name": "controller10"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "all"
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "16-channel Mode",
+                    "shortName": "16ch",
+                    "channels": [
+                        "mode",
+                        "memloc",
+                        "step",
+                        "go",
+                        "speed1",
+                        "speed2",
+                        "color1",
+                        "length1",
+                        "color_fw",
+                        "color_bw",
+                        "color2",
+                        "length2",
+                        "endmark",
+                        "memsel",
+                        "DBO",
+                        "controller"
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/fixtures/imports/ecue-MainLibrary/Publitec.json
+++ b/fixtures/imports/ecue-MainLibrary/Publitec.json
@@ -1,0 +1,245 @@
+{
+    "manufacturers": {
+        "Publitec": {
+            "name": "Publitec",
+            "website": "http://www.publitec.tv"
+        }
+    },
+    "fixtures": [
+        {
+            "manufacturer": "Publitec",
+            "name": "BeaMover 40",
+            "shortName": "Bea40",
+            "comment": "http://www.beamover.tv/de/  http://www.beamover.tv/de/attachments/023_beaMover%2040-50-55%20DMX.pdf",
+            "physical": {
+                "dimensions": [954, 954, 1024]
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 0,
+                    "highlightValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 0,
+                    "highlightValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Focus": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Zoom": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Signal": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 84],
+                            "name": "Slot 1",
+                            "center": true
+                        },
+                        {
+                            "range": [85, 169],
+                            "name": "Slot 2",
+                            "center": true
+                        },
+                        {
+                            "range": [170, 255],
+                            "name": "Slot 3",
+                            "center": true
+                        }
+                    ]
+                },
+                "Imgage": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 63],
+                            "name": "inv.off/rear.of",
+                            "center": true
+                        },
+                        {
+                            "range": [64, 127],
+                            "name": "inv.off/rear.on",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 191],
+                            "name": "inv.on/rear.off",
+                            "center": true
+                        },
+                        {
+                            "range": [192, 255],
+                            "name": "inv.on/rear.on",
+                            "center": true
+                        }
+                    ]
+                },
+                "Trapezoid_vert": {
+                    "type": "Beam",
+                    "defaultValue": 31,
+                    "highlightValue": 31,
+                    "capabilities": [
+                        {
+                            "range": [0, 64],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Trapezoid_hor": {
+                    "type": "Beam",
+                    "defaultValue": 14,
+                    "highlightValue": 14,
+                    "capabilities": [
+                        {
+                            "range": [0, 28],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Shutter": {
+                    "type": "Shutter",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "Mute on"
+                        },
+                        {
+                            "range": [128, 255],
+                            "name": "Shutter"
+                        }
+                    ]
+                },
+                "Control": {
+                    "type": "Beam",
+                    "defaultValue": 100,
+                    "highlightValue": 100,
+                    "capabilities": [
+                        {
+                            "range": [0, 99],
+                            "name": "nofunction"
+                        },
+                        {
+                            "range": [100, 100],
+                            "name": "Power on"
+                        },
+                        {
+                            "range": [101, 199],
+                            "name": "nofunction"
+                        },
+                        {
+                            "range": [200, 200],
+                            "name": "Power off"
+                        },
+                        {
+                            "range": [201, 201],
+                            "name": "nofunction"
+                        },
+                        {
+                            "range": [202, 202],
+                            "name": "reset servo"
+                        },
+                        {
+                            "range": [203, 203],
+                            "name": "reset trapezoid"
+                        },
+                        {
+                            "range": [204, 255],
+                            "name": "nofunction"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "12-channel Mode",
+                    "shortName": "12ch",
+                    "channels": [
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "Focus",
+                        "Zoom",
+                        "Signal",
+                        "Imgage",
+                        "Trapezoid_vert",
+                        "Trapezoid_hor",
+                        "Shutter",
+                        "Control"
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/fixtures/imports/ecue-MainLibrary/Rainbow.json
+++ b/fixtures/imports/ecue-MainLibrary/Rainbow.json
@@ -1,0 +1,45 @@
+{
+    "manufacturers": {
+        "Rainbow": {
+            "name": "Rainbow",
+            "website": "http://www.rainbow-colour-changers.de/"
+        }
+    },
+    "fixtures": [
+        {
+            "manufacturer": "Rainbow",
+            "name": "Rainbow Pro",
+            "shortName": "RainPro",
+            "physical": {
+                "dimensions": [200, 350, 100]
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "crossfade": true
+                },
+                "SpdPos": {
+                    "type": "Beam"
+                },
+                "SpdFan": {
+                    "type": "Beam"
+                },
+                "Remote": {
+                    "type": "Beam"
+                }
+            },
+            "modes": [
+                {
+                    "name": "4-channel Mode",
+                    "shortName": "4ch",
+                    "channels": [
+                        "Pan",
+                        "SpdPos",
+                        "SpdFan",
+                        "Remote"
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/fixtures/imports/ecue-MainLibrary/Roblon.json
+++ b/fixtures/imports/ecue-MainLibrary/Roblon.json
@@ -1,0 +1,120 @@
+{
+    "manufacturers": {
+        "Roblon": {
+            "name": "Roblon",
+            "website": "www.roblon.com"
+        }
+    },
+    "fixtures": [
+        {
+            "manufacturer": "Roblon",
+            "name": "Fiber Optic Source FL150-2C",
+            "shortName": "FL150-2C",
+            "physical": {
+                "dimensions": [234, 160, 414],
+                "power": 185
+            },
+            "availableChannels": {
+                "Color": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 30],
+                            "name": "white",
+                            "color": "#ffffff"
+                        },
+                        {
+                            "range": [31, 63],
+                            "name": "Green",
+                            "color": "#00ff00"
+                        },
+                        {
+                            "range": [64, 98],
+                            "name": "Orange",
+                            "color": "#ff7f00"
+                        },
+                        {
+                            "range": [99, 130],
+                            "name": "Blue",
+                            "color": "#0000ff"
+                        },
+                        {
+                            "range": [131, 166],
+                            "name": "Red",
+                            "color": "#ff0000"
+                        },
+                        {
+                            "range": [167, 195],
+                            "name": "Yellow",
+                            "color": "#ffff00"
+                        },
+                        {
+                            "range": [196, 221],
+                            "name": "Rotation forwar"
+                        },
+                        {
+                            "range": [223, 248],
+                            "name": "Rotation backwa"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "Reset"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 165,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [167, 167],
+                            "name": "full"
+                        },
+                        {
+                            "range": [168, 254],
+                            "name": "reserved"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "reset"
+                        }
+                    ]
+                },
+                "Control": {
+                    "type": "Beam",
+                    "defaultValue": 120,
+                    "highlightValue": 120,
+                    "capabilities": [
+                        {
+                            "range": [67, 128],
+                            "name": "lamp on"
+                        },
+                        {
+                            "range": [0, 65],
+                            "name": "lamp off"
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "3-channel Mode",
+                    "shortName": "3ch",
+                    "channels": [
+                        "Color",
+                        "Intensity",
+                        "Control"
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/fixtures/imports/ecue-MainLibrary/SGM.json
+++ b/fixtures/imports/ecue-MainLibrary/SGM.json
@@ -1,0 +1,5646 @@
+{
+    "manufacturers": {
+        "SGM": {
+            "name": "SGM",
+            "website": "www.sgmtechnologyforlighting.com"
+        }
+    },
+    "fixtures": [
+        {
+            "manufacturer": "SGM",
+            "name": "Flasher 15 DMX",
+            "shortName": "Flasher1_5",
+            "physical": {
+                "dimensions": [500, 200, 220],
+                "weight": 6,
+                "power": 400
+            },
+            "availableChannels": {
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Rate": {
+                    "type": "Beam",
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "2-channel Mode",
+                    "shortName": "2ch",
+                    "channels": [
+                        "Intensity",
+                        "Rate"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "SGM",
+            "name": "Giotto Profile 400",
+            "shortName": "GPF400",
+            "physical": {
+                "dimensions": [600, 600, 700],
+                "weight": 24.8,
+                "power": 600
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "CTO": {
+                    "type": "MultiColor",
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "Filter Out"
+                        },
+                        {
+                            "range": [128, 255],
+                            "name": "Filter In"
+                        }
+                    ]
+                },
+                "Colour": {
+                    "type": "MultiColor",
+                    "capabilities": [
+                        {
+                            "range": [0, 36],
+                            "name": "WHITE",
+                            "color": "#ffffff",
+                            "center": true
+                        },
+                        {
+                            "range": [37, 72],
+                            "name": "AMBER",
+                            "color": "#ffbf00",
+                            "center": true
+                        },
+                        {
+                            "range": [73, 108],
+                            "name": "GREEN",
+                            "color": "#00ff00",
+                            "center": true
+                        },
+                        {
+                            "range": [109, 144],
+                            "name": "RED",
+                            "color": "#ff0000",
+                            "center": true
+                        },
+                        {
+                            "range": [145, 180],
+                            "name": "MAGENTA",
+                            "color": "#ca1f7b",
+                            "center": true
+                        },
+                        {
+                            "range": [181, 216],
+                            "name": "BLUE",
+                            "color": "#0000ff",
+                            "center": true
+                        },
+                        {
+                            "range": [217, 255],
+                            "name": "YELLOW",
+                            "color": "#ffff00",
+                            "center": true
+                        }
+                    ]
+                },
+                "Effect": {
+                    "type": "Effect",
+                    "capabilities": [
+                        {
+                            "range": [0, 36],
+                            "name": "-",
+                            "center": true
+                        },
+                        {
+                            "range": [37, 72],
+                            "name": "CYAN",
+                            "color": "#00ffff",
+                            "center": true
+                        },
+                        {
+                            "range": [73, 108],
+                            "name": "GOBO",
+                            "center": true
+                        },
+                        {
+                            "range": [109, 144],
+                            "name": "PINK",
+                            "color": "#ffc0cb",
+                            "center": true
+                        },
+                        {
+                            "range": [145, 180],
+                            "name": "GOBO",
+                            "center": true
+                        },
+                        {
+                            "range": [181, 216],
+                            "name": "ORANGE",
+                            "color": "#ff7f00",
+                            "center": true
+                        },
+                        {
+                            "range": [217, 255],
+                            "name": "GOBO",
+                            "center": true
+                        }
+                    ]
+                },
+                "Sht/Strobe": {
+                    "type": "Strobe",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "capabilities": [
+                        {
+                            "range": [0, 7],
+                            "name": "Closed",
+                            "center": true
+                        },
+                        {
+                            "range": [8, 15],
+                            "name": "1 Hz",
+                            "center": true
+                        },
+                        {
+                            "range": [16, 22],
+                            "name": "1.38 Hz",
+                            "center": true
+                        },
+                        {
+                            "range": [24, 31],
+                            "name": "1.6 Hz",
+                            "center": true
+                        },
+                        {
+                            "range": [32, 39],
+                            "name": "1.9 Hz",
+                            "center": true
+                        },
+                        {
+                            "range": [40, 47],
+                            "name": "2.3 Hz",
+                            "center": true
+                        },
+                        {
+                            "range": [48, 55],
+                            "name": "2.7 Hz",
+                            "center": true
+                        },
+                        {
+                            "range": [56, 63],
+                            "name": "3.4 Hz",
+                            "center": true
+                        },
+                        {
+                            "range": [64, 71],
+                            "name": "4 Hz",
+                            "center": true
+                        },
+                        {
+                            "range": [72, 79],
+                            "name": "5 Hz",
+                            "center": true
+                        },
+                        {
+                            "range": [80, 87],
+                            "name": "6 Hz",
+                            "center": true
+                        },
+                        {
+                            "range": [88, 95],
+                            "name": "7 Hz",
+                            "center": true
+                        },
+                        {
+                            "range": [96, 103],
+                            "name": "8 Hz",
+                            "center": true
+                        },
+                        {
+                            "range": [104, 111],
+                            "name": "9 Hz",
+                            "center": true
+                        },
+                        {
+                            "range": [112, 119],
+                            "name": "10 Hz",
+                            "center": true
+                        },
+                        {
+                            "range": [120, 136],
+                            "name": "bass freq strob",
+                            "center": true
+                        },
+                        {
+                            "range": [137, 153],
+                            "name": "music flash low",
+                            "center": true
+                        },
+                        {
+                            "range": [154, 170],
+                            "name": "Autoshade colou",
+                            "center": true
+                        },
+                        {
+                            "range": [171, 187],
+                            "name": "Autoshade effec",
+                            "center": true
+                        },
+                        {
+                            "range": [188, 204],
+                            "name": "Autoshad col+fx",
+                            "center": true
+                        },
+                        {
+                            "range": [205, 255],
+                            "name": "open",
+                            "center": true
+                        }
+                    ]
+                },
+                "Dimmer": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Shut1": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [1, 254],
+                            "name": "Linear Regulati"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "Closed"
+                        }
+                    ]
+                },
+                "Rot Sht 1": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "No Rot"
+                        },
+                        {
+                            "range": [1, 254],
+                            "name": "Linear Reg"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "Max Rot Angle"
+                        }
+                    ]
+                },
+                "Shut2": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [1, 254],
+                            "name": "Linear Regulati"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "Closed"
+                        }
+                    ]
+                },
+                "Rot Sht 2": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "No Rot"
+                        },
+                        {
+                            "range": [1, 254],
+                            "name": "Linear Reg"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "Max Rot Angle"
+                        }
+                    ]
+                },
+                "Shut3": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [1, 254],
+                            "name": "Linear Regulati"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "Closed"
+                        }
+                    ]
+                },
+                "Rot Sht 3": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "No Rot"
+                        },
+                        {
+                            "range": [1, 254],
+                            "name": "Linear Reg"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "Max Rot Angle"
+                        }
+                    ]
+                },
+                "Shut4": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [1, 254],
+                            "name": "Linear Regulati"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "Closed"
+                        }
+                    ]
+                },
+                "Rot Sht 4": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "No Rot"
+                        },
+                        {
+                            "range": [1, 254],
+                            "name": "Linear Reg"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "Max Rot Angle"
+                        }
+                    ]
+                },
+                "Reset/Lamp": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "off"
+                        },
+                        {
+                            "range": [61, 129],
+                            "name": "Hysteresis"
+                        },
+                        {
+                            "range": [130, 179],
+                            "name": "on"
+                        },
+                        {
+                            "range": [180, 239],
+                            "name": "Hysteresis"
+                        },
+                        {
+                            "range": [240, 255],
+                            "name": "Reset"
+                        }
+                    ]
+                },
+                "MoveSpeed": {
+                    "type": "Speed",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 3],
+                            "name": "Crossfade"
+                        },
+                        {
+                            "range": [4, 255],
+                            "name": "slowest fastest"
+                        }
+                    ]
+                },
+                "Focus": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Zoom": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "In 12"
+                        },
+                        {
+                            "range": [1, 254],
+                            "name": "Linear"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "Out 18"
+                        }
+                    ]
+                },
+                "Frost": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "disabled"
+                        },
+                        {
+                            "range": [1, 254],
+                            "name": "linear"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "fully inserted"
+                        }
+                    ]
+                },
+                "Colour-u1fpe": {
+                    "name": "Colour",
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "MusicHardChange"
+                        }
+                    ]
+                },
+                "Effect-1w06x": {
+                    "name": "Effect",
+                    "type": "Effect",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 85],
+                            "name": "Full Col.Effect",
+                            "center": true
+                        },
+                        {
+                            "range": [86, 170],
+                            "name": "Rainbow soft",
+                            "center": true
+                        },
+                        {
+                            "range": [171, 255],
+                            "name": "MusicHardChange",
+                            "center": true
+                        }
+                    ]
+                },
+                "Shake 1": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 47],
+                            "name": "disinserito",
+                            "center": true
+                        },
+                        {
+                            "range": [48, 60],
+                            "name": "Speed 1",
+                            "center": true
+                        },
+                        {
+                            "range": [61, 73],
+                            "name": "Speed 2",
+                            "center": true
+                        },
+                        {
+                            "range": [74, 86],
+                            "name": "Speed 3",
+                            "center": true
+                        },
+                        {
+                            "range": [87, 99],
+                            "name": "Speed 4",
+                            "center": true
+                        },
+                        {
+                            "range": [100, 112],
+                            "name": "Speed 5",
+                            "center": true
+                        },
+                        {
+                            "range": [113, 125],
+                            "name": "Speed 6",
+                            "center": true
+                        },
+                        {
+                            "range": [126, 138],
+                            "name": "Speed 7",
+                            "center": true
+                        },
+                        {
+                            "range": [139, 151],
+                            "name": "Speed 8",
+                            "center": true
+                        },
+                        {
+                            "range": [152, 164],
+                            "name": "Speed 9",
+                            "center": true
+                        },
+                        {
+                            "range": [165, 177],
+                            "name": "Speed 10",
+                            "center": true
+                        },
+                        {
+                            "range": [178, 190],
+                            "name": "Speed 11",
+                            "center": true
+                        },
+                        {
+                            "range": [191, 203],
+                            "name": "Speed 12",
+                            "center": true
+                        },
+                        {
+                            "range": [204, 216],
+                            "name": "Speed 13",
+                            "center": true
+                        },
+                        {
+                            "range": [217, 229],
+                            "name": "Speed 14",
+                            "center": true
+                        },
+                        {
+                            "range": [230, 242],
+                            "name": "Speed 15",
+                            "center": true
+                        },
+                        {
+                            "range": [243, 255],
+                            "name": "Speed16",
+                            "center": true
+                        }
+                    ]
+                },
+                "Shake 2": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 47],
+                            "name": "disinserito",
+                            "center": true
+                        },
+                        {
+                            "range": [48, 60],
+                            "name": "Speed 1",
+                            "center": true
+                        },
+                        {
+                            "range": [61, 73],
+                            "name": "Speed 2",
+                            "center": true
+                        },
+                        {
+                            "range": [74, 86],
+                            "name": "Speed 3",
+                            "center": true
+                        },
+                        {
+                            "range": [87, 99],
+                            "name": "Speed 4",
+                            "center": true
+                        },
+                        {
+                            "range": [100, 112],
+                            "name": "Speed 5",
+                            "center": true
+                        },
+                        {
+                            "range": [113, 125],
+                            "name": "Speed 6",
+                            "center": true
+                        },
+                        {
+                            "range": [126, 138],
+                            "name": "Speed 7",
+                            "center": true
+                        },
+                        {
+                            "range": [139, 151],
+                            "name": "Speed 8",
+                            "center": true
+                        },
+                        {
+                            "range": [152, 164],
+                            "name": "Speed 9",
+                            "center": true
+                        },
+                        {
+                            "range": [165, 177],
+                            "name": "Speed 10",
+                            "center": true
+                        },
+                        {
+                            "range": [178, 190],
+                            "name": "Speed 11",
+                            "center": true
+                        },
+                        {
+                            "range": [191, 203],
+                            "name": "Speed 12",
+                            "center": true
+                        },
+                        {
+                            "range": [204, 216],
+                            "name": "Speed 13",
+                            "center": true
+                        },
+                        {
+                            "range": [217, 229],
+                            "name": "Speed 14",
+                            "center": true
+                        },
+                        {
+                            "range": [230, 242],
+                            "name": "Speed 15",
+                            "center": true
+                        },
+                        {
+                            "range": [243, 255],
+                            "name": "Speed16",
+                            "center": true
+                        }
+                    ]
+                },
+                "Macro": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 7],
+                            "name": "No Macro",
+                            "center": true
+                        },
+                        {
+                            "range": [8, 15],
+                            "name": "Macro 1",
+                            "center": true
+                        },
+                        {
+                            "range": [16, 23],
+                            "name": "Macro 2",
+                            "center": true
+                        },
+                        {
+                            "range": [24, 31],
+                            "name": "Macro 3",
+                            "center": true
+                        },
+                        {
+                            "range": [32, 39],
+                            "name": "Macro 4",
+                            "center": true
+                        },
+                        {
+                            "range": [40, 47],
+                            "name": "Macro 5",
+                            "center": true
+                        },
+                        {
+                            "range": [48, 55],
+                            "name": "Macro 6",
+                            "center": true
+                        },
+                        {
+                            "range": [56, 63],
+                            "name": "Macro 7",
+                            "center": true
+                        },
+                        {
+                            "range": [64, 71],
+                            "name": "Macro 8",
+                            "center": true
+                        },
+                        {
+                            "range": [72, 79],
+                            "name": "Macro 9",
+                            "center": true
+                        },
+                        {
+                            "range": [80, 87],
+                            "name": "Macro 10",
+                            "center": true
+                        },
+                        {
+                            "range": [88, 95],
+                            "name": "Macro 11",
+                            "center": true
+                        },
+                        {
+                            "range": [96, 255],
+                            "name": "reserved"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "27-channel Mode",
+                    "shortName": "27ch",
+                    "channels": [
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "CTO",
+                        "Colour",
+                        "Effect",
+                        "Sht/Strobe",
+                        "Dimmer",
+                        "Shut1",
+                        "Rot Sht 1",
+                        "Shut2",
+                        "Rot Sht 2",
+                        "Shut3",
+                        "Rot Sht 3",
+                        "Shut4",
+                        "Rot Sht 4",
+                        "Reset/Lamp",
+                        "MoveSpeed",
+                        "Focus",
+                        "Zoom",
+                        "Frost",
+                        "Colour-u1fpe",
+                        "Effect-1w06x",
+                        "Shake 1",
+                        "Shake 2",
+                        "Macro"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "SGM",
+            "name": "Giotto Spot 1200",
+            "shortName": "GSP1200",
+            "physical": {
+                "dimensions": [550, 550, 800],
+                "weight": 47,
+                "power": 2000
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Iris": {
+                    "type": "Beam",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Color": {
+                    "type": "MultiColor",
+                    "capabilities": [
+                        {
+                            "range": [3, 10],
+                            "name": "white",
+                            "color": "#ffffff"
+                        },
+                        {
+                            "range": [11, 17],
+                            "name": "Pink",
+                            "color": "#ffc0cb"
+                        },
+                        {
+                            "range": [18, 24],
+                            "name": "Magenta",
+                            "color": "#ca1f7b"
+                        },
+                        {
+                            "range": [25, 31],
+                            "name": "Lavender",
+                            "color": "#b57edc"
+                        },
+                        {
+                            "range": [32, 38],
+                            "name": "Blu Light"
+                        },
+                        {
+                            "range": [39, 45],
+                            "name": "Azure",
+                            "color": "#007fff"
+                        },
+                        {
+                            "range": [46, 52],
+                            "name": "Cyan",
+                            "color": "#00ffff"
+                        },
+                        {
+                            "range": [53, 59],
+                            "name": "Yellow",
+                            "color": "#ffff00"
+                        },
+                        {
+                            "range": [60, 66],
+                            "name": "Amber",
+                            "color": "#ffbf00"
+                        },
+                        {
+                            "range": [67, 73],
+                            "name": "Flame Red"
+                        },
+                        {
+                            "range": [74, 80],
+                            "name": "Wood"
+                        },
+                        {
+                            "range": [81, 87],
+                            "name": "Primary Red"
+                        },
+                        {
+                            "range": [88, 94],
+                            "name": "Light Green",
+                            "color": "#90ee90"
+                        },
+                        {
+                            "range": [95, 101],
+                            "name": "Green Azure"
+                        },
+                        {
+                            "range": [102, 108],
+                            "name": "Green Amber"
+                        },
+                        {
+                            "range": [109, 115],
+                            "name": "Yellow Green",
+                            "color": "#9acd32"
+                        },
+                        {
+                            "range": [116, 122],
+                            "name": "Green Cyan",
+                            "color": "#009966"
+                        },
+                        {
+                            "range": [123, 129],
+                            "name": "Green Yellow",
+                            "color": "#adff2f"
+                        },
+                        {
+                            "range": [130, 136],
+                            "name": "Dark Red",
+                            "color": "#8b0000"
+                        },
+                        {
+                            "range": [137, 143],
+                            "name": "Light Med Blue"
+                        },
+                        {
+                            "range": [144, 150],
+                            "name": "Green",
+                            "color": "#00ff00"
+                        },
+                        {
+                            "range": [151, 157],
+                            "name": "Med Blue"
+                        },
+                        {
+                            "range": [158, 164],
+                            "name": "Med Red"
+                        },
+                        {
+                            "range": [165, 171],
+                            "name": "Orange",
+                            "color": "#ff7f00"
+                        },
+                        {
+                            "range": [172, 178],
+                            "name": "Dark Purple",
+                            "color": "#301934"
+                        },
+                        {
+                            "range": [179, 185],
+                            "name": "Rainbow S1"
+                        },
+                        {
+                            "range": [186, 192],
+                            "name": "Rainbow S2"
+                        },
+                        {
+                            "range": [193, 206],
+                            "name": "Rainbow S3"
+                        },
+                        {
+                            "range": [207, 213],
+                            "name": "Music Beat 1"
+                        },
+                        {
+                            "range": [214, 220],
+                            "name": "Music Beat 2"
+                        },
+                        {
+                            "range": [221, 235],
+                            "name": "Music Beat 3"
+                        },
+                        {
+                            "range": [236, 255],
+                            "name": "Music Beat 4"
+                        }
+                    ]
+                },
+                "Gobo": {
+                    "type": "Gobo",
+                    "defaultValue": 10,
+                    "highlightValue": 10,
+                    "capabilities": [
+                        {
+                            "range": [4, 12],
+                            "name": "White A-WhiteB"
+                        },
+                        {
+                            "range": [13, 21],
+                            "name": "White A-White1B"
+                        },
+                        {
+                            "range": [22, 30],
+                            "name": "White A-Gobo2B"
+                        },
+                        {
+                            "range": [31, 39],
+                            "name": "WhiteA-Gobo3B"
+                        },
+                        {
+                            "range": [40, 48],
+                            "name": "WhiteA-Gobo4B"
+                        },
+                        {
+                            "range": [49, 57],
+                            "name": "Gobo4B-WhiteB"
+                        },
+                        {
+                            "range": [58, 66],
+                            "name": "Gobo3B-WhiteB"
+                        },
+                        {
+                            "range": [67, 75],
+                            "name": "Gobo2B-WhiteB"
+                        },
+                        {
+                            "range": [76, 84],
+                            "name": "Gobo1B-WhiteB"
+                        },
+                        {
+                            "range": [85, 93],
+                            "name": "Gobo1A-Gobo1B"
+                        },
+                        {
+                            "range": [94, 102],
+                            "name": "Gobo2A-Gobo1B"
+                        },
+                        {
+                            "range": [103, 111],
+                            "name": "Gobo3A-Gobo1B"
+                        },
+                        {
+                            "range": [112, 120],
+                            "name": "Gobo4A-Gobo1B"
+                        },
+                        {
+                            "range": [121, 129],
+                            "name": "Gobo4A-Gobo2B"
+                        },
+                        {
+                            "range": [130, 138],
+                            "name": "Gobo3A-Gobo2B"
+                        },
+                        {
+                            "range": [139, 147],
+                            "name": "Gobo2A-Gobo2B"
+                        },
+                        {
+                            "range": [148, 156],
+                            "name": "Gobo1A-Gobo2B"
+                        },
+                        {
+                            "range": [157, 165],
+                            "name": "Gobo1A-Gobo3B"
+                        },
+                        {
+                            "range": [166, 174],
+                            "name": "Gobo2A-Gobo3B"
+                        },
+                        {
+                            "range": [175, 183],
+                            "name": "Gobo3A-Gobo3B"
+                        },
+                        {
+                            "range": [184, 192],
+                            "name": "Gobo4A-Gobo3B"
+                        },
+                        {
+                            "range": [193, 201],
+                            "name": "Gobo4A-Gobo4B"
+                        },
+                        {
+                            "range": [202, 210],
+                            "name": "Gobo3A-Gobo4B"
+                        },
+                        {
+                            "range": [211, 219],
+                            "name": "Gobo2A-Gobo4B"
+                        },
+                        {
+                            "range": [220, 229],
+                            "name": "Gobo1A-Gobo4B"
+                        },
+                        {
+                            "range": [230, 236],
+                            "name": "RainbowAS1"
+                        },
+                        {
+                            "range": [237, 244],
+                            "name": "RainbowAS2"
+                        },
+                        {
+                            "range": [245, 252],
+                            "name": "RainbowAS3"
+                        },
+                        {
+                            "range": [253, 255],
+                            "name": "Music"
+                        }
+                    ]
+                },
+                "Shutter": {
+                    "type": "Shutter",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "capabilities": [
+                        {
+                            "range": [0, 11],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [12, 127],
+                            "name": "speed"
+                        },
+                        {
+                            "range": [128, 144],
+                            "name": "strobe"
+                        },
+                        {
+                            "range": [145, 161],
+                            "name": "music"
+                        },
+                        {
+                            "range": [162, 178],
+                            "name": "shade.gobo"
+                        },
+                        {
+                            "range": [179, 212],
+                            "name": "shade.color"
+                        },
+                        {
+                            "range": [213, 254],
+                            "name": "gobo.ch"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "open"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Gobo.Rot": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "position"
+                        }
+                    ]
+                },
+                "Prism": {
+                    "type": "Prism",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 84],
+                            "name": "none"
+                        },
+                        {
+                            "range": [85, 170],
+                            "name": "4-faced"
+                        },
+                        {
+                            "range": [171, 255],
+                            "name": "9-faced"
+                        }
+                    ]
+                },
+                "Prism.Rot": {
+                    "type": "Prism",
+                    "defaultValue": 112,
+                    "highlightValue": 112,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 111],
+                            "name": "CW"
+                        },
+                        {
+                            "range": [112, 143],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [144, 255],
+                            "name": "ccw"
+                        }
+                    ]
+                },
+                "Focus": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Lense": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [21, 9],
+                            "name": "6 Degree"
+                        },
+                        {
+                            "range": [64, 106],
+                            "name": "no lens"
+                        },
+                        {
+                            "range": [107, 14],
+                            "name": "5 Degree"
+                        },
+                        {
+                            "range": [150, 17],
+                            "name": "7 Degree"
+                        },
+                        {
+                            "range": [193, 234],
+                            "name": "Multi-focal"
+                        },
+                        {
+                            "range": [235, 255],
+                            "name": "Frost",
+                            "color": "#edf5dd"
+                        }
+                    ]
+                },
+                "Filters": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [18, 54],
+                            "name": "white",
+                            "color": "#ffffff"
+                        },
+                        {
+                            "range": [55, 91],
+                            "name": "Yellow/Cyan"
+                        },
+                        {
+                            "range": [92, 128],
+                            "name": "Green/Red"
+                        },
+                        {
+                            "range": [129, 165],
+                            "name": "White/Yellow"
+                        },
+                        {
+                            "range": [166, 202],
+                            "name": "White/Cyan"
+                        },
+                        {
+                            "range": [203, 237],
+                            "name": "D46 CTO"
+                        },
+                        {
+                            "range": [238, 255],
+                            "name": "D46 1/2 CTO"
+                        }
+                    ]
+                },
+                "Frost": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Speed": {
+                    "type": "Speed",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Reset": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 60],
+                            "name": "off"
+                        },
+                        {
+                            "range": [61, 129],
+                            "name": "hysterese"
+                        },
+                        {
+                            "range": [130, 179],
+                            "name": "on"
+                        },
+                        {
+                            "range": [180, 239],
+                            "name": "hysterese"
+                        },
+                        {
+                            "range": [240, 255],
+                            "name": "reset"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "18-channel Mode",
+                    "shortName": "18ch",
+                    "channels": [
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "Iris",
+                        "Color",
+                        "Gobo",
+                        "Shutter",
+                        "Intensity",
+                        "Gobo.Rot",
+                        "Prism",
+                        "Prism.Rot",
+                        "Focus",
+                        "Lense",
+                        "Filters",
+                        "Frost",
+                        "Speed",
+                        "Reset"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "SGM",
+            "name": "Giotto Spot 250",
+            "shortName": "GSP250",
+            "physical": {
+                "dimensions": [500, 500, 500],
+                "weight": 27,
+                "power": 400
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Iris": {
+                    "type": "Beam",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Color": {
+                    "type": "MultiColor",
+                    "capabilities": [
+                        {
+                            "range": [12, 36],
+                            "name": "white",
+                            "color": "#ffffff"
+                        },
+                        {
+                            "range": [37, 61],
+                            "name": "red",
+                            "color": "#ff0000"
+                        },
+                        {
+                            "range": [62, 86],
+                            "name": "yellow",
+                            "color": "#ffff00"
+                        },
+                        {
+                            "range": [87, 111],
+                            "name": "green",
+                            "color": "#00ff00"
+                        },
+                        {
+                            "range": [112, 136],
+                            "name": "lightblue",
+                            "color": "#add8e6"
+                        },
+                        {
+                            "range": [137, 161],
+                            "name": "blue",
+                            "color": "#0000ff"
+                        },
+                        {
+                            "range": [162, 186],
+                            "name": "magenta",
+                            "color": "#ca1f7b"
+                        },
+                        {
+                            "range": [187, 211],
+                            "name": "pink",
+                            "color": "#ffc0cb"
+                        },
+                        {
+                            "range": [212, 236],
+                            "name": "bernstein"
+                        },
+                        {
+                            "range": [237, 255],
+                            "name": "orange",
+                            "color": "#ff7f00"
+                        }
+                    ]
+                },
+                "Gobo": {
+                    "type": "Gobo",
+                    "defaultValue": 10,
+                    "highlightValue": 10,
+                    "capabilities": [
+                        {
+                            "range": [10, 30],
+                            "name": "open"
+                        },
+                        {
+                            "range": [31, 51],
+                            "name": "gobo1"
+                        },
+                        {
+                            "range": [52, 72],
+                            "name": "gobo2"
+                        },
+                        {
+                            "range": [73, 93],
+                            "name": "gobo3"
+                        },
+                        {
+                            "range": [94, 114],
+                            "name": "gobo4"
+                        },
+                        {
+                            "range": [115, 135],
+                            "name": "gobo5"
+                        },
+                        {
+                            "range": [136, 156],
+                            "name": "gobo6"
+                        },
+                        {
+                            "range": [157, 177],
+                            "name": "gobo7"
+                        },
+                        {
+                            "range": [178, 192],
+                            "name": "gobo8"
+                        },
+                        {
+                            "range": [193, 199],
+                            "name": "rainbow1"
+                        },
+                        {
+                            "range": [200, 206],
+                            "name": "rainbow2"
+                        },
+                        {
+                            "range": [207, 213],
+                            "name": "rainbow3"
+                        },
+                        {
+                            "range": [214, 220],
+                            "name": "rainbow4"
+                        },
+                        {
+                            "range": [221, 227],
+                            "name": "rainbow5"
+                        },
+                        {
+                            "range": [228, 234],
+                            "name": "rainbow6"
+                        },
+                        {
+                            "range": [235, 241],
+                            "name": "rainbow7"
+                        },
+                        {
+                            "range": [242, 251],
+                            "name": "rainbow8"
+                        },
+                        {
+                            "range": [252, 255],
+                            "name": "music"
+                        }
+                    ]
+                },
+                "Shutter": {
+                    "type": "Shutter",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "capabilities": [
+                        {
+                            "range": [0, 11],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [12, 127],
+                            "name": "speed"
+                        },
+                        {
+                            "range": [128, 144],
+                            "name": "strobe"
+                        },
+                        {
+                            "range": [145, 161],
+                            "name": "music"
+                        },
+                        {
+                            "range": [162, 178],
+                            "name": "shade.gobo"
+                        },
+                        {
+                            "range": [179, 212],
+                            "name": "shade.color"
+                        },
+                        {
+                            "range": [213, 254],
+                            "name": "gobo.ch"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "open"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Gobo.Rot": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "position"
+                        }
+                    ]
+                },
+                "Prism": {
+                    "type": "Prism",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 84],
+                            "name": "none"
+                        },
+                        {
+                            "range": [85, 170],
+                            "name": "comet",
+                            "color": "#5c5d75"
+                        },
+                        {
+                            "range": [171, 255],
+                            "name": "4-facet"
+                        }
+                    ]
+                },
+                "Prism.Rot": {
+                    "type": "Prism",
+                    "defaultValue": 112,
+                    "highlightValue": 112,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 111],
+                            "name": "CW"
+                        },
+                        {
+                            "range": [112, 143],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [144, 255],
+                            "name": "ccw"
+                        }
+                    ]
+                },
+                "Edge": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Zoom": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Effects": {
+                    "type": "Effect",
+                    "capabilities": [
+                        {
+                            "range": [0, 46],
+                            "name": "white",
+                            "color": "#ffffff"
+                        },
+                        {
+                            "range": [47, 77],
+                            "name": "gobo1"
+                        },
+                        {
+                            "range": [78, 108],
+                            "name": "stripped"
+                        },
+                        {
+                            "range": [109, 139],
+                            "name": "honeycomb"
+                        },
+                        {
+                            "range": [140, 170],
+                            "name": "gobo2"
+                        },
+                        {
+                            "range": [171, 201],
+                            "name": "wood"
+                        },
+                        {
+                            "range": [202, 235],
+                            "name": "1/2CTO"
+                        },
+                        {
+                            "range": [236, 255],
+                            "name": "CTO"
+                        }
+                    ]
+                },
+                "Frost": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Speed": {
+                    "type": "Speed",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Reset": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 60],
+                            "name": "off"
+                        },
+                        {
+                            "range": [61, 129],
+                            "name": "hysterese"
+                        },
+                        {
+                            "range": [130, 179],
+                            "name": "on"
+                        },
+                        {
+                            "range": [180, 239],
+                            "name": "hysterese"
+                        },
+                        {
+                            "range": [240, 255],
+                            "name": "reset"
+                        }
+                    ]
+                },
+                "Gobo.Shake": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 47],
+                            "name": "off"
+                        },
+                        {
+                            "range": [48, 255],
+                            "name": "speed"
+                        }
+                    ]
+                },
+                "Mod_Color": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 50],
+                            "name": "full.color"
+                        },
+                        {
+                            "range": [51, 101],
+                            "name": "half.color"
+                        },
+                        {
+                            "range": [102, 152],
+                            "name": "soft.color"
+                        },
+                        {
+                            "range": [153, 203],
+                            "name": "rainbow"
+                        },
+                        {
+                            "range": [204, 255],
+                            "name": "music"
+                        }
+                    ]
+                },
+                "Mod_GBrot": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "position"
+                        },
+                        {
+                            "range": [128, 255],
+                            "name": "rotation"
+                        }
+                    ]
+                },
+                "Macro": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 7],
+                            "name": "off"
+                        },
+                        {
+                            "range": [8, 15],
+                            "name": "macro1"
+                        },
+                        {
+                            "range": [16, 23],
+                            "name": "macro2"
+                        },
+                        {
+                            "range": [24, 31],
+                            "name": "macro3"
+                        },
+                        {
+                            "range": [32, 39],
+                            "name": "macro4"
+                        },
+                        {
+                            "range": [40, 47],
+                            "name": "macro5"
+                        },
+                        {
+                            "range": [48, 55],
+                            "name": "macro6"
+                        },
+                        {
+                            "range": [56, 63],
+                            "name": "macro7"
+                        },
+                        {
+                            "range": [64, 71],
+                            "name": "macro8"
+                        },
+                        {
+                            "range": [72, 79],
+                            "name": "macro9"
+                        },
+                        {
+                            "range": [80, 87],
+                            "name": "macro10"
+                        },
+                        {
+                            "range": [88, 95],
+                            "name": "macro11"
+                        },
+                        {
+                            "range": [96, 103],
+                            "name": "macro12"
+                        },
+                        {
+                            "range": [104, 111],
+                            "name": "macro13"
+                        },
+                        {
+                            "range": [112, 119],
+                            "name": "macro14"
+                        },
+                        {
+                            "range": [120, 127],
+                            "name": "macro15"
+                        },
+                        {
+                            "range": [128, 135],
+                            "name": "macro16"
+                        },
+                        {
+                            "range": [136, 255],
+                            "name": "reserved"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "22-channel Mode",
+                    "shortName": "22ch",
+                    "channels": [
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "Iris",
+                        "Color",
+                        "Gobo",
+                        "Shutter",
+                        "Intensity",
+                        "Gobo.Rot",
+                        "Prism",
+                        "Prism.Rot",
+                        "Edge",
+                        "Zoom",
+                        "Effects",
+                        "Frost",
+                        "Speed",
+                        "Reset",
+                        "Gobo.Shake",
+                        "Mod_Color",
+                        "Mod_GBrot",
+                        "Macro"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "SGM",
+            "name": "Giotto Spot 400",
+            "shortName": "GSP400",
+            "physical": {
+                "dimensions": [450, 450, 700],
+                "weight": 28.5,
+                "power": 600
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Iris": {
+                    "type": "Beam",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Color": {
+                    "type": "MultiColor",
+                    "capabilities": [
+                        {
+                            "range": [14, 40],
+                            "name": "white",
+                            "color": "#ffffff"
+                        },
+                        {
+                            "range": [41, 67],
+                            "name": "red",
+                            "color": "#ff0000"
+                        },
+                        {
+                            "range": [68, 96],
+                            "name": "yellow",
+                            "color": "#ffff00"
+                        },
+                        {
+                            "range": [97, 124],
+                            "name": "green",
+                            "color": "#00ff00"
+                        },
+                        {
+                            "range": [125, 152],
+                            "name": "lightblue",
+                            "color": "#add8e6"
+                        },
+                        {
+                            "range": [153, 180],
+                            "name": "blue",
+                            "color": "#0000ff"
+                        },
+                        {
+                            "range": [181, 208],
+                            "name": "magenta",
+                            "color": "#ca1f7b"
+                        },
+                        {
+                            "range": [209, 238],
+                            "name": "azur"
+                        },
+                        {
+                            "range": [239, 255],
+                            "name": "orange",
+                            "color": "#ff7f00"
+                        }
+                    ]
+                },
+                "Gobo": {
+                    "type": "Gobo",
+                    "defaultValue": 10,
+                    "highlightValue": 10,
+                    "capabilities": [
+                        {
+                            "range": [10, 30],
+                            "name": "open"
+                        },
+                        {
+                            "range": [31, 51],
+                            "name": "gobo1"
+                        },
+                        {
+                            "range": [52, 72],
+                            "name": "gobo2"
+                        },
+                        {
+                            "range": [73, 93],
+                            "name": "gobo3"
+                        },
+                        {
+                            "range": [94, 114],
+                            "name": "gobo4"
+                        },
+                        {
+                            "range": [115, 135],
+                            "name": "gobo5"
+                        },
+                        {
+                            "range": [136, 156],
+                            "name": "gobo6"
+                        },
+                        {
+                            "range": [157, 177],
+                            "name": "gobo7"
+                        },
+                        {
+                            "range": [178, 192],
+                            "name": "gobo8"
+                        },
+                        {
+                            "range": [193, 199],
+                            "name": "rainbow1"
+                        },
+                        {
+                            "range": [200, 206],
+                            "name": "rainbow2"
+                        },
+                        {
+                            "range": [207, 213],
+                            "name": "rainbow3"
+                        },
+                        {
+                            "range": [214, 220],
+                            "name": "rainbow4"
+                        },
+                        {
+                            "range": [221, 227],
+                            "name": "rainbow5"
+                        },
+                        {
+                            "range": [228, 234],
+                            "name": "rainbow6"
+                        },
+                        {
+                            "range": [235, 241],
+                            "name": "rainbow7"
+                        },
+                        {
+                            "range": [242, 251],
+                            "name": "rainbow8"
+                        },
+                        {
+                            "range": [252, 255],
+                            "name": "music"
+                        }
+                    ]
+                },
+                "Shutter": {
+                    "type": "Shutter",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "capabilities": [
+                        {
+                            "range": [0, 11],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [12, 127],
+                            "name": "speed"
+                        },
+                        {
+                            "range": [128, 144],
+                            "name": "strobe"
+                        },
+                        {
+                            "range": [145, 161],
+                            "name": "music"
+                        },
+                        {
+                            "range": [162, 178],
+                            "name": "shade.gobo"
+                        },
+                        {
+                            "range": [179, 212],
+                            "name": "shade.color"
+                        },
+                        {
+                            "range": [213, 254],
+                            "name": "gobo.ch"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "open"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Gobo.Rot": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "position"
+                        }
+                    ]
+                },
+                "Prism": {
+                    "type": "Prism",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 84],
+                            "name": "none"
+                        },
+                        {
+                            "range": [85, 170],
+                            "name": "comet",
+                            "color": "#5c5d75"
+                        },
+                        {
+                            "range": [171, 255],
+                            "name": "4-facet"
+                        }
+                    ]
+                },
+                "Prism.Rot": {
+                    "type": "Prism",
+                    "defaultValue": 112,
+                    "highlightValue": 112,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 111],
+                            "name": "CW"
+                        },
+                        {
+                            "range": [112, 143],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [144, 255],
+                            "name": "ccw"
+                        }
+                    ]
+                },
+                "Edge": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Zoom": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Effects": {
+                    "type": "Effect",
+                    "capabilities": [
+                        {
+                            "range": [0, 40],
+                            "name": "white",
+                            "color": "#ffffff"
+                        },
+                        {
+                            "range": [41, 67],
+                            "name": "gobo1"
+                        },
+                        {
+                            "range": [68, 96],
+                            "name": "stripped"
+                        },
+                        {
+                            "range": [97, 124],
+                            "name": "honeycomb"
+                        },
+                        {
+                            "range": [125, 152],
+                            "name": "gobo2"
+                        },
+                        {
+                            "range": [153, 180],
+                            "name": "wood"
+                        },
+                        {
+                            "range": [181, 208],
+                            "name": "1/2CTO"
+                        },
+                        {
+                            "range": [209, 238],
+                            "name": "CTO"
+                        },
+                        {
+                            "range": [239, 255],
+                            "name": "bernstein"
+                        }
+                    ]
+                },
+                "Frost": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Speed": {
+                    "type": "Speed",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Reset": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 60],
+                            "name": "off"
+                        },
+                        {
+                            "range": [61, 129],
+                            "name": "hysterese"
+                        },
+                        {
+                            "range": [130, 179],
+                            "name": "on"
+                        },
+                        {
+                            "range": [180, 239],
+                            "name": "hysterese"
+                        },
+                        {
+                            "range": [240, 255],
+                            "name": "reset"
+                        }
+                    ]
+                },
+                "Gobo.Shake": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 47],
+                            "name": "off"
+                        },
+                        {
+                            "range": [48, 255],
+                            "name": "speed"
+                        }
+                    ]
+                },
+                "Mod_Color": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 50],
+                            "name": "full.color"
+                        },
+                        {
+                            "range": [51, 101],
+                            "name": "half.color"
+                        },
+                        {
+                            "range": [102, 152],
+                            "name": "soft.color"
+                        },
+                        {
+                            "range": [153, 203],
+                            "name": "rainbow"
+                        },
+                        {
+                            "range": [204, 255],
+                            "name": "music"
+                        }
+                    ]
+                },
+                "Mod_GBrot": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "position"
+                        },
+                        {
+                            "range": [128, 255],
+                            "name": "rotation"
+                        }
+                    ]
+                },
+                "Macro": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 7],
+                            "name": "off"
+                        },
+                        {
+                            "range": [8, 15],
+                            "name": "macro1"
+                        },
+                        {
+                            "range": [16, 23],
+                            "name": "macro2"
+                        },
+                        {
+                            "range": [24, 31],
+                            "name": "macro3"
+                        },
+                        {
+                            "range": [32, 39],
+                            "name": "macro4"
+                        },
+                        {
+                            "range": [40, 47],
+                            "name": "macro5"
+                        },
+                        {
+                            "range": [48, 55],
+                            "name": "macro6"
+                        },
+                        {
+                            "range": [56, 63],
+                            "name": "macro7"
+                        },
+                        {
+                            "range": [64, 71],
+                            "name": "macro8"
+                        },
+                        {
+                            "range": [72, 79],
+                            "name": "macro9"
+                        },
+                        {
+                            "range": [80, 87],
+                            "name": "macro10"
+                        },
+                        {
+                            "range": [88, 95],
+                            "name": "macro11"
+                        },
+                        {
+                            "range": [96, 103],
+                            "name": "macro12"
+                        },
+                        {
+                            "range": [104, 111],
+                            "name": "macro13"
+                        },
+                        {
+                            "range": [112, 119],
+                            "name": "macro14"
+                        },
+                        {
+                            "range": [120, 127],
+                            "name": "macro15"
+                        },
+                        {
+                            "range": [128, 135],
+                            "name": "macro16"
+                        },
+                        {
+                            "range": [136, 255],
+                            "name": "reserved"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "22-channel Mode",
+                    "shortName": "22ch",
+                    "channels": [
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "Iris",
+                        "Color",
+                        "Gobo",
+                        "Shutter",
+                        "Intensity",
+                        "Gobo.Rot",
+                        "Prism",
+                        "Prism.Rot",
+                        "Edge",
+                        "Zoom",
+                        "Effects",
+                        "Frost",
+                        "Speed",
+                        "Reset",
+                        "Gobo.Shake",
+                        "Mod_Color",
+                        "Mod_GBrot",
+                        "Macro"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "SGM",
+            "name": "Giotto Spot 400 CMY",
+            "shortName": "GSP400CMY",
+            "comment": "cd",
+            "physical": {
+                "dimensions": [450, 450, 700],
+                "weight": 28.5,
+                "power": 600
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Iris": {
+                    "type": "Beam",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Color": {
+                    "type": "MultiColor",
+                    "capabilities": [
+                        {
+                            "range": [0, 35],
+                            "name": "open",
+                            "center": true
+                        },
+                        {
+                            "range": [36, 71],
+                            "name": "red",
+                            "color": "#ff0000",
+                            "center": true
+                        },
+                        {
+                            "range": [72, 107],
+                            "name": "green",
+                            "color": "#00ff00",
+                            "center": true
+                        },
+                        {
+                            "range": [108, 145],
+                            "name": "blue",
+                            "color": "#0000ff",
+                            "center": true
+                        },
+                        {
+                            "range": [146, 181],
+                            "name": "pink",
+                            "color": "#ffc0cb",
+                            "center": true
+                        },
+                        {
+                            "range": [182, 215],
+                            "name": "amber",
+                            "color": "#ffbf00",
+                            "center": true
+                        },
+                        {
+                            "range": [216, 255],
+                            "name": "wood",
+                            "center": true
+                        }
+                    ]
+                },
+                "Gobo1": {
+                    "type": "Gobo",
+                    "defaultValue": 10,
+                    "highlightValue": 10,
+                    "capabilities": [
+                        {
+                            "range": [0, 20],
+                            "name": "open",
+                            "center": true
+                        },
+                        {
+                            "range": [21, 41],
+                            "name": "slot1",
+                            "center": true
+                        },
+                        {
+                            "range": [42, 62],
+                            "name": "slot2",
+                            "center": true
+                        },
+                        {
+                            "range": [63, 83],
+                            "name": "slot3"
+                        },
+                        {
+                            "range": [84, 104],
+                            "name": "slot4"
+                        },
+                        {
+                            "range": [105, 125],
+                            "name": "slot5",
+                            "center": true
+                        },
+                        {
+                            "range": [126, 146],
+                            "name": "slot6"
+                        },
+                        {
+                            "range": [147, 167],
+                            "name": "slot7"
+                        },
+                        {
+                            "range": [168, 189],
+                            "name": "slot8",
+                            "center": true
+                        },
+                        {
+                            "range": [190, 245],
+                            "name": ">>",
+                            "center": true
+                        },
+                        {
+                            "range": [252, 255],
+                            "name": "music"
+                        }
+                    ]
+                },
+                "Shutter": {
+                    "type": "Shutter",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "capabilities": [
+                        {
+                            "range": [0, 7],
+                            "name": "closed",
+                            "center": true
+                        },
+                        {
+                            "range": [8, 136],
+                            "name": "strobe",
+                            "center": true
+                        },
+                        {
+                            "range": [137, 153],
+                            "name": "music",
+                            "center": true
+                        },
+                        {
+                            "range": [154, 170],
+                            "name": "shade.gobo",
+                            "center": true
+                        },
+                        {
+                            "range": [171, 187],
+                            "name": "shade.color",
+                            "center": true
+                        },
+                        {
+                            "range": [188, 204],
+                            "name": "shade.col/gob",
+                            "center": true
+                        },
+                        {
+                            "range": [205, 221],
+                            "name": "sl. go. ch.",
+                            "center": true
+                        },
+                        {
+                            "range": [222, 255],
+                            "name": "open"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Gobo1 rot": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "Gobo1 rot fine": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "Prism": {
+                    "type": "Prism",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 63],
+                            "name": "open"
+                        },
+                        {
+                            "range": [64, 127],
+                            "name": "flattener",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 191],
+                            "name": "prism",
+                            "center": true
+                        },
+                        {
+                            "range": [192, 255],
+                            "name": "prism/flatt",
+                            "center": true
+                        }
+                    ]
+                },
+                "Prisma rot.": {
+                    "type": "Prism",
+                    "defaultValue": 112,
+                    "highlightValue": 112,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 111],
+                            "name": ">>"
+                        },
+                        {
+                            "range": [112, 143],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [144, 255],
+                            "name": "<<"
+                        }
+                    ]
+                },
+                "Focus": {
+                    "type": "Beam",
+                    "defaultValue": 128,
+                    "crossfade": true
+                },
+                "Zoom": {
+                    "type": "Beam",
+                    "highlightValue": 128,
+                    "crossfade": true
+                },
+                "Animation": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "open"
+                        },
+                        {
+                            "range": [128, 255],
+                            "name": "insert"
+                        }
+                    ]
+                },
+                "Frost": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "P/T Speed": {
+                    "type": "Speed",
+                    "crossfade": true
+                },
+                "Reset": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 60],
+                            "name": "lamp off"
+                        },
+                        {
+                            "range": [61, 129],
+                            "name": "hysterese"
+                        },
+                        {
+                            "range": [130, 179],
+                            "name": "lamp on"
+                        },
+                        {
+                            "range": [180, 239],
+                            "name": "hysterese"
+                        },
+                        {
+                            "range": [240, 255],
+                            "name": "reset"
+                        }
+                    ]
+                },
+                "Gobo1 sh.": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 47],
+                            "name": "off"
+                        },
+                        {
+                            "range": [48, 255],
+                            "name": "speed"
+                        }
+                    ]
+                },
+                "Color mode": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 50],
+                            "name": "full.color"
+                        },
+                        {
+                            "range": [51, 101],
+                            "name": "half.color"
+                        },
+                        {
+                            "range": [102, 152],
+                            "name": "soft.color"
+                        },
+                        {
+                            "range": [153, 203],
+                            "name": "rainbow"
+                        },
+                        {
+                            "range": [204, 255],
+                            "name": "music"
+                        }
+                    ]
+                },
+                "Gobo1 mode": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "ind."
+                        },
+                        {
+                            "range": [128, 255],
+                            "name": "rot."
+                        }
+                    ]
+                },
+                "Macro": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 7],
+                            "name": "off"
+                        },
+                        {
+                            "range": [8, 15],
+                            "name": "macro1"
+                        },
+                        {
+                            "range": [16, 23],
+                            "name": "macro2"
+                        },
+                        {
+                            "range": [24, 31],
+                            "name": "macro3"
+                        },
+                        {
+                            "range": [32, 39],
+                            "name": "macro4"
+                        },
+                        {
+                            "range": [40, 47],
+                            "name": "macro5"
+                        },
+                        {
+                            "range": [48, 55],
+                            "name": "macro6"
+                        },
+                        {
+                            "range": [56, 63],
+                            "name": "macro7"
+                        },
+                        {
+                            "range": [64, 71],
+                            "name": "macro8"
+                        },
+                        {
+                            "range": [72, 79],
+                            "name": "macro9"
+                        },
+                        {
+                            "range": [80, 87],
+                            "name": "macro10"
+                        },
+                        {
+                            "range": [88, 95],
+                            "name": "macro11"
+                        },
+                        {
+                            "range": [96, 103],
+                            "name": "macro12"
+                        },
+                        {
+                            "range": [104, 111],
+                            "name": "macro13"
+                        },
+                        {
+                            "range": [112, 119],
+                            "name": "macro14"
+                        },
+                        {
+                            "range": [120, 127],
+                            "name": "macro15"
+                        },
+                        {
+                            "range": [128, 135],
+                            "name": "macro16"
+                        },
+                        {
+                            "range": [136, 255],
+                            "name": "reserved"
+                        }
+                    ]
+                },
+                "Gobo2": {
+                    "type": "Gobo",
+                    "defaultValue": 10,
+                    "highlightValue": 10,
+                    "capabilities": [
+                        {
+                            "range": [0, 20],
+                            "name": "open",
+                            "center": true
+                        },
+                        {
+                            "range": [21, 41],
+                            "name": "slot1",
+                            "center": true
+                        },
+                        {
+                            "range": [42, 62],
+                            "name": "slot2",
+                            "center": true
+                        },
+                        {
+                            "range": [63, 83],
+                            "name": "slot3"
+                        },
+                        {
+                            "range": [84, 104],
+                            "name": "slot4"
+                        },
+                        {
+                            "range": [105, 125],
+                            "name": "slot5",
+                            "center": true
+                        },
+                        {
+                            "range": [126, 146],
+                            "name": "slot6"
+                        },
+                        {
+                            "range": [147, 167],
+                            "name": "slot7"
+                        },
+                        {
+                            "range": [168, 189],
+                            "name": "slot8",
+                            "center": true
+                        },
+                        {
+                            "range": [190, 245],
+                            "name": ">>",
+                            "center": true
+                        },
+                        {
+                            "range": [252, 255],
+                            "name": "music"
+                        }
+                    ]
+                },
+                "Gobo2 rot": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "Gobo2 rot fine": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "Gobo2 mode": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "ind."
+                        },
+                        {
+                            "range": [128, 255],
+                            "name": "rot."
+                        }
+                    ]
+                },
+                "Gobo2 sh.": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 47],
+                            "name": "off"
+                        },
+                        {
+                            "range": [48, 255],
+                            "name": "speed"
+                        }
+                    ]
+                },
+                "Animation rot.": {
+                    "type": "Beam",
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 111],
+                            "name": "rot. down"
+                        },
+                        {
+                            "range": [112, 143],
+                            "name": "stop",
+                            "center": true
+                        },
+                        {
+                            "range": [144, 255],
+                            "name": "rot. up",
+                            "center": true
+                        }
+                    ]
+                },
+                "Cyan": {
+                    "type": "SingleColor",
+                    "color": "Cyan",
+                    "crossfade": true
+                },
+                "Magenta": {
+                    "type": "SingleColor",
+                    "color": "Magenta",
+                    "crossfade": true
+                },
+                "Yellow": {
+                    "type": "SingleColor",
+                    "color": "Yellow",
+                    "crossfade": true
+                },
+                "CTO": {
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "crossfade": true
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ],
+                [
+                    "Gobo1 rot",
+                    "Gobo1 rot fine"
+                ],
+                [
+                    "Gobo2 rot",
+                    "Gobo2 rot fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "33-channel Mode",
+                    "shortName": "33ch",
+                    "channels": [
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "Iris",
+                        "Color",
+                        "Gobo1",
+                        "Shutter",
+                        "Intensity",
+                        "Gobo1 rot",
+                        "Prism",
+                        "Prisma rot.",
+                        "Focus",
+                        "Zoom",
+                        "Animation",
+                        "Frost",
+                        "P/T Speed",
+                        "Reset",
+                        "Gobo1 sh.",
+                        "Color mode",
+                        "Gobo1 mode",
+                        "Macro",
+                        "Gobo1 rot fine",
+                        "Gobo2",
+                        "Gobo2 rot",
+                        "Gobo2 rot fine",
+                        "Gobo2 mode",
+                        "Gobo2 sh.",
+                        "Animation rot.",
+                        "Cyan",
+                        "Magenta",
+                        "Yellow",
+                        "CTO"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "SGM",
+            "name": "Giotto Wash 400",
+            "shortName": "GWS400",
+            "physical": {
+                "dimensions": [450, 450, 700],
+                "weight": 24.8,
+                "power": 600
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Color": {
+                    "type": "MultiColor",
+                    "capabilities": [
+                        {
+                            "range": [10, 29],
+                            "name": "white",
+                            "color": "#ffffff"
+                        },
+                        {
+                            "range": [30, 49],
+                            "name": "red",
+                            "color": "#ff0000"
+                        },
+                        {
+                            "range": [50, 69],
+                            "name": "blue",
+                            "color": "#0000ff"
+                        },
+                        {
+                            "range": [70, 89],
+                            "name": "orange",
+                            "color": "#ff7f00"
+                        },
+                        {
+                            "range": [90, 109],
+                            "name": "green",
+                            "color": "#00ff00"
+                        },
+                        {
+                            "range": [110, 129],
+                            "name": "yellow",
+                            "color": "#ffff00"
+                        },
+                        {
+                            "range": [130, 149],
+                            "name": "pink",
+                            "color": "#ffc0cb"
+                        },
+                        {
+                            "range": [150, 160],
+                            "name": "UV"
+                        },
+                        {
+                            "range": [161, 255],
+                            "name": "rainbow"
+                        }
+                    ]
+                },
+                "Cyan": {
+                    "type": "SingleColor",
+                    "color": "Cyan",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Magenta": {
+                    "type": "SingleColor",
+                    "color": "Magenta",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Yellow": {
+                    "type": "SingleColor",
+                    "color": "Yellow",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Shutter": {
+                    "type": "Shutter",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "capabilities": [
+                        {
+                            "range": [0, 17],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [18, 254],
+                            "name": "speed"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "open"
+                        }
+                    ]
+                },
+                "Zoom": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Speed": {
+                    "type": "Speed",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Reset": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 60],
+                            "name": "off"
+                        },
+                        {
+                            "range": [61, 129],
+                            "name": "hysterese"
+                        },
+                        {
+                            "range": [130, 179],
+                            "name": "on"
+                        },
+                        {
+                            "range": [180, 239],
+                            "name": "hysterese"
+                        },
+                        {
+                            "range": [240, 255],
+                            "name": "reset"
+                        }
+                    ]
+                },
+                "CTO": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 254],
+                            "name": "open"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "3200k"
+                        }
+                    ]
+                },
+                "Color.Map": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Macro": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "reserved"
+                        }
+                    ]
+                },
+                "SP.Beam": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "open"
+                        },
+                        {
+                            "range": [1, 254],
+                            "name": "beam"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "full"
+                        }
+                    ]
+                },
+                "SP.Rot": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "position"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "18-channel Mode",
+                    "shortName": "18ch",
+                    "channels": [
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "Color",
+                        "Cyan",
+                        "Magenta",
+                        "Yellow",
+                        "Intensity",
+                        "Shutter",
+                        "Zoom",
+                        "Speed",
+                        "Reset",
+                        "CTO",
+                        "Color.Map",
+                        "Macro",
+                        "SP.Beam",
+                        "SP.Rot"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "SGM",
+            "name": "Idea Moving Led100 16Bit Mode",
+            "shortName": "SGM LED 100 M2",
+            "physical": {
+                "dimensions": [300, 300, 390],
+                "weight": 6
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "P/T speed": {
+                    "type": "Speed",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 225],
+                            "name": "max to min"
+                        },
+                        {
+                            "range": [226, 235],
+                            "name": "bl. by movement"
+                        },
+                        {
+                            "range": [236, 255],
+                            "name": "no funktion"
+                        }
+                    ]
+                },
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "White": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Strobe": {
+                    "type": "Strobe",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 31],
+                            "name": "LED off"
+                        },
+                        {
+                            "range": [32, 63],
+                            "name": "LED on"
+                        },
+                        {
+                            "range": [64, 95],
+                            "name": "slow to fast"
+                        },
+                        {
+                            "range": [96, 127],
+                            "name": "LED on"
+                        },
+                        {
+                            "range": [128, 159],
+                            "name": "pulse"
+                        },
+                        {
+                            "range": [160, 191],
+                            "name": "LED on"
+                        },
+                        {
+                            "range": [192, 223],
+                            "name": "Random"
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "LED on"
+                        }
+                    ]
+                },
+                "Dimmer": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "_Rainbow": {
+                    "type": "MultiColor",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 7],
+                            "name": "no funktionl"
+                        },
+                        {
+                            "range": [8, 39],
+                            "name": "Rainb. 1"
+                        },
+                        {
+                            "range": [40, 71],
+                            "name": "Rainb. 2"
+                        },
+                        {
+                            "range": [72, 103],
+                            "name": "Rainb. 3"
+                        },
+                        {
+                            "range": [104, 135],
+                            "name": "Rainb. 4"
+                        },
+                        {
+                            "range": [136, 167],
+                            "name": "Rainb. 5"
+                        },
+                        {
+                            "range": [168, 199],
+                            "name": "Rainb. 6"
+                        },
+                        {
+                            "range": [200, 231],
+                            "name": "Rainb. 7"
+                        },
+                        {
+                            "range": [232, 255],
+                            "name": "crossfade"
+                        }
+                    ]
+                },
+                "Control": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 79],
+                            "name": "normal"
+                        },
+                        {
+                            "range": [80, 84],
+                            "name": "all mot. reset"
+                        },
+                        {
+                            "range": [85, 87],
+                            "name": "scan mot. reset"
+                        },
+                        {
+                            "range": [88, 99],
+                            "name": "no function"
+                        },
+                        {
+                            "range": [100, 119],
+                            "name": "Progr. 1"
+                        },
+                        {
+                            "range": [120, 139],
+                            "name": "Progr. 2"
+                        },
+                        {
+                            "range": [140, 159],
+                            "name": "Progr. 3"
+                        },
+                        {
+                            "range": [160, 179],
+                            "name": "Progr. 4"
+                        },
+                        {
+                            "range": [180, 199],
+                            "name": "Progr. 5"
+                        },
+                        {
+                            "range": [200, 219],
+                            "name": "Progr. 6"
+                        },
+                        {
+                            "range": [220, 239],
+                            "name": "Progr. 7"
+                        },
+                        {
+                            "range": [240, 255],
+                            "name": "Sound to light"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "13-channel Mode",
+                    "shortName": "13ch",
+                    "channels": [
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "P/T speed",
+                        "Red",
+                        "Green",
+                        "Blue",
+                        "White",
+                        "Strobe",
+                        "Dimmer",
+                        "_Rainbow",
+                        "Control"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "SGM",
+            "name": "Idea Moving Led100 8Bit Mode",
+            "shortName": "SGM LED 100 M1",
+            "physical": {
+                "dimensions": [300, 300, 390],
+                "weight": 6
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 32767,
+                    "highlightValue": 32767,
+                    "crossfade": true
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 32767,
+                    "highlightValue": 32767,
+                    "crossfade": true
+                },
+                "P/T speed": {
+                    "type": "Speed",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 225],
+                            "name": "max to min"
+                        },
+                        {
+                            "range": [226, 235],
+                            "name": "bl. by movement"
+                        },
+                        {
+                            "range": [236, 255],
+                            "name": "no funktion"
+                        }
+                    ]
+                },
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "White": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Strobe": {
+                    "type": "Strobe",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 31],
+                            "name": "LED off"
+                        },
+                        {
+                            "range": [32, 63],
+                            "name": "LED on"
+                        },
+                        {
+                            "range": [64, 95],
+                            "name": "slow to fast"
+                        },
+                        {
+                            "range": [96, 127],
+                            "name": "LED on"
+                        },
+                        {
+                            "range": [128, 159],
+                            "name": "pulse"
+                        },
+                        {
+                            "range": [160, 191],
+                            "name": "LED on"
+                        },
+                        {
+                            "range": [192, 223],
+                            "name": "Random"
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "LED on"
+                        }
+                    ]
+                },
+                "Dimmer": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "_Rainbow": {
+                    "type": "MultiColor",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 7],
+                            "name": "no funktionl"
+                        },
+                        {
+                            "range": [8, 39],
+                            "name": "Rainb. 1"
+                        },
+                        {
+                            "range": [40, 71],
+                            "name": "Rainb. 2"
+                        },
+                        {
+                            "range": [72, 103],
+                            "name": "Rainb. 3"
+                        },
+                        {
+                            "range": [104, 135],
+                            "name": "Rainb. 4"
+                        },
+                        {
+                            "range": [136, 167],
+                            "name": "Rainb. 5"
+                        },
+                        {
+                            "range": [168, 199],
+                            "name": "Rainb. 6"
+                        },
+                        {
+                            "range": [200, 231],
+                            "name": "Rainb. 7"
+                        },
+                        {
+                            "range": [232, 255],
+                            "name": "crossfade"
+                        }
+                    ]
+                },
+                "Control": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 79],
+                            "name": "normal"
+                        },
+                        {
+                            "range": [80, 84],
+                            "name": "all mot. reset"
+                        },
+                        {
+                            "range": [85, 87],
+                            "name": "scan mot. reset"
+                        },
+                        {
+                            "range": [88, 99],
+                            "name": "no function"
+                        },
+                        {
+                            "range": [100, 119],
+                            "name": "Progr. 1"
+                        },
+                        {
+                            "range": [120, 139],
+                            "name": "Progr. 2"
+                        },
+                        {
+                            "range": [140, 159],
+                            "name": "Progr. 3"
+                        },
+                        {
+                            "range": [160, 179],
+                            "name": "Progr. 4"
+                        },
+                        {
+                            "range": [180, 199],
+                            "name": "Progr. 5"
+                        },
+                        {
+                            "range": [200, 219],
+                            "name": "Progr. 6"
+                        },
+                        {
+                            "range": [220, 239],
+                            "name": "Progr. 7"
+                        },
+                        {
+                            "range": [240, 255],
+                            "name": "Sound to light"
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "11-channel Mode",
+                    "shortName": "11ch",
+                    "channels": [
+                        "Pan",
+                        "Tilt",
+                        "P/T speed",
+                        "Red",
+                        "Green",
+                        "Blue",
+                        "White",
+                        "Strobe",
+                        "Dimmer",
+                        "_Rainbow",
+                        "Control"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "SGM",
+            "name": "Idea Moving Led100300 Basic Mode",
+            "shortName": "SGM LED 100/300 M2",
+            "physical": {
+                "dimensions": [340, 340, 440],
+                "weight": 9
+            },
+            "availableChannels": {
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "White": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "P/T speed": {
+                    "type": "Speed",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 225],
+                            "name": "max to min"
+                        },
+                        {
+                            "range": [226, 235],
+                            "name": "bl. by movement"
+                        },
+                        {
+                            "range": [236, 255],
+                            "name": "no funktion"
+                        }
+                    ]
+                },
+                "Strobe": {
+                    "type": "Strobe",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 31],
+                            "name": "LED off"
+                        },
+                        {
+                            "range": [32, 63],
+                            "name": "LED on"
+                        },
+                        {
+                            "range": [64, 95],
+                            "name": "slow to fast"
+                        },
+                        {
+                            "range": [96, 127],
+                            "name": "LED on"
+                        },
+                        {
+                            "range": [128, 159],
+                            "name": "pulse"
+                        },
+                        {
+                            "range": [160, 191],
+                            "name": "LED on"
+                        },
+                        {
+                            "range": [192, 223],
+                            "name": "Random"
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "LED on"
+                        }
+                    ]
+                },
+                "Dimmer": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "_Rainbow": {
+                    "type": "MultiColor",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 7],
+                            "name": "no funktionl"
+                        },
+                        {
+                            "range": [8, 39],
+                            "name": "Rainb. 1"
+                        },
+                        {
+                            "range": [40, 71],
+                            "name": "Rainb. 2"
+                        },
+                        {
+                            "range": [72, 103],
+                            "name": "Rainb. 3"
+                        },
+                        {
+                            "range": [104, 135],
+                            "name": "Rainb. 4"
+                        },
+                        {
+                            "range": [136, 167],
+                            "name": "Rainb. 5"
+                        },
+                        {
+                            "range": [168, 199],
+                            "name": "Rainb. 6"
+                        },
+                        {
+                            "range": [200, 231],
+                            "name": "Rainb. 7"
+                        },
+                        {
+                            "range": [232, 255],
+                            "name": "crossfade"
+                        }
+                    ]
+                },
+                "Control": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 79],
+                            "name": "normal"
+                        },
+                        {
+                            "range": [80, 84],
+                            "name": "all mot. reset"
+                        },
+                        {
+                            "range": [85, 87],
+                            "name": "scan mot. reset"
+                        },
+                        {
+                            "range": [88, 99],
+                            "name": "no function"
+                        },
+                        {
+                            "range": [100, 119],
+                            "name": "Progr. 1"
+                        },
+                        {
+                            "range": [120, 139],
+                            "name": "Progr. 2"
+                        },
+                        {
+                            "range": [140, 159],
+                            "name": "Progr. 3"
+                        },
+                        {
+                            "range": [160, 179],
+                            "name": "Progr. 4"
+                        },
+                        {
+                            "range": [180, 199],
+                            "name": "Progr. 5"
+                        },
+                        {
+                            "range": [200, 219],
+                            "name": "Progr. 6"
+                        },
+                        {
+                            "range": [220, 239],
+                            "name": "Progr. 7"
+                        },
+                        {
+                            "range": [240, 255],
+                            "name": "Sound to light"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "13-channel Mode",
+                    "shortName": "13ch",
+                    "channels": [
+                        "Red",
+                        "Green",
+                        "Blue",
+                        "White",
+                        "Pan",
+                        "Tilt",
+                        "P/T speed",
+                        "Strobe",
+                        "Dimmer",
+                        "_Rainbow",
+                        "Control",
+                        "Pan fine",
+                        "Tilt fine"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "SGM",
+            "name": "Idea Moving Led100300 Standard M",
+            "shortName": "SGM LED 100/300 M1",
+            "physical": {
+                "dimensions": [340, 340, 440],
+                "weight": 9
+            },
+            "availableChannels": {
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "White": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 32767,
+                    "highlightValue": 32767,
+                    "crossfade": true
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 32767,
+                    "highlightValue": 32767,
+                    "crossfade": true
+                },
+                "P/T speed": {
+                    "type": "Speed",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 225],
+                            "name": "max to min"
+                        },
+                        {
+                            "range": [226, 235],
+                            "name": "bl. by movement"
+                        },
+                        {
+                            "range": [236, 255],
+                            "name": "no funktion"
+                        }
+                    ]
+                },
+                "Strobe": {
+                    "type": "Strobe",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 31],
+                            "name": "LED off"
+                        },
+                        {
+                            "range": [32, 63],
+                            "name": "LED on"
+                        },
+                        {
+                            "range": [64, 95],
+                            "name": "slow to fast"
+                        },
+                        {
+                            "range": [96, 127],
+                            "name": "LED on"
+                        },
+                        {
+                            "range": [128, 159],
+                            "name": "pulse"
+                        },
+                        {
+                            "range": [160, 191],
+                            "name": "LED on"
+                        },
+                        {
+                            "range": [192, 223],
+                            "name": "Random"
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "LED on"
+                        }
+                    ]
+                },
+                "Dimmer": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "_Rainbow": {
+                    "type": "MultiColor",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 7],
+                            "name": "no funktionl"
+                        },
+                        {
+                            "range": [8, 39],
+                            "name": "Rainb. 1"
+                        },
+                        {
+                            "range": [40, 71],
+                            "name": "Rainb. 2"
+                        },
+                        {
+                            "range": [72, 103],
+                            "name": "Rainb. 3"
+                        },
+                        {
+                            "range": [104, 135],
+                            "name": "Rainb. 4"
+                        },
+                        {
+                            "range": [136, 167],
+                            "name": "Rainb. 5"
+                        },
+                        {
+                            "range": [168, 199],
+                            "name": "Rainb. 6"
+                        },
+                        {
+                            "range": [200, 231],
+                            "name": "Rainb. 7"
+                        },
+                        {
+                            "range": [232, 255],
+                            "name": "crossfade"
+                        }
+                    ]
+                },
+                "Control": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 79],
+                            "name": "normal"
+                        },
+                        {
+                            "range": [80, 84],
+                            "name": "all mot. reset"
+                        },
+                        {
+                            "range": [85, 87],
+                            "name": "scan mot. reset"
+                        },
+                        {
+                            "range": [88, 99],
+                            "name": "no function"
+                        },
+                        {
+                            "range": [100, 119],
+                            "name": "Progr. 1"
+                        },
+                        {
+                            "range": [120, 139],
+                            "name": "Progr. 2"
+                        },
+                        {
+                            "range": [140, 159],
+                            "name": "Progr. 3"
+                        },
+                        {
+                            "range": [160, 179],
+                            "name": "Progr. 4"
+                        },
+                        {
+                            "range": [180, 199],
+                            "name": "Progr. 5"
+                        },
+                        {
+                            "range": [200, 219],
+                            "name": "Progr. 6"
+                        },
+                        {
+                            "range": [220, 239],
+                            "name": "Progr. 7"
+                        },
+                        {
+                            "range": [240, 255],
+                            "name": "Sound to light"
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "11-channel Mode",
+                    "shortName": "11ch",
+                    "channels": [
+                        "Red",
+                        "Green",
+                        "Blue",
+                        "White",
+                        "Pan",
+                        "Tilt",
+                        "P/T speed",
+                        "Strobe",
+                        "Dimmer",
+                        "_Rainbow",
+                        "Control"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "SGM",
+            "name": "Palco 3  Palco 5",
+            "shortName": "Palco",
+            "physical": {
+                "dimensions": [425, 375, 230],
+                "weight": 13.5,
+                "power": 250
+            },
+            "availableChannels": {
+                "Shutter": {
+                    "type": "Shutter",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 7],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [8, 15],
+                            "name": "open"
+                        },
+                        {
+                            "range": [16, 151],
+                            "name": "linear"
+                        },
+                        {
+                            "range": [152, 175],
+                            "name": "pulse open"
+                        },
+                        {
+                            "range": [176, 199],
+                            "name": "pulse close"
+                        },
+                        {
+                            "range": [200, 223],
+                            "name": "random"
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "open"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "CTC": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 19],
+                            "name": "off"
+                        },
+                        {
+                            "range": [20, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Macro": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 7],
+                            "name": "no macro"
+                        },
+                        {
+                            "range": [8, 15],
+                            "name": "macro 1"
+                        },
+                        {
+                            "range": [16, 23],
+                            "name": "macro 2"
+                        },
+                        {
+                            "range": [24, 31],
+                            "name": "macro 3"
+                        },
+                        {
+                            "range": [32, 39],
+                            "name": "macro 4"
+                        },
+                        {
+                            "range": [40, 47],
+                            "name": "macro 5"
+                        },
+                        {
+                            "range": [48, 55],
+                            "name": "macro 6"
+                        },
+                        {
+                            "range": [56, 63],
+                            "name": "macro 7"
+                        },
+                        {
+                            "range": [64, 70],
+                            "name": "macro 8"
+                        },
+                        {
+                            "range": [71, 71],
+                            "name": "store enable"
+                        },
+                        {
+                            "range": [72, 79],
+                            "name": "macro 9"
+                        },
+                        {
+                            "range": [80, 87],
+                            "name": "macro 10"
+                        },
+                        {
+                            "range": [88, 255],
+                            "name": "reserved"
+                        }
+                    ]
+                },
+                "Mod_Color": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 63],
+                            "name": "white disabled"
+                        },
+                        {
+                            "range": [64, 189],
+                            "name": "white enabled"
+                        },
+                        {
+                            "range": [190, 250],
+                            "name": "white disabled"
+                        },
+                        {
+                            "range": [251, 255],
+                            "name": "store balance"
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "8-channel Mode",
+                    "shortName": "8ch",
+                    "channels": [
+                        "Shutter",
+                        "Intensity",
+                        "Red",
+                        "Green",
+                        "Blue",
+                        "CTC",
+                        "Macro",
+                        "Mod_Color"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "SGM",
+            "name": "Synthesis Spot",
+            "shortName": "SynSp",
+            "comment": "HRT mode",
+            "physical": {
+                "dimensions": [500, 500, 800],
+                "weight": 42,
+                "power": 1000
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Iris": {
+                    "type": "Beam",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Color": {
+                    "type": "MultiColor",
+                    "capabilities": [
+                        {
+                            "range": [0, 35],
+                            "name": "open",
+                            "center": true
+                        },
+                        {
+                            "range": [36, 71],
+                            "name": "red",
+                            "color": "#ff0000",
+                            "center": true
+                        },
+                        {
+                            "range": [72, 107],
+                            "name": "green",
+                            "color": "#00ff00",
+                            "center": true
+                        },
+                        {
+                            "range": [108, 145],
+                            "name": "blue",
+                            "color": "#0000ff",
+                            "center": true
+                        },
+                        {
+                            "range": [146, 181],
+                            "name": "pink",
+                            "color": "#ffc0cb",
+                            "center": true
+                        },
+                        {
+                            "range": [182, 215],
+                            "name": "amber",
+                            "color": "#ffbf00",
+                            "center": true
+                        },
+                        {
+                            "range": [216, 255],
+                            "name": "wood",
+                            "center": true
+                        }
+                    ]
+                },
+                "Gobo1": {
+                    "type": "Gobo",
+                    "defaultValue": 10,
+                    "highlightValue": 10,
+                    "capabilities": [
+                        {
+                            "range": [0, 20],
+                            "name": "open",
+                            "center": true
+                        },
+                        {
+                            "range": [21, 41],
+                            "name": "slot1",
+                            "center": true
+                        },
+                        {
+                            "range": [42, 62],
+                            "name": "slot2",
+                            "center": true
+                        },
+                        {
+                            "range": [63, 83],
+                            "name": "slot3"
+                        },
+                        {
+                            "range": [84, 104],
+                            "name": "slot4"
+                        },
+                        {
+                            "range": [105, 125],
+                            "name": "slot5",
+                            "center": true
+                        },
+                        {
+                            "range": [126, 146],
+                            "name": "slot6"
+                        },
+                        {
+                            "range": [147, 167],
+                            "name": "slot7"
+                        },
+                        {
+                            "range": [168, 189],
+                            "name": "slot8",
+                            "center": true
+                        },
+                        {
+                            "range": [190, 245],
+                            "name": ">>",
+                            "center": true
+                        },
+                        {
+                            "range": [252, 255],
+                            "name": "music"
+                        }
+                    ]
+                },
+                "Shutter": {
+                    "type": "Shutter",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "capabilities": [
+                        {
+                            "range": [0, 7],
+                            "name": "closed",
+                            "center": true
+                        },
+                        {
+                            "range": [8, 136],
+                            "name": "strobe",
+                            "center": true
+                        },
+                        {
+                            "range": [137, 153],
+                            "name": "music",
+                            "center": true
+                        },
+                        {
+                            "range": [154, 170],
+                            "name": "shade.gobo",
+                            "center": true
+                        },
+                        {
+                            "range": [171, 187],
+                            "name": "shade.color",
+                            "center": true
+                        },
+                        {
+                            "range": [188, 204],
+                            "name": "shade.col/gob",
+                            "center": true
+                        },
+                        {
+                            "range": [205, 221],
+                            "name": "sl. go. ch.",
+                            "center": true
+                        },
+                        {
+                            "range": [222, 255],
+                            "name": "open"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Gobo1 rot": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "Gobo1 rot fine": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "Prism": {
+                    "type": "Prism",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 63],
+                            "name": "open"
+                        },
+                        {
+                            "range": [64, 127],
+                            "name": "flattener",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 191],
+                            "name": "prism",
+                            "center": true
+                        },
+                        {
+                            "range": [192, 255],
+                            "name": "prism/flatt",
+                            "center": true
+                        }
+                    ]
+                },
+                "Prisma rot.": {
+                    "type": "Prism",
+                    "defaultValue": 112,
+                    "highlightValue": 112,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 111],
+                            "name": ">>"
+                        },
+                        {
+                            "range": [112, 143],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [144, 255],
+                            "name": "<<"
+                        }
+                    ]
+                },
+                "Focus": {
+                    "type": "Beam",
+                    "defaultValue": 0,
+                    "crossfade": true,
+                    "highlightValue": null
+                },
+                "Focus fine": {
+                    "type": "Beam",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "highlightValue": null
+                },
+                "Zoom": {
+                    "type": "Beam",
+                    "highlightValue": 128,
+                    "crossfade": true
+                },
+                "Animation": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "open"
+                        },
+                        {
+                            "range": [128, 255],
+                            "name": "insert"
+                        }
+                    ]
+                },
+                "Frost": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "P/T Speed": {
+                    "type": "Speed",
+                    "crossfade": true
+                },
+                "Reset": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 60],
+                            "name": "lamp off"
+                        },
+                        {
+                            "range": [61, 129],
+                            "name": "hysterese"
+                        },
+                        {
+                            "range": [130, 179],
+                            "name": "lamp on"
+                        },
+                        {
+                            "range": [180, 239],
+                            "name": "hysterese"
+                        },
+                        {
+                            "range": [240, 255],
+                            "name": "reset"
+                        }
+                    ]
+                },
+                "Gobo1 sh.": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 47],
+                            "name": "off"
+                        },
+                        {
+                            "range": [48, 255],
+                            "name": "speed"
+                        }
+                    ]
+                },
+                "Color mode": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 50],
+                            "name": "full.color"
+                        },
+                        {
+                            "range": [51, 101],
+                            "name": "half.color"
+                        },
+                        {
+                            "range": [102, 152],
+                            "name": "soft.color"
+                        },
+                        {
+                            "range": [153, 203],
+                            "name": "rainbow"
+                        },
+                        {
+                            "range": [204, 255],
+                            "name": "music"
+                        }
+                    ]
+                },
+                "Gobo1 mode": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "ind."
+                        },
+                        {
+                            "range": [128, 255],
+                            "name": "rot."
+                        }
+                    ]
+                },
+                "Macro": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 7],
+                            "name": "off"
+                        },
+                        {
+                            "range": [8, 15],
+                            "name": "macro1"
+                        },
+                        {
+                            "range": [16, 23],
+                            "name": "macro2"
+                        },
+                        {
+                            "range": [24, 31],
+                            "name": "macro3"
+                        },
+                        {
+                            "range": [32, 39],
+                            "name": "macro4"
+                        },
+                        {
+                            "range": [40, 47],
+                            "name": "macro5"
+                        },
+                        {
+                            "range": [48, 55],
+                            "name": "macro6"
+                        },
+                        {
+                            "range": [56, 63],
+                            "name": "macro7"
+                        },
+                        {
+                            "range": [64, 71],
+                            "name": "macro8"
+                        },
+                        {
+                            "range": [72, 79],
+                            "name": "macro9"
+                        },
+                        {
+                            "range": [80, 87],
+                            "name": "macro10"
+                        },
+                        {
+                            "range": [88, 95],
+                            "name": "macro11"
+                        },
+                        {
+                            "range": [96, 103],
+                            "name": "macro12"
+                        },
+                        {
+                            "range": [104, 111],
+                            "name": "macro13"
+                        },
+                        {
+                            "range": [112, 119],
+                            "name": "macro14"
+                        },
+                        {
+                            "range": [120, 127],
+                            "name": "macro15"
+                        },
+                        {
+                            "range": [128, 135],
+                            "name": "macro16"
+                        },
+                        {
+                            "range": [136, 255],
+                            "name": "reserved"
+                        }
+                    ]
+                },
+                "Gobo2": {
+                    "type": "Gobo",
+                    "defaultValue": 10,
+                    "highlightValue": 10,
+                    "capabilities": [
+                        {
+                            "range": [0, 20],
+                            "name": "open",
+                            "center": true
+                        },
+                        {
+                            "range": [21, 41],
+                            "name": "slot1",
+                            "center": true
+                        },
+                        {
+                            "range": [42, 62],
+                            "name": "slot2",
+                            "center": true
+                        },
+                        {
+                            "range": [63, 83],
+                            "name": "slot3"
+                        },
+                        {
+                            "range": [84, 104],
+                            "name": "slot4"
+                        },
+                        {
+                            "range": [105, 125],
+                            "name": "slot5",
+                            "center": true
+                        },
+                        {
+                            "range": [126, 146],
+                            "name": "slot6"
+                        },
+                        {
+                            "range": [147, 167],
+                            "name": "slot7"
+                        },
+                        {
+                            "range": [168, 189],
+                            "name": "slot8",
+                            "center": true
+                        },
+                        {
+                            "range": [190, 245],
+                            "name": ">>",
+                            "center": true
+                        },
+                        {
+                            "range": [252, 255],
+                            "name": "music"
+                        }
+                    ]
+                },
+                "Gobo2 rot": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "Gobo2 rot fine": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "Gobo2 mode": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "ind."
+                        },
+                        {
+                            "range": [128, 255],
+                            "name": "rot."
+                        }
+                    ]
+                },
+                "Gobo2 sh.": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 47],
+                            "name": "off"
+                        },
+                        {
+                            "range": [48, 255],
+                            "name": "speed"
+                        }
+                    ]
+                },
+                "Animation rot.": {
+                    "type": "Beam",
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 111],
+                            "name": "rot. down"
+                        },
+                        {
+                            "range": [112, 143],
+                            "name": "stop",
+                            "center": true
+                        },
+                        {
+                            "range": [144, 255],
+                            "name": "rot. up",
+                            "center": true
+                        }
+                    ]
+                },
+                "Animation2": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Cyan": {
+                    "type": "SingleColor",
+                    "color": "Cyan",
+                    "crossfade": true
+                },
+                "Magenta": {
+                    "type": "SingleColor",
+                    "color": "Magenta",
+                    "crossfade": true
+                },
+                "Yellow": {
+                    "type": "SingleColor",
+                    "color": "Yellow",
+                    "crossfade": true
+                },
+                "CTO": {
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "crossfade": true
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ],
+                [
+                    "Gobo1 rot",
+                    "Gobo1 rot fine"
+                ],
+                [
+                    "Focus",
+                    "Focus fine"
+                ],
+                [
+                    "Gobo2 rot",
+                    "Gobo2 rot fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "35-channel Mode",
+                    "shortName": "35ch",
+                    "channels": [
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "Iris",
+                        "Color",
+                        "Gobo1",
+                        "Shutter",
+                        "Intensity",
+                        "Gobo1 rot",
+                        "Prism",
+                        "Prisma rot.",
+                        "Focus",
+                        "Zoom",
+                        "Animation",
+                        "Frost",
+                        "P/T Speed",
+                        "Reset",
+                        "Gobo1 sh.",
+                        "Color mode",
+                        "Gobo1 mode",
+                        "Macro",
+                        "Gobo1 rot fine",
+                        "Gobo2",
+                        "Gobo2 rot",
+                        "Gobo2 rot fine",
+                        "Gobo2 mode",
+                        "Gobo2 sh.",
+                        "Animation rot.",
+                        "Animation2",
+                        "Cyan",
+                        "Magenta",
+                        "Yellow",
+                        "CTO",
+                        "Focus fine"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "SGM",
+            "name": "Victory 250",
+            "shortName": "Vic250",
+            "comment": "16bit Mode",
+            "physical": {
+                "dimensions": [350, 650, 260],
+                "weight": 14,
+                "power": 250
+            },
+            "availableChannels": {
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Color": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 19],
+                            "name": "white",
+                            "color": "#ffffff"
+                        },
+                        {
+                            "range": [20, 39],
+                            "name": "Yellow",
+                            "color": "#ffff00"
+                        },
+                        {
+                            "range": [40, 59],
+                            "name": "Magenta",
+                            "color": "#ca1f7b"
+                        },
+                        {
+                            "range": [60, 79],
+                            "name": "Cyan",
+                            "color": "#00ffff"
+                        },
+                        {
+                            "range": [80, 99],
+                            "name": "Orange",
+                            "color": "#ff7f00"
+                        },
+                        {
+                            "range": [100, 119],
+                            "name": "Green",
+                            "color": "#00ff00"
+                        },
+                        {
+                            "range": [120, 139],
+                            "name": "Blue",
+                            "color": "#0000ff"
+                        },
+                        {
+                            "range": [140, 159],
+                            "name": "Red",
+                            "color": "#ff0000"
+                        },
+                        {
+                            "range": [160, 244],
+                            "name": "Rainbow"
+                        },
+                        {
+                            "range": [245, 255],
+                            "name": "FX"
+                        }
+                    ]
+                },
+                "Gobo": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 19],
+                            "name": "open"
+                        },
+                        {
+                            "range": [20, 39],
+                            "name": "Gobo 1"
+                        },
+                        {
+                            "range": [40, 59],
+                            "name": "Gobo 2"
+                        },
+                        {
+                            "range": [60, 79],
+                            "name": "Gobo 3"
+                        },
+                        {
+                            "range": [80, 99],
+                            "name": "Gobo 4"
+                        },
+                        {
+                            "range": [100, 119],
+                            "name": "Gobo 5"
+                        },
+                        {
+                            "range": [120, 139],
+                            "name": "Gobo 6"
+                        },
+                        {
+                            "range": [140, 159],
+                            "name": "Gobo 7"
+                        },
+                        {
+                            "range": [160, 229],
+                            "name": "Rot Speed"
+                        },
+                        {
+                            "range": [230, 255],
+                            "name": "FX"
+                        },
+                        {
+                            "range": [0, 0],
+                            "name": "New Range"
+                        }
+                    ]
+                },
+                "Shutter": {
+                    "type": "Shutter",
+                    "capabilities": [
+                        {
+                            "range": [0, 9],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [10, 149],
+                            "name": "Strobe"
+                        },
+                        {
+                            "range": [150, 159],
+                            "name": "FX 1"
+                        },
+                        {
+                            "range": [160, 172],
+                            "name": "FX 2"
+                        },
+                        {
+                            "range": [173, 185],
+                            "name": "FX 3"
+                        },
+                        {
+                            "range": [186, 198],
+                            "name": "FX 4"
+                        },
+                        {
+                            "range": [199, 221],
+                            "name": "FX 5"
+                        },
+                        {
+                            "range": [212, 224],
+                            "name": "FX 6"
+                        },
+                        {
+                            "range": [225, 237],
+                            "name": "FX 7"
+                        },
+                        {
+                            "range": [238, 255],
+                            "name": "open"
+                        }
+                    ]
+                },
+                "Gobo Rot": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 112],
+                            "name": "cw rot"
+                        },
+                        {
+                            "range": [113, 142],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [0, 255],
+                            "name": "ccw rot"
+                        }
+                    ]
+                },
+                "Palette": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 63],
+                            "name": "off"
+                        },
+                        {
+                            "range": [64, 127],
+                            "name": "conver"
+                        },
+                        {
+                            "range": [128, 191],
+                            "name": "Frost",
+                            "color": "#edf5dd"
+                        },
+                        {
+                            "range": [192, 255],
+                            "name": "con + frost"
+                        }
+                    ]
+                },
+                "Prism": {
+                    "type": "Prism",
+                    "capabilities": [
+                        {
+                            "range": [0, 49],
+                            "name": "off"
+                        },
+                        {
+                            "range": [50, 79],
+                            "name": "prism"
+                        },
+                        {
+                            "range": [80, 255],
+                            "name": "prism rot"
+                        }
+                    ]
+                },
+                "Reset": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 49],
+                            "name": "off"
+                        },
+                        {
+                            "range": [50, 234],
+                            "name": "Lamp"
+                        },
+                        {
+                            "range": [235, 255],
+                            "name": "Reset"
+                        }
+                    ]
+                },
+                "Reset-3v3lc": {
+                    "name": "Reset",
+                    "type": "Beam"
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "12-channel Mode",
+                    "shortName": "12ch",
+                    "channels": [
+                        "Intensity",
+                        "Color",
+                        "Gobo",
+                        "Shutter",
+                        "Pan fine",
+                        "Tilt fine",
+                        "Prism",
+                        "Reset",
+                        "Reset-3v3lc",
+                        null,
+                        "Pan",
+                        "Tilt"
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/fixtures/imports/ecue-MainLibrary/Sagitter.json
+++ b/fixtures/imports/ecue-MainLibrary/Sagitter.json
@@ -1,0 +1,504 @@
+{
+    "manufacturers": {
+        "Sagitter": {
+            "name": "Sagitter",
+            "website": "www.sagitter.it"
+        }
+    },
+    "fixtures": [
+        {
+            "manufacturer": "Sagitter",
+            "name": "Sagitter Infinity Zoom 1200",
+            "shortName": "IZ1200",
+            "comment": "1200 W MSR",
+            "physical": {
+                "dimensions": [440, 1240, 420],
+                "weight": 47,
+                "power": 1700
+            },
+            "availableChannels": {
+                "Dimmer": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Shutter": {
+                    "type": "Shutter",
+                    "highlightValue": 40,
+                    "capabilities": [
+                        {
+                            "range": [0, 22],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [29, 50],
+                            "name": "open",
+                            "center": true
+                        }
+                    ]
+                },
+                "Iris": {
+                    "type": "Beam",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Zoom": {
+                    "type": "Beam",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Focus": {
+                    "type": "Beam",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "GoboStat.": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 21],
+                            "name": "ohne Gobo",
+                            "center": true
+                        },
+                        {
+                            "range": [35, 39],
+                            "name": "Gobo 1",
+                            "center": true
+                        },
+                        {
+                            "range": [60, 65],
+                            "name": "Gobo 2 Dichro",
+                            "center": true
+                        },
+                        {
+                            "range": [86, 90],
+                            "name": "Gobo 3",
+                            "center": true
+                        },
+                        {
+                            "range": [111, 115],
+                            "name": "Gobo 4",
+                            "center": true
+                        },
+                        {
+                            "range": [137, 140],
+                            "name": "Gobo 5",
+                            "center": true
+                        }
+                    ]
+                },
+                "RotGobo": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 45],
+                            "name": "Ohne Gobo",
+                            "center": true
+                        },
+                        {
+                            "range": [55, 102],
+                            "name": "GoboRot 1",
+                            "center": true
+                        },
+                        {
+                            "range": [107, 150],
+                            "name": "GoboRot 2",
+                            "center": true
+                        },
+                        {
+                            "range": [158, 202],
+                            "name": "GoboRot 3",
+                            "center": true
+                        },
+                        {
+                            "range": [210, 255],
+                            "name": "GoboRot 4",
+                            "center": true
+                        }
+                    ]
+                },
+                "RotatGobo": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 156],
+                            "name": "Index Posit."
+                        },
+                        {
+                            "range": [156, 198],
+                            "name": "V-schn.-lgs"
+                        },
+                        {
+                            "range": [212, 255],
+                            "name": "RW-lgs-schn"
+                        },
+                        {
+                            "range": [204, 204],
+                            "name": "Stop-Rotation"
+                        }
+                    ]
+                },
+                "Prismen": {
+                    "type": "Prism",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 60],
+                            "name": "Ohne Prisma",
+                            "center": true
+                        },
+                        {
+                            "range": [68, 124],
+                            "name": "Prisma 1",
+                            "center": true
+                        },
+                        {
+                            "range": [134, 188],
+                            "name": "Prisma 2",
+                            "center": true
+                        },
+                        {
+                            "range": [200, 255],
+                            "name": "Prisma 3",
+                            "center": true
+                        }
+                    ]
+                },
+                "RotatPrisma": {
+                    "type": "Prism",
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 153],
+                            "name": "Index Posit."
+                        },
+                        {
+                            "range": [156, 198],
+                            "name": "V-schn.-lgs."
+                        },
+                        {
+                            "range": [204, 204],
+                            "name": "Stop-Rotation"
+                        },
+                        {
+                            "range": [212, 255],
+                            "name": "RW-lgs-schn"
+                        }
+                    ]
+                },
+                "Frost": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 45],
+                            "name": "Ohne Frost",
+                            "center": true
+                        },
+                        {
+                            "range": [55, 102],
+                            "name": "Frost 1",
+                            "center": true
+                        },
+                        {
+                            "range": [107, 150],
+                            "name": "Frost 2",
+                            "center": true
+                        },
+                        {
+                            "range": [158, 202],
+                            "name": "Leer",
+                            "center": true
+                        },
+                        {
+                            "range": [210, 255],
+                            "name": "Multiface Pr.",
+                            "center": true
+                        }
+                    ]
+                },
+                "Color": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 9],
+                            "name": "Weiss",
+                            "center": true
+                        },
+                        {
+                            "range": [14, 19],
+                            "name": "Weiss-Rot",
+                            "center": true
+                        },
+                        {
+                            "range": [24, 29],
+                            "name": "ROT",
+                            "center": true
+                        },
+                        {
+                            "range": [35, 39],
+                            "name": "Rot-Gelb",
+                            "center": true
+                        },
+                        {
+                            "range": [45, 50],
+                            "name": "GELB",
+                            "center": true
+                        },
+                        {
+                            "range": [55, 60],
+                            "name": "Gelb-Magenta",
+                            "center": true
+                        },
+                        {
+                            "range": [65, 70],
+                            "name": "MAGENTA",
+                            "color": "#ca1f7b",
+                            "center": true
+                        },
+                        {
+                            "range": [75, 80],
+                            "name": "Mag.-Gr"
+                        },
+                        {
+                            "range": [86, 90],
+                            "name": "Gr"
+                        },
+                        {
+                            "range": [96, 101],
+                            "name": "Gr"
+                        },
+                        {
+                            "range": [106, 111],
+                            "name": "ORANGE",
+                            "color": "#ff7f00",
+                            "center": true
+                        },
+                        {
+                            "range": [116, 120],
+                            "name": "Orange-Blau",
+                            "center": true
+                        },
+                        {
+                            "range": [126, 131],
+                            "name": "BLAU",
+                            "center": true
+                        },
+                        {
+                            "range": [137, 141],
+                            "name": "Blau-Pink",
+                            "center": true
+                        },
+                        {
+                            "range": [147, 152],
+                            "name": "PINK",
+                            "color": "#ffc0cb",
+                            "center": true
+                        },
+                        {
+                            "range": [157, 162],
+                            "name": "Pink-Weiss",
+                            "center": true
+                        },
+                        {
+                            "range": [166, 204],
+                            "name": "Vorw-Max-Min"
+                        },
+                        {
+                            "range": [208, 210],
+                            "name": "Stop-Rotation",
+                            "center": true
+                        },
+                        {
+                            "range": [215, 255],
+                            "name": "R"
+                        }
+                    ]
+                },
+                "Cyan": {
+                    "type": "SingleColor",
+                    "color": "Cyan",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Yellow": {
+                    "type": "SingleColor",
+                    "color": "Yellow",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Magenta": {
+                    "type": "SingleColor",
+                    "color": "Magenta",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Lamp/Reset": {
+                    "type": "Beam",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "capabilities": [
+                        {
+                            "range": [0, 75],
+                            "name": "Lampe aus",
+                            "center": true
+                        },
+                        {
+                            "range": [81, 100],
+                            "name": "Selbst-Test",
+                            "center": true
+                        },
+                        {
+                            "range": [116, 139],
+                            "name": "RESET",
+                            "center": true
+                        },
+                        {
+                            "range": [190, 255],
+                            "name": "Lampe an!",
+                            "center": true
+                        }
+                    ]
+                },
+                "PAN": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "PAN fine": {
+                    "type": "Pan",
+                    "defaultValue": 0,
+                    "highlightValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "TILT": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "TILT fine": {
+                    "type": "Tilt",
+                    "defaultValue": 0,
+                    "highlightValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "PAN",
+                    "PAN fine"
+                ],
+                [
+                    "TILT",
+                    "TILT fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "20-channel Mode",
+                    "shortName": "20ch",
+                    "channels": [
+                        "Dimmer",
+                        "Shutter",
+                        "Iris",
+                        "Zoom",
+                        "Focus",
+                        "GoboStat.",
+                        "RotGobo",
+                        "RotatGobo",
+                        "Prismen",
+                        "RotatPrisma",
+                        "Frost",
+                        "Color",
+                        "Cyan",
+                        "Yellow",
+                        "Magenta",
+                        "Lamp/Reset",
+                        "PAN",
+                        "PAN fine",
+                        "TILT",
+                        "TILT fine"
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/fixtures/imports/ecue-MainLibrary/Showtec.json
+++ b/fixtures/imports/ecue-MainLibrary/Showtec.json
@@ -1,0 +1,1808 @@
+{
+    "manufacturers": {
+        "Showtec": {
+            "name": "Showtec",
+            "website": "www.highlite.nl"
+        }
+    },
+    "fixtures": [
+        {
+            "manufacturer": "Showtec",
+            "name": "Explorer 250 Pro",
+            "shortName": "Explorer250Pro",
+            "comment": "http:  www.highlite.nl index.php highlite silver.download downl",
+            "physical": {
+                "dimensions": [400, 400, 500],
+                "weight": 25,
+                "power": 500
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 0,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 0,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Speed": {
+                    "type": "Speed",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "% Fs-Sl"
+                        }
+                    ]
+                },
+                "Lamp": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "No Function"
+                        },
+                        {
+                            "range": [128, 139],
+                            "name": "LampON (>3sRes)",
+                            "center": true
+                        },
+                        {
+                            "range": [140, 229],
+                            "name": "No Function",
+                            "center": true
+                        },
+                        {
+                            "range": [230, 239],
+                            "name": "LampOff(>3sRes)",
+                            "center": true
+                        },
+                        {
+                            "range": [240, 255],
+                            "name": "No Function",
+                            "center": true
+                        }
+                    ]
+                },
+                "Color1": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 14],
+                            "name": "open"
+                        },
+                        {
+                            "range": [15, 31],
+                            "name": "Red",
+                            "color": "#ff0000",
+                            "center": true
+                        },
+                        {
+                            "range": [32, 47],
+                            "name": "Yellow",
+                            "color": "#ffff00",
+                            "center": true
+                        },
+                        {
+                            "range": [48, 63],
+                            "name": "Magenta",
+                            "color": "#ca1f7b",
+                            "center": true
+                        },
+                        {
+                            "range": [64, 79],
+                            "name": "Green",
+                            "color": "#00ff00",
+                            "center": true
+                        },
+                        {
+                            "range": [80, 95],
+                            "name": "Orange",
+                            "color": "#ff7f00",
+                            "center": true
+                        },
+                        {
+                            "range": [96, 111],
+                            "name": "Blue",
+                            "color": "#0000ff",
+                            "center": true
+                        },
+                        {
+                            "range": [112, 127],
+                            "name": "Pink",
+                            "color": "#ffc0cb",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 255],
+                            "name": "rainbow_cw S-F"
+                        }
+                    ]
+                },
+                "Stat.Gobo Color": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 36],
+                            "name": "open"
+                        },
+                        {
+                            "range": [37, 73],
+                            "name": "Gobo1",
+                            "center": true
+                        },
+                        {
+                            "range": [74, 110],
+                            "name": "Gobo2",
+                            "center": true
+                        },
+                        {
+                            "range": [111, 147],
+                            "name": "Gobo3 Color",
+                            "center": true
+                        },
+                        {
+                            "range": [148, 184],
+                            "name": "Light Orange",
+                            "center": true
+                        },
+                        {
+                            "range": [185, 221],
+                            "name": "Pale Purple",
+                            "center": true
+                        },
+                        {
+                            "range": [222, 255],
+                            "name": "Light Blue",
+                            "color": "#add8e6",
+                            "center": true
+                        }
+                    ]
+                },
+                "Prism": {
+                    "type": "Prism",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "open"
+                        },
+                        {
+                            "range": [128, 255],
+                            "name": "3 facet Prism",
+                            "center": true
+                        }
+                    ]
+                },
+                "Prism rot": {
+                    "type": "Prism",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 4],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [5, 127],
+                            "name": "rotate_cw S-F"
+                        },
+                        {
+                            "range": [128, 132],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [133, 255],
+                            "name": "rotate_ccw S-F"
+                        }
+                    ]
+                },
+                "Rot Gobo": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 31],
+                            "name": "open",
+                            "center": true
+                        },
+                        {
+                            "range": [32, 63],
+                            "name": "Gobo1 (Glas)",
+                            "center": true
+                        },
+                        {
+                            "range": [64, 95],
+                            "name": "Gobo2 (Glas)",
+                            "center": true
+                        },
+                        {
+                            "range": [96, 127],
+                            "name": "Gobo3 (Glas)",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 159],
+                            "name": "Gobo4",
+                            "center": true
+                        },
+                        {
+                            "range": [160, 223],
+                            "name": "Gobo5",
+                            "center": true
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "rot wheel S-F",
+                            "center": true
+                        }
+                    ]
+                },
+                "Gobo ind/rot": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 60],
+                            "name": "Index 0-540"
+                        },
+                        {
+                            "range": [61, 158],
+                            "name": "rot cw S-F"
+                        },
+                        {
+                            "range": [159, 255],
+                            "name": "rot ccw S-F"
+                        }
+                    ]
+                },
+                "Zoom": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 31],
+                            "name": "15deg"
+                        },
+                        {
+                            "range": [32, 47],
+                            "name": "18deg"
+                        },
+                        {
+                            "range": [48, 63],
+                            "name": "21deg"
+                        },
+                        {
+                            "range": [64, 79],
+                            "name": "24deg"
+                        },
+                        {
+                            "range": [80, 95],
+                            "name": "26deg"
+                        },
+                        {
+                            "range": [96, 111],
+                            "name": "Frost",
+                            "color": "#edf5dd",
+                            "center": true
+                        },
+                        {
+                            "range": [112, 127],
+                            "name": "UV-Filter",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 159],
+                            "name": "15deg correctio"
+                        },
+                        {
+                            "range": [160, 175],
+                            "name": "18deg correctio"
+                        },
+                        {
+                            "range": [176, 191],
+                            "name": "21deg correctio"
+                        },
+                        {
+                            "range": [192, 207],
+                            "name": "24deg correctio"
+                        },
+                        {
+                            "range": [208, 223],
+                            "name": "26deg correctio"
+                        },
+                        {
+                            "range": [224, 239],
+                            "name": "Frost",
+                            "color": "#edf5dd",
+                            "center": true
+                        },
+                        {
+                            "range": [240, 255],
+                            "name": "UV-Filter",
+                            "center": true
+                        }
+                    ]
+                },
+                "Focus": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Shutter": {
+                    "type": "Shutter",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 31],
+                            "name": "closed",
+                            "center": true
+                        },
+                        {
+                            "range": [32, 63],
+                            "name": "open",
+                            "center": true
+                        },
+                        {
+                            "range": [64, 95],
+                            "name": "strobe"
+                        },
+                        {
+                            "range": [96, 127],
+                            "name": "open"
+                        },
+                        {
+                            "range": [128, 143],
+                            "name": "pulse_o"
+                        },
+                        {
+                            "range": [144, 159],
+                            "name": "pulse_c"
+                        },
+                        {
+                            "range": [160, 191],
+                            "name": "open"
+                        },
+                        {
+                            "range": [192, 223],
+                            "name": "random"
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "open"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "16-channel Mode",
+                    "shortName": "16ch",
+                    "channels": [
+                        "Pan",
+                        null,
+                        "Tilt",
+                        "Tilt fine",
+                        "Speed",
+                        "Lamp",
+                        "Color1",
+                        "Stat.Gobo Color",
+                        "Prism",
+                        "Prism rot",
+                        "Rot Gobo",
+                        "Gobo ind/rot",
+                        "Zoom",
+                        "Focus",
+                        "Shutter",
+                        "Intensity"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Showtec",
+            "name": "Indigo 4500 Advanced",
+            "shortName": "Indigo4500Advanced",
+            "comment": "http://www.highlite.nl/highlite/silver.econtent/catalog/highlite/entertainment_products/showtec/lighteffects/movingheads/indigo_4500",
+            "physical": {
+                "dimensions": [295, 290, 485],
+                "weight": 14,
+                "power": 60
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 0,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 0,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "P/T speed": {
+                    "type": "Speed",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "P+T Speed"
+                        }
+                    ]
+                },
+                "Colorwheel": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 16],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [17, 33],
+                            "name": "Red",
+                            "color": "#ff0000",
+                            "center": true
+                        },
+                        {
+                            "range": [34, 50],
+                            "name": "Yellow",
+                            "color": "#ffff00",
+                            "center": true
+                        },
+                        {
+                            "range": [51, 67],
+                            "name": "Magenta",
+                            "color": "#ca1f7b",
+                            "center": true
+                        },
+                        {
+                            "range": [68, 84],
+                            "name": "Green",
+                            "color": "#00ff00",
+                            "center": true
+                        },
+                        {
+                            "range": [85, 101],
+                            "name": "Orange",
+                            "color": "#ff7f00",
+                            "center": true
+                        },
+                        {
+                            "range": [102, 118],
+                            "name": "Blue",
+                            "color": "#0000ff",
+                            "center": true
+                        },
+                        {
+                            "range": [119, 135],
+                            "name": "Lite Blue",
+                            "center": true
+                        },
+                        {
+                            "range": [136, 152],
+                            "name": "Light Green",
+                            "color": "#90ee90",
+                            "center": true
+                        },
+                        {
+                            "range": [153, 255],
+                            "name": "Backwards"
+                        }
+                    ]
+                },
+                "Stat Gobo Wheel": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 9],
+                            "name": "open",
+                            "center": true
+                        },
+                        {
+                            "range": [10, 19],
+                            "name": "Gobo1 Metal",
+                            "center": true
+                        },
+                        {
+                            "range": [20, 29],
+                            "name": "Gobo2 Metal",
+                            "center": true
+                        },
+                        {
+                            "range": [30, 39],
+                            "name": "Gobo3 Metal",
+                            "center": true
+                        },
+                        {
+                            "range": [40, 49],
+                            "name": "Gobo4 Metal",
+                            "center": true
+                        },
+                        {
+                            "range": [50, 59],
+                            "name": "Gobo5 Metal",
+                            "center": true
+                        },
+                        {
+                            "range": [60, 69],
+                            "name": "Gobo6 Metal",
+                            "center": true
+                        },
+                        {
+                            "range": [70, 79],
+                            "name": "Gobo7 Metal",
+                            "center": true
+                        },
+                        {
+                            "range": [80, 89],
+                            "name": "Gobo8 Metal",
+                            "center": true
+                        },
+                        {
+                            "range": [90, 99],
+                            "name": "Gobo9 Metal",
+                            "center": true
+                        },
+                        {
+                            "range": [100, 114],
+                            "name": "Gobo9 Shake",
+                            "center": true
+                        },
+                        {
+                            "range": [115, 129],
+                            "name": "Gobo8 Shake",
+                            "center": true
+                        },
+                        {
+                            "range": [130, 144],
+                            "name": "Gobo7 Shake",
+                            "center": true
+                        },
+                        {
+                            "range": [145, 159],
+                            "name": "Gobo6 Shake",
+                            "center": true
+                        },
+                        {
+                            "range": [160, 174],
+                            "name": "Gobo5 Shake",
+                            "center": true
+                        },
+                        {
+                            "range": [175, 189],
+                            "name": "Gobo4 Shake",
+                            "center": true
+                        },
+                        {
+                            "range": [190, 204],
+                            "name": "Gobo3 Shake",
+                            "center": true
+                        },
+                        {
+                            "range": [205, 219],
+                            "name": "Gobo2 Shake",
+                            "center": true
+                        },
+                        {
+                            "range": [220, 234],
+                            "name": "Gobo1 Shake",
+                            "center": true
+                        },
+                        {
+                            "range": [235, 255],
+                            "name": "Backwards ",
+                            "center": true
+                        }
+                    ]
+                },
+                "Rot Gobo Wheel": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 9],
+                            "name": "open",
+                            "center": true
+                        },
+                        {
+                            "range": [10, 19],
+                            "name": "Gobo1 Metal",
+                            "center": true
+                        },
+                        {
+                            "range": [20, 29],
+                            "name": "Gobo2 Metal",
+                            "center": true
+                        },
+                        {
+                            "range": [30, 39],
+                            "name": "Gobo3 Metal",
+                            "center": true
+                        },
+                        {
+                            "range": [40, 49],
+                            "name": "Gobo4 Metal",
+                            "center": true
+                        },
+                        {
+                            "range": [50, 59],
+                            "name": "Gobo5 Metal",
+                            "center": true
+                        },
+                        {
+                            "range": [60, 69],
+                            "name": "Gobo6 Glass",
+                            "center": true
+                        },
+                        {
+                            "range": [70, 79],
+                            "name": "Gobo7 Glass",
+                            "center": true
+                        },
+                        {
+                            "range": [80, 99],
+                            "name": "Gobo7 Shake",
+                            "center": true
+                        },
+                        {
+                            "range": [100, 119],
+                            "name": "Gobo6 Shake",
+                            "center": true
+                        },
+                        {
+                            "range": [120, 139],
+                            "name": "Gobo5 Shake",
+                            "center": true
+                        },
+                        {
+                            "range": [140, 159],
+                            "name": "Gobo4 Shake",
+                            "center": true
+                        },
+                        {
+                            "range": [160, 179],
+                            "name": "Gobo3 Shake",
+                            "center": true
+                        },
+                        {
+                            "range": [180, 199],
+                            "name": "Gobo2 Shake",
+                            "center": true
+                        },
+                        {
+                            "range": [200, 219],
+                            "name": "Gobo1 Shake",
+                            "center": true
+                        },
+                        {
+                            "range": [220, 255],
+                            "name": "Forwards",
+                            "center": true
+                        }
+                    ]
+                },
+                "Gobo Rot": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 60],
+                            "name": "Index"
+                        },
+                        {
+                            "range": [61, 158],
+                            "name": "Rot cw S-F"
+                        },
+                        {
+                            "range": [159, 255],
+                            "name": "Rot ccw S-F"
+                        }
+                    ]
+                },
+                "Prism Rot": {
+                    "type": "Prism",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 4],
+                            "name": "Stop"
+                        },
+                        {
+                            "range": [5, 127],
+                            "name": "Rotate_ccw S-F"
+                        },
+                        {
+                            "range": [128, 132],
+                            "name": "Stop"
+                        },
+                        {
+                            "range": [133, 255],
+                            "name": "Rotate_ccw S-F"
+                        }
+                    ]
+                },
+                "Focus": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Shutter": {
+                    "type": "Shutter",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 31],
+                            "name": "Closed",
+                            "center": true
+                        },
+                        {
+                            "range": [32, 63],
+                            "name": "Open",
+                            "center": true
+                        },
+                        {
+                            "range": [64, 95],
+                            "name": "Strobe"
+                        },
+                        {
+                            "range": [96, 127],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [128, 159],
+                            "name": "Pulse-Effect"
+                        },
+                        {
+                            "range": [160, 191],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [192, 223],
+                            "name": "random"
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "open"
+                        }
+                    ]
+                },
+                "Channel Funct": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 19],
+                            "name": "No Function",
+                            "center": true
+                        },
+                        {
+                            "range": [20, 39],
+                            "name": "Blackout P+T",
+                            "center": true
+                        },
+                        {
+                            "range": [40, 59],
+                            "name": "Disable Blackou",
+                            "center": true
+                        },
+                        {
+                            "range": [60, 79],
+                            "name": "Auto 1",
+                            "center": true
+                        },
+                        {
+                            "range": [80, 99],
+                            "name": "Auto 2",
+                            "center": true
+                        },
+                        {
+                            "range": [100, 119],
+                            "name": "Sound 1",
+                            "center": true
+                        },
+                        {
+                            "range": [120, 139],
+                            "name": "Sound 2 ",
+                            "center": true
+                        },
+                        {
+                            "range": [140, 159],
+                            "name": "Custom",
+                            "center": true
+                        },
+                        {
+                            "range": [160, 179],
+                            "name": "Test",
+                            "center": true
+                        },
+                        {
+                            "range": [180, 199],
+                            "name": "No Function",
+                            "center": true
+                        },
+                        {
+                            "range": [200, 219],
+                            "name": "Reset",
+                            "center": true
+                        },
+                        {
+                            "range": [220, 255],
+                            "name": "No Function",
+                            "center": true
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "14-channel Mode",
+                    "shortName": "14ch",
+                    "channels": [
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "P/T speed",
+                        "Colorwheel",
+                        "Stat Gobo Wheel",
+                        "Rot Gobo Wheel",
+                        "Gobo Rot",
+                        "Prism Rot",
+                        "Focus",
+                        "Intensity",
+                        "Shutter",
+                        "Channel Funct"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Showtec",
+            "name": "Indigo 4500 Basic",
+            "shortName": "Indigo4500Basic",
+            "comment": "http://www.highlite.nl/highlite/silver.econtent/catalog/highlite/entertainment_products/showtec/lighteffects/movingheads/indigo_4500",
+            "physical": {
+                "dimensions": [295, 290, 485],
+                "weight": 14,
+                "power": 60
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 32768,
+                    "highlightValue": 65535,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 32768,
+                    "highlightValue": 65535,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Colorwheel": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 16],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [17, 33],
+                            "name": "Red",
+                            "color": "#ff0000",
+                            "center": true
+                        },
+                        {
+                            "range": [34, 50],
+                            "name": "Yellow",
+                            "color": "#ffff00",
+                            "center": true
+                        },
+                        {
+                            "range": [51, 67],
+                            "name": "Magenta",
+                            "color": "#ca1f7b",
+                            "center": true
+                        },
+                        {
+                            "range": [68, 84],
+                            "name": "Green",
+                            "color": "#00ff00",
+                            "center": true
+                        },
+                        {
+                            "range": [85, 101],
+                            "name": "Orange",
+                            "color": "#ff7f00",
+                            "center": true
+                        },
+                        {
+                            "range": [102, 118],
+                            "name": "Blue",
+                            "color": "#0000ff",
+                            "center": true
+                        },
+                        {
+                            "range": [119, 135],
+                            "name": "Lite Blue",
+                            "center": true
+                        },
+                        {
+                            "range": [136, 152],
+                            "name": "Light Green",
+                            "color": "#90ee90",
+                            "center": true
+                        },
+                        {
+                            "range": [153, 255],
+                            "name": "Backwards"
+                        }
+                    ]
+                },
+                "Stat Gobo Wheel": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 9],
+                            "name": "open",
+                            "center": true
+                        },
+                        {
+                            "range": [10, 19],
+                            "name": "Gobo1 Metal",
+                            "center": true
+                        },
+                        {
+                            "range": [20, 29],
+                            "name": "Gobo2 Metal",
+                            "center": true
+                        },
+                        {
+                            "range": [30, 39],
+                            "name": "Gobo3 Metal",
+                            "center": true
+                        },
+                        {
+                            "range": [40, 49],
+                            "name": "Gobo4 Metal",
+                            "center": true
+                        },
+                        {
+                            "range": [50, 59],
+                            "name": "Gobo5 Metal",
+                            "center": true
+                        },
+                        {
+                            "range": [60, 69],
+                            "name": "Gobo6 Metal",
+                            "center": true
+                        },
+                        {
+                            "range": [70, 79],
+                            "name": "Gobo7 Metal",
+                            "center": true
+                        },
+                        {
+                            "range": [80, 89],
+                            "name": "Gobo8 Metal",
+                            "center": true
+                        },
+                        {
+                            "range": [90, 99],
+                            "name": "Gobo9 Metal",
+                            "center": true
+                        },
+                        {
+                            "range": [100, 114],
+                            "name": "Gobo9 Shake",
+                            "center": true
+                        },
+                        {
+                            "range": [115, 129],
+                            "name": "Gobo8 Shake",
+                            "center": true
+                        },
+                        {
+                            "range": [130, 144],
+                            "name": "Gobo7 Shake",
+                            "center": true
+                        },
+                        {
+                            "range": [145, 159],
+                            "name": "Gobo6 Shake",
+                            "center": true
+                        },
+                        {
+                            "range": [160, 174],
+                            "name": "Gobo5 Shake",
+                            "center": true
+                        },
+                        {
+                            "range": [175, 189],
+                            "name": "Gobo4 Shake",
+                            "center": true
+                        },
+                        {
+                            "range": [190, 204],
+                            "name": "Gobo3 Shake",
+                            "center": true
+                        },
+                        {
+                            "range": [205, 219],
+                            "name": "Gobo2 Shake",
+                            "center": true
+                        },
+                        {
+                            "range": [220, 234],
+                            "name": "Gobo1 Shake",
+                            "center": true
+                        },
+                        {
+                            "range": [235, 255],
+                            "name": "Backwards ",
+                            "center": true
+                        }
+                    ]
+                },
+                "Rot Gobo Wheel": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 9],
+                            "name": "open",
+                            "center": true
+                        },
+                        {
+                            "range": [10, 19],
+                            "name": "Gobo1 Metal",
+                            "center": true
+                        },
+                        {
+                            "range": [20, 29],
+                            "name": "Gobo2 Metal",
+                            "center": true
+                        },
+                        {
+                            "range": [30, 39],
+                            "name": "Gobo3 Metal",
+                            "center": true
+                        },
+                        {
+                            "range": [40, 49],
+                            "name": "Gobo4 Metal",
+                            "center": true
+                        },
+                        {
+                            "range": [50, 59],
+                            "name": "Gobo5 Metal",
+                            "center": true
+                        },
+                        {
+                            "range": [60, 69],
+                            "name": "Gobo6 Glass",
+                            "center": true
+                        },
+                        {
+                            "range": [70, 79],
+                            "name": "Gobo7 Glass",
+                            "center": true
+                        },
+                        {
+                            "range": [80, 99],
+                            "name": "Gobo7 Shake",
+                            "center": true
+                        },
+                        {
+                            "range": [100, 119],
+                            "name": "Gobo6 Shake",
+                            "center": true
+                        },
+                        {
+                            "range": [120, 139],
+                            "name": "Gobo5 Shake",
+                            "center": true
+                        },
+                        {
+                            "range": [140, 159],
+                            "name": "Gobo4 Shake",
+                            "center": true
+                        },
+                        {
+                            "range": [160, 179],
+                            "name": "Gobo3 Shake",
+                            "center": true
+                        },
+                        {
+                            "range": [180, 199],
+                            "name": "Gobo2 Shake",
+                            "center": true
+                        },
+                        {
+                            "range": [200, 219],
+                            "name": "Gobo1 Shake",
+                            "center": true
+                        },
+                        {
+                            "range": [220, 255],
+                            "name": "Forwards",
+                            "center": true
+                        }
+                    ]
+                },
+                "Gobo Rot": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 60],
+                            "name": "Index"
+                        },
+                        {
+                            "range": [61, 158],
+                            "name": "Rot cw S-F"
+                        },
+                        {
+                            "range": [159, 255],
+                            "name": "Rot ccw S-F"
+                        }
+                    ]
+                },
+                "Prism Rot": {
+                    "type": "Prism",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 4],
+                            "name": "Stop"
+                        },
+                        {
+                            "range": [5, 127],
+                            "name": "Rotate_ccw S-F"
+                        },
+                        {
+                            "range": [128, 132],
+                            "name": "Stop"
+                        },
+                        {
+                            "range": [133, 255],
+                            "name": "Rotate_ccw S-F"
+                        }
+                    ]
+                },
+                "Focus": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Shutter": {
+                    "type": "Shutter",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 31],
+                            "name": "Closed",
+                            "center": true
+                        },
+                        {
+                            "range": [32, 63],
+                            "name": "Open",
+                            "center": true
+                        },
+                        {
+                            "range": [64, 95],
+                            "name": "Strobe"
+                        },
+                        {
+                            "range": [96, 127],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [128, 159],
+                            "name": "Pulse-Effect"
+                        },
+                        {
+                            "range": [160, 191],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [192, 223],
+                            "name": "random"
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "open"
+                        }
+                    ]
+                },
+                "Channel Funct": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 19],
+                            "name": "No Function",
+                            "center": true
+                        },
+                        {
+                            "range": [20, 39],
+                            "name": "Blackout P+T",
+                            "center": true
+                        },
+                        {
+                            "range": [40, 59],
+                            "name": "Disable Blackou",
+                            "center": true
+                        },
+                        {
+                            "range": [60, 79],
+                            "name": "Auto 1",
+                            "center": true
+                        },
+                        {
+                            "range": [80, 99],
+                            "name": "Auto 2",
+                            "center": true
+                        },
+                        {
+                            "range": [100, 119],
+                            "name": "Sound 1",
+                            "center": true
+                        },
+                        {
+                            "range": [120, 139],
+                            "name": "Sound 2 ",
+                            "center": true
+                        },
+                        {
+                            "range": [140, 159],
+                            "name": "Custom",
+                            "center": true
+                        },
+                        {
+                            "range": [160, 179],
+                            "name": "Test",
+                            "center": true
+                        },
+                        {
+                            "range": [180, 199],
+                            "name": "No Function",
+                            "center": true
+                        },
+                        {
+                            "range": [200, 219],
+                            "name": "Reset",
+                            "center": true
+                        },
+                        {
+                            "range": [220, 255],
+                            "name": "No Function",
+                            "center": true
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "14-channel Mode",
+                    "shortName": "14ch",
+                    "channels": [
+                        "Pan",
+                        "Tilt",
+                        "Colorwheel",
+                        "Stat Gobo Wheel",
+                        "Rot Gobo Wheel",
+                        "Gobo Rot",
+                        "Prism Rot",
+                        "Focus",
+                        "Intensity",
+                        "Shutter",
+                        "Channel Funct"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Showtec",
+            "name": "Revolution 250",
+            "shortName": "Revo250",
+            "comment": "cd",
+            "physical": {
+                "dimensions": [430, 460, 400],
+                "weight": 19,
+                "power": 300
+            },
+            "availableChannels": {
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 159],
+                            "name": "dim"
+                        },
+                        {
+                            "range": [160, 253],
+                            "name": "strobe"
+                        },
+                        {
+                            "range": [254, 255],
+                            "name": "open"
+                        }
+                    ]
+                },
+                "Color": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 13],
+                            "name": "open"
+                        },
+                        {
+                            "range": [14, 25],
+                            "name": "blue",
+                            "color": "#0000ff"
+                        },
+                        {
+                            "range": [26, 38],
+                            "name": "green",
+                            "color": "#00ff00"
+                        },
+                        {
+                            "range": [39, 51],
+                            "name": "pink",
+                            "color": "#ffc0cb"
+                        },
+                        {
+                            "range": [52, 63],
+                            "name": "yellow",
+                            "color": "#ffff00"
+                        },
+                        {
+                            "range": [64, 77],
+                            "name": "violet",
+                            "color": "#7f00ff"
+                        },
+                        {
+                            "range": [78, 89],
+                            "name": "red",
+                            "color": "#ff0000"
+                        },
+                        {
+                            "range": [90, 102],
+                            "name": "UV"
+                        },
+                        {
+                            "range": [103, 115],
+                            "name": "dark blue",
+                            "color": "#00008b"
+                        },
+                        {
+                            "range": [116, 127],
+                            "name": "orange",
+                            "color": "#ff7f00"
+                        },
+                        {
+                            "range": [128, 141],
+                            "name": "bright blue"
+                        },
+                        {
+                            "range": [142, 153],
+                            "name": "CTO"
+                        },
+                        {
+                            "range": [154, 202],
+                            "name": ">>"
+                        },
+                        {
+                            "range": [203, 206],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [207, 255],
+                            "name": "<<"
+                        }
+                    ]
+                },
+                "Gobo": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 23],
+                            "name": "open"
+                        },
+                        {
+                            "range": [24, 47],
+                            "name": "slot1"
+                        },
+                        {
+                            "range": [48, 71],
+                            "name": "slot2"
+                        },
+                        {
+                            "range": [72, 95],
+                            "name": "slot3"
+                        },
+                        {
+                            "range": [96, 119],
+                            "name": "slot4"
+                        },
+                        {
+                            "range": [120, 143],
+                            "name": "slot5"
+                        },
+                        {
+                            "range": [144, 167],
+                            "name": "slot6"
+                        },
+                        {
+                            "range": [168, 255],
+                            "name": ">>"
+                        }
+                    ]
+                },
+                "Gobo rot.": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "ind."
+                        },
+                        {
+                            "range": [128, 190],
+                            "name": ">>"
+                        },
+                        {
+                            "range": [191, 192],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [193, 255],
+                            "name": "<<"
+                        }
+                    ]
+                },
+                "Prisma": {
+                    "type": "Prism",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 1],
+                            "name": "open"
+                        },
+                        {
+                            "range": [2, 7],
+                            "name": "prisma"
+                        },
+                        {
+                            "range": [8, 127],
+                            "name": "<<"
+                        },
+                        {
+                            "range": [128, 133],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [134, 253],
+                            "name": ">>"
+                        },
+                        {
+                            "range": [254, 255],
+                            "name": "stop"
+                        }
+                    ]
+                },
+                "Focus": {
+                    "type": "Beam",
+                    "defaultValue": 128,
+                    "crossfade": true
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "crossfade": true
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "crossfade": true
+                },
+                "Pan rot.": {
+                    "type": "Pan",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 3],
+                            "name": "idle"
+                        },
+                        {
+                            "range": [4, 127],
+                            "name": ">>"
+                        },
+                        {
+                            "range": [128, 131],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [132, 255],
+                            "name": "<<"
+                        }
+                    ]
+                },
+                "Tilt rot.": {
+                    "type": "Tilt",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 3],
+                            "name": "idle"
+                        },
+                        {
+                            "range": [4, 127],
+                            "name": ">>"
+                        },
+                        {
+                            "range": [128, 131],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [132, 255],
+                            "name": "<<"
+                        }
+                    ]
+                },
+                "Reset": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "idle"
+                        },
+                        {
+                            "range": [128, 255],
+                            "name": "reset"
+                        }
+                    ]
+                },
+                "Lamp": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 47],
+                            "name": "idle"
+                        },
+                        {
+                            "range": [48, 95],
+                            "name": "on"
+                        },
+                        {
+                            "range": [96, 159],
+                            "name": "idle"
+                        },
+                        {
+                            "range": [160, 207],
+                            "name": "off"
+                        },
+                        {
+                            "range": [208, 255],
+                            "name": "idle"
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "12-channel Mode",
+                    "shortName": "12ch",
+                    "channels": [
+                        "Intensity",
+                        "Color",
+                        "Gobo",
+                        "Gobo rot.",
+                        "Prisma",
+                        "Focus",
+                        "Pan",
+                        "Tilt",
+                        "Pan rot.",
+                        "Tilt rot.",
+                        "Reset",
+                        "Lamp"
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/fixtures/imports/ecue-MainLibrary/Soundlight.json
+++ b/fixtures/imports/ecue-MainLibrary/Soundlight.json
@@ -1,0 +1,1202 @@
+{
+    "manufacturers": {
+        "Soundlight": {
+            "name": "Soundlight",
+            "website": "www.soundlight.de"
+        }
+    },
+    "fixtures": [
+        {
+            "manufacturer": "Soundlight",
+            "name": "12CH Demultiplexer",
+            "shortName": "SL 12CH",
+            "physical": {
+                "dimensions": [100, 100, 100]
+            },
+            "availableChannels": {
+                "CH01": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "CH02": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "CH03": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "CH04": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "CH05": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "CH06": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "CH07": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "CH08": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "CH09": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "CH10": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "CH11": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "CH12": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "12-channel Mode",
+                    "shortName": "12ch",
+                    "channels": [
+                        "CH01",
+                        "CH02",
+                        "CH03",
+                        "CH04",
+                        "CH05",
+                        "CH06",
+                        "CH07",
+                        "CH08",
+                        "CH09",
+                        "CH10",
+                        "CH11",
+                        "CH12"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Soundlight",
+            "name": "30CH Demultiplexer",
+            "shortName": "SL 30CH",
+            "physical": {
+                "dimensions": [100, 100, 100]
+            },
+            "availableChannels": {
+                "CH01": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "CH02": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "CH03": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "CH04": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "CH05": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "CH06": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "CH07": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "CH08": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "CH09": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "CH10": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "CH11": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "CH12": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "CH13": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "CH14": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "CH15": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "CH16": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "CH17": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "CH18": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "CH19": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "CH20": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "CH21": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "CH22": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "CH23": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "CH24": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "CH25": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "CH26": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "CH27": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "CH28": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "CH29": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "CH30": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "30-channel Mode",
+                    "shortName": "30ch",
+                    "channels": [
+                        "CH01",
+                        "CH02",
+                        "CH03",
+                        "CH04",
+                        "CH05",
+                        "CH06",
+                        "CH07",
+                        "CH08",
+                        "CH09",
+                        "CH10",
+                        "CH11",
+                        "CH12",
+                        "CH13",
+                        "CH14",
+                        "CH15",
+                        "CH16",
+                        "CH17",
+                        "CH18",
+                        "CH19",
+                        "CH20",
+                        "CH21",
+                        "CH22",
+                        "CH23",
+                        "CH24",
+                        "CH25",
+                        "CH26",
+                        "CH27",
+                        "CH28",
+                        "CH29",
+                        "CH30"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Soundlight",
+            "name": "32CH Demultiplexer",
+            "shortName": "SL 32CH",
+            "physical": {
+                "dimensions": [100, 100, 100]
+            },
+            "availableChannels": {
+                "CH01": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "CH02": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "CH03": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "CH04": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "CH05": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "CH06": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "CH07": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "CH08": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "CH09": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "CH10": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "CH11": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "CH12": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "CH13": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "CH14": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "CH15": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "CH16": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "CH17": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "CH18": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "CH19": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "CH20": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "CH21": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "CH22": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "CH23": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "CH24": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "CH25": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "CH26": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "CH27": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "CH28": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "CH29": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "CH30": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "CH31": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "CH32": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "32-channel Mode",
+                    "shortName": "32ch",
+                    "channels": [
+                        "CH01",
+                        "CH02",
+                        "CH03",
+                        "CH04",
+                        "CH05",
+                        "CH06",
+                        "CH07",
+                        "CH08",
+                        "CH09",
+                        "CH10",
+                        "CH11",
+                        "CH12",
+                        "CH13",
+                        "CH14",
+                        "CH15",
+                        "CH16",
+                        "CH17",
+                        "CH18",
+                        "CH19",
+                        "CH20",
+                        "CH21",
+                        "CH22",
+                        "CH23",
+                        "CH24",
+                        "CH25",
+                        "CH26",
+                        "CH27",
+                        "CH28",
+                        "CH29",
+                        "CH30",
+                        "CH31",
+                        "CH32"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Soundlight",
+            "name": "6CH Demultiplexer",
+            "shortName": "SL 6CH",
+            "physical": {
+                "dimensions": [100, 100, 100]
+            },
+            "availableChannels": {
+                "CH01": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "CH02": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "CH03": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "CH04": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "CH05": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "CH06": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "6-channel Mode",
+                    "shortName": "6ch",
+                    "channels": [
+                        "CH01",
+                        "CH02",
+                        "CH03",
+                        "CH04",
+                        "CH05",
+                        "CH06"
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/fixtures/imports/ecue-MainLibrary/Space-Cannon-VH.json
+++ b/fixtures/imports/ecue-MainLibrary/Space-Cannon-VH.json
@@ -1,0 +1,506 @@
+{
+    "manufacturers": {
+        "Space Cannon VH": {
+            "name": "Space Cannon VH",
+            "website": "http://www.spacecannon.it/"
+        }
+    },
+    "fixtures": [
+        {
+            "manufacturer": "Space Cannon VH",
+            "name": "Black Devil",
+            "shortName": "BlackDevil",
+            "physical": {
+                "dimensions": [1100, 1100, 1400],
+                "weight": 170,
+                "power": 7000
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "crossfade": true
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "crossfade": true
+                },
+                "lamp on": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "lamp off": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "reserved": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "reserved-qs7xb": {
+                    "name": "reserved",
+                    "type": "Beam",
+                    "crossfade": true
+                }
+            },
+            "modes": [
+                {
+                    "name": "8-channel Mode",
+                    "shortName": "8ch",
+                    "channels": [
+                        "Pan",
+                        "Tilt",
+                        null,
+                        null,
+                        "lamp on",
+                        "lamp off",
+                        "reserved",
+                        "reserved-qs7xb"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Space Cannon VH",
+            "name": "Color Art",
+            "shortName": "ColorArt",
+            "physical": {
+                "dimensions": [1000, 1000, 1000]
+            },
+            "availableChannels": {
+                "Magenta": {
+                    "type": "SingleColor",
+                    "color": "Magenta",
+                    "crossfade": true
+                },
+                "Cyan": {
+                    "type": "SingleColor",
+                    "color": "Cyan",
+                    "crossfade": true
+                },
+                "Yellow": {
+                    "type": "SingleColor",
+                    "color": "Yellow",
+                    "crossfade": true
+                },
+                "Zoom": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Lamp": {
+                    "type": "Beam",
+                    "defaultValue": 256,
+                    "crossfade": true
+                },
+                "Shutter": {
+                    "type": "Shutter",
+                    "crossfade": true
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Strobe": {
+                    "type": "Strobe"
+                },
+                "Strobe sync": {
+                    "type": "Strobe",
+                    "crossfade": true
+                },
+                "Strobe delay": {
+                    "type": "Strobe",
+                    "crossfade": true
+                },
+                "Reset": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [255, 255],
+                            "name": "Reset"
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "15-channel Mode",
+                    "shortName": "15ch",
+                    "channels": [
+                        "Magenta",
+                        "Cyan",
+                        "Yellow",
+                        "Zoom",
+                        "Lamp",
+                        "Shutter",
+                        "Intensity",
+                        "Strobe",
+                        null,
+                        null,
+                        null,
+                        null,
+                        "Strobe sync",
+                        "Strobe delay",
+                        "Reset"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Space Cannon VH",
+            "name": "Focus",
+            "shortName": "Focus",
+            "physical": {
+                "dimensions": [1000, 1000, 1000]
+            },
+            "availableChannels": {
+                "Magenta": {
+                    "type": "SingleColor",
+                    "color": "Magenta",
+                    "crossfade": true
+                },
+                "Cyan": {
+                    "type": "SingleColor",
+                    "color": "Cyan",
+                    "crossfade": true
+                },
+                "Yellow": {
+                    "type": "SingleColor",
+                    "color": "Yellow",
+                    "crossfade": true
+                },
+                "Zoom": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Lamp": {
+                    "type": "Beam"
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Reset": {
+                    "type": "Beam"
+                }
+            },
+            "modes": [
+                {
+                    "name": "8-channel Mode",
+                    "shortName": "8ch",
+                    "channels": [
+                        "Magenta",
+                        "Cyan",
+                        "Yellow",
+                        "Zoom",
+                        "Lamp",
+                        "Intensity",
+                        null,
+                        "Reset"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Space Cannon VH",
+            "name": "Ireos Pro VHT 7000",
+            "shortName": "Ireos 7kw",
+            "physical": {
+                "dimensions": [1000, 1000, 1000]
+            },
+            "availableChannels": {
+                "Magenta": {
+                    "type": "SingleColor",
+                    "color": "Magenta",
+                    "crossfade": true
+                },
+                "Cyan": {
+                    "type": "SingleColor",
+                    "color": "Cyan",
+                    "crossfade": true
+                },
+                "Yellow": {
+                    "type": "SingleColor",
+                    "color": "Yellow",
+                    "crossfade": true
+                },
+                "Zoom": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Park off on": {
+                    "type": "Beam",
+                    "defaultValue": 256,
+                    "crossfade": true
+                },
+                "Shutter": {
+                    "type": "Shutter",
+                    "crossfade": true
+                },
+                "Dimmer": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Strobe": {
+                    "type": "Strobe"
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 0,
+                    "highlightValue": 0,
+                    "crossfade": true
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 0,
+                    "highlightValue": 0,
+                    "crossfade": true
+                },
+                "Strobe sync": {
+                    "type": "Strobe",
+                    "crossfade": true
+                },
+                "Strobe delay": {
+                    "type": "Strobe",
+                    "crossfade": true
+                },
+                "Reset": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [255, 255],
+                            "name": "Reset"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "15-channel Mode",
+                    "shortName": "15ch",
+                    "channels": [
+                        "Magenta",
+                        "Cyan",
+                        "Yellow",
+                        "Zoom",
+                        "Park off on",
+                        "Shutter",
+                        "Dimmer",
+                        "Strobe",
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "Strobe sync",
+                        "Strobe delay",
+                        "Reset"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Space Cannon VH",
+            "name": "Millenium",
+            "shortName": "Millenium",
+            "physical": {
+                "dimensions": [1000, 1000, 1000],
+                "weight": 127
+            },
+            "availableChannels": {
+                "Pan L Limit": {
+                    "type": "Pan",
+                    "crossfade": true
+                },
+                "Pan R Limit": {
+                    "type": "Pan",
+                    "crossfade": true
+                },
+                "Pan Speed": {
+                    "type": "Speed",
+                    "crossfade": true
+                },
+                "Lamp": {
+                    "type": "Beam"
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Strobe": {
+                    "type": "Strobe",
+                    "crossfade": true
+                },
+                "Delay": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Synchro": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Reset": {
+                    "type": "Beam"
+                }
+            },
+            "modes": [
+                {
+                    "name": "9-channel Mode",
+                    "shortName": "9ch",
+                    "channels": [
+                        "Pan L Limit",
+                        "Pan R Limit",
+                        "Pan Speed",
+                        "Lamp",
+                        "Intensity",
+                        "Strobe",
+                        "Delay",
+                        "Synchro",
+                        "Reset"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Space Cannon VH",
+            "name": "NF 2000 DMX",
+            "shortName": "NF2000",
+            "physical": {
+                "dimensions": [1000, 1000, 1000]
+            },
+            "availableChannels": {
+                "Lamp": {
+                    "type": "Beam"
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Strobe": {
+                    "type": "Strobe"
+                },
+                "Synchro": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Delay": {
+                    "type": "Beam",
+                    "crossfade": true
+                }
+            },
+            "modes": [
+                {
+                    "name": "5-channel Mode",
+                    "shortName": "5ch",
+                    "channels": [
+                        "Lamp",
+                        "Intensity",
+                        "Strobe",
+                        "Synchro",
+                        "Delay"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Space Cannon VH",
+            "name": "Target",
+            "shortName": "Target",
+            "physical": {
+                "dimensions": [1000, 1000, 1000]
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "crossfade": true
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "crossfade": true
+                },
+                "Color": {
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "crossfade": true
+                },
+                "Rotation": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Lamp On": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Lamp Off": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "reserved": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "reserved-tmkdo": {
+                    "name": "reserved",
+                    "type": "Beam",
+                    "crossfade": true
+                }
+            },
+            "modes": [
+                {
+                    "name": "8-channel Mode",
+                    "shortName": "8ch",
+                    "channels": [
+                        "Pan",
+                        "Tilt",
+                        "Color",
+                        "Rotation",
+                        "Lamp On",
+                        "Lamp Off",
+                        "reserved",
+                        "reserved-tmkdo"
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/fixtures/imports/ecue-MainLibrary/Spotlight.json
+++ b/fixtures/imports/ecue-MainLibrary/Spotlight.json
@@ -1,0 +1,1766 @@
+{
+    "manufacturers": {
+        "Spotlight": {
+            "name": "Spotlight",
+            "comment": "Manufactor from Mailand, Italy with more than 45 Years Experience to develop and build Luminaires. The New GreenLine offers Fresnels, PCs and ZoomProfiles with LEDs. From 25W up to 600W  in the moment.",
+            "website": "www.spotlight.it"
+        }
+    },
+    "fixtures": [
+        {
+            "manufacturer": "Spotlight",
+            "name": "ARC Beamlight 16bit",
+            "shortName": "ARC Beam",
+            "comment": "80V 1200W beamlight in ARC Yoke with Focus",
+            "physical": {
+                "dimensions": [250, 250, 150],
+                "weight": 30,
+                "power": 1300
+            },
+            "availableChannels": {
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "Focus": {
+                    "type": "Beam",
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "Focus fine": {
+                    "type": "Beam",
+                    "defaultValue": null,
+                    "highlightValue": null
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ],
+                [
+                    "Focus",
+                    "Focus fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "7-channel Mode",
+                    "shortName": "7ch",
+                    "channels": [
+                        "Intensity",
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "Focus",
+                        "Focus fine"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Spotlight",
+            "name": "ARC Fresnel 250W CCT 8bit",
+            "shortName": "ARCFN250CCT",
+            "comment": "Yoke in 16bit and Fresnel 250W CCT in 8bit",
+            "physical": {
+                "dimensions": [500, 450, 30],
+                "weight": 29,
+                "power": 350
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "highlightValue": null
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 0,
+                    "highlightValue": null
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "highlightValue": null
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 0,
+                    "highlightValue": null
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "CCT": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 50],
+                            "name": "3000K",
+                            "center": true
+                        },
+                        {
+                            "range": [51, 100],
+                            "name": "3200K",
+                            "center": true
+                        },
+                        {
+                            "range": [101, 150],
+                            "name": "4000K",
+                            "center": true
+                        },
+                        {
+                            "range": [151, 200],
+                            "name": "5600K",
+                            "center": true
+                        },
+                        {
+                            "range": [201, 255],
+                            "name": "6500K",
+                            "center": true
+                        }
+                    ]
+                },
+                "Strobe": {
+                    "type": "Strobe"
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "7-channel Mode",
+                    "shortName": "7ch",
+                    "channels": [
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "Intensity",
+                        "CCT",
+                        "Strobe"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Spotlight",
+            "name": "ARC Fresnel 250W RGBW  8bit",
+            "shortName": "ARCFN250RGBW8",
+            "comment": "Fresnel 250W RGBW in 8bit, Yoke in 16bit",
+            "physical": {
+                "dimensions": [500, 450, 30],
+                "weight": 29,
+                "power": 350
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "highlightValue": null
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 0,
+                    "highlightValue": null
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "highlightValue": null
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 0,
+                    "highlightValue": null
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "White": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Strobe": {
+                    "type": "Strobe"
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "10-channel Mode",
+                    "shortName": "10ch",
+                    "channels": [
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "Intensity",
+                        "Red",
+                        "Green",
+                        "Blue",
+                        "White",
+                        "Strobe"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Spotlight",
+            "name": "ARC Fresnel 250W RGBW + CCT 8bit",
+            "shortName": "ARC250RGBWC8",
+            "comment": "the Yoke in 16bit the Fresnel in 8bit",
+            "physical": {
+                "dimensions": [500, 450, 30],
+                "weight": 29,
+                "power": 350
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "highlightValue": null
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 0,
+                    "highlightValue": null
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "highlightValue": null
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 0,
+                    "highlightValue": null
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "White": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "CCT": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 50],
+                            "name": "2900K",
+                            "center": true
+                        },
+                        {
+                            "range": [51, 100],
+                            "name": "3200K",
+                            "center": true
+                        },
+                        {
+                            "range": [101, 150],
+                            "name": "4000K",
+                            "center": true
+                        },
+                        {
+                            "range": [151, 200],
+                            "name": "5600K",
+                            "center": true
+                        },
+                        {
+                            "range": [201, 255],
+                            "name": "6500K",
+                            "center": true
+                        }
+                    ]
+                },
+                "Strobe": {
+                    "type": "Strobe"
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "11-channel Mode",
+                    "shortName": "11ch",
+                    "channels": [
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "Intensity",
+                        "Red",
+                        "Green",
+                        "Blue",
+                        "White",
+                        "CCT",
+                        "Strobe"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Spotlight",
+            "name": "ARC Fresnel 250W RGBW 16bit",
+            "shortName": "ARCFN250RGBW",
+            "comment": "Yoke and Fresnel 250W RGBW in 16bit",
+            "physical": {
+                "dimensions": [500, 450, 30],
+                "weight": 29,
+                "power": 350
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "highlightValue": null
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 0,
+                    "highlightValue": null
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "highlightValue": null
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 0,
+                    "highlightValue": null
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "Red fine": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "Green fine": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "Blue fine": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "White": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "White fine": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "Strobe": {
+                    "type": "Strobe"
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ],
+                [
+                    "Red",
+                    "Red fine"
+                ],
+                [
+                    "Green",
+                    "Green fine"
+                ],
+                [
+                    "Blue",
+                    "Blue fine"
+                ],
+                [
+                    "White",
+                    "White fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "14-channel Mode",
+                    "shortName": "14ch",
+                    "channels": [
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "Intensity",
+                        "Red",
+                        "Red fine",
+                        "Green",
+                        "Green fine",
+                        "Blue",
+                        "Blue fine",
+                        "White",
+                        "White fine",
+                        "Strobe"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Spotlight",
+            "name": "ARC Fresnel 250W TW",
+            "shortName": "ARCFN250TW",
+            "comment": "Yoke in 16bit and Fresnel 250W TW (Tunable White) in 8bit",
+            "physical": {
+                "dimensions": [500, 450, 30],
+                "weight": 29,
+                "power": 350
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "highlightValue": null
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 0,
+                    "highlightValue": null
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "highlightValue": null
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 0,
+                    "highlightValue": null
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "CTO": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 10],
+                            "name": "3000K",
+                            "center": true
+                        },
+                        {
+                            "range": [11, 60],
+                            "name": "3000-3200",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [61, 70],
+                            "name": "3200K",
+                            "center": true
+                        },
+                        {
+                            "range": [71, 120],
+                            "name": "3200-4000",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [121, 130],
+                            "name": "4000K",
+                            "center": true
+                        },
+                        {
+                            "range": [131, 180],
+                            "name": "4000-5600",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [181, 190],
+                            "name": "5600K",
+                            "center": true
+                        },
+                        {
+                            "range": [191, 240],
+                            "name": "5600-6500",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [241, 255],
+                            "name": "6500K",
+                            "center": true
+                        }
+                    ]
+                },
+                "Strobe": {
+                    "type": "Strobe"
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "7-channel Mode",
+                    "shortName": "7ch",
+                    "channels": [
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "Intensity",
+                        "CTO",
+                        "Strobe"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Spotlight",
+            "name": "ARC only Yoke in 16bit",
+            "shortName": "ARC",
+            "comment": "only Pan/Tilt. Yoke for different Fixtures",
+            "physical": {
+                "dimensions": [600, 600, 30],
+                "weight": 20,
+                "power": 100
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "highlightValue": null
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 0,
+                    "highlightValue": null
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "highlightValue": null
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 0,
+                    "highlightValue": null
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "4-channel Mode",
+                    "shortName": "4ch",
+                    "channels": [
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Spotlight",
+            "name": "Fresnel 250W CCT 8bit",
+            "shortName": "FN250CCT",
+            "comment": "Fresnel 250W CCT in 8bit",
+            "physical": {
+                "dimensions": [500, 450, 30],
+                "weight": 9,
+                "power": 250
+            },
+            "availableChannels": {
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "CCT": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 50],
+                            "name": "3000K",
+                            "center": true
+                        },
+                        {
+                            "range": [51, 100],
+                            "name": "3200K",
+                            "center": true
+                        },
+                        {
+                            "range": [101, 150],
+                            "name": "4000K",
+                            "center": true
+                        },
+                        {
+                            "range": [151, 200],
+                            "name": "5600K",
+                            "center": true
+                        },
+                        {
+                            "range": [201, 255],
+                            "name": "6500K",
+                            "center": true
+                        }
+                    ]
+                },
+                "Strobe": {
+                    "type": "Strobe"
+                }
+            },
+            "modes": [
+                {
+                    "name": "3-channel Mode",
+                    "shortName": "3ch",
+                    "channels": [
+                        "Intensity",
+                        "CCT",
+                        "Strobe"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Spotlight",
+            "name": "Fresnel 250W CMYW  8bit",
+            "shortName": "FN250CYMW",
+            "comment": "Fresnel 250W RGBW in 8bit",
+            "physical": {
+                "dimensions": [500, 450, 30],
+                "weight": 9,
+                "power": 250
+            },
+            "availableChannels": {
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Cyan": {
+                    "type": "SingleColor",
+                    "color": "Cyan",
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Magenta": {
+                    "type": "SingleColor",
+                    "color": "Magenta",
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Yellow": {
+                    "type": "SingleColor",
+                    "color": "Yellow",
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "White": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Strobe": {
+                    "type": "Strobe"
+                }
+            },
+            "modes": [
+                {
+                    "name": "6-channel Mode",
+                    "shortName": "6ch",
+                    "channels": [
+                        "Intensity",
+                        "Cyan",
+                        "Magenta",
+                        "Yellow",
+                        "White",
+                        "Strobe"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Spotlight",
+            "name": "Fresnel 250W HSI 8bit",
+            "shortName": "FN250HSI",
+            "comment": "Fresnel 250W HSI in 8bit",
+            "physical": {
+                "dimensions": [500, 450, 30],
+                "weight": 9,
+                "power": 250
+            },
+            "availableChannels": {
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Hue": {
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Saturation": {
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Strobe": {
+                    "type": "Strobe"
+                }
+            },
+            "modes": [
+                {
+                    "name": "4-channel Mode",
+                    "shortName": "4ch",
+                    "channels": [
+                        "Intensity",
+                        "Hue",
+                        "Saturation",
+                        "Strobe"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Spotlight",
+            "name": "Fresnel 250W RGBW  8bit",
+            "shortName": "FN250RGBW8",
+            "comment": "Fresnel 250W RGBW in 8bit",
+            "physical": {
+                "dimensions": [500, 450, 30],
+                "weight": 9,
+                "power": 250
+            },
+            "availableChannels": {
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "White": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Strobe": {
+                    "type": "Strobe"
+                }
+            },
+            "modes": [
+                {
+                    "name": "6-channel Mode",
+                    "shortName": "6ch",
+                    "channels": [
+                        "Intensity",
+                        "Red",
+                        "Green",
+                        "Blue",
+                        "White",
+                        "Strobe"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Spotlight",
+            "name": "Fresnel 250W RGBW + CCT 8bit",
+            "shortName": "FN250RGBWC8",
+            "comment": "Fresnel 250W RGBW in 8bit with CCT",
+            "physical": {
+                "dimensions": [500, 450, 30],
+                "weight": 9,
+                "power": 250
+            },
+            "availableChannels": {
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "White": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "CCT": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 50],
+                            "name": "2900K",
+                            "center": true
+                        },
+                        {
+                            "range": [51, 100],
+                            "name": "3200K",
+                            "center": true
+                        },
+                        {
+                            "range": [101, 150],
+                            "name": "4000K",
+                            "center": true
+                        },
+                        {
+                            "range": [151, 200],
+                            "name": "5600K",
+                            "center": true
+                        },
+                        {
+                            "range": [201, 255],
+                            "name": "6500K",
+                            "center": true
+                        }
+                    ]
+                },
+                "Strobe": {
+                    "type": "Strobe"
+                }
+            },
+            "modes": [
+                {
+                    "name": "7-channel Mode",
+                    "shortName": "7ch",
+                    "channels": [
+                        "Intensity",
+                        "Red",
+                        "Green",
+                        "Blue",
+                        "White",
+                        "CCT",
+                        "Strobe"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Spotlight",
+            "name": "Fresnel 250W RGBW 16bit",
+            "shortName": "FN250RGBW",
+            "comment": "Fresnel 250W RGBW in 16bit",
+            "physical": {
+                "dimensions": [500, 450, 30],
+                "weight": 9,
+                "power": 250
+            },
+            "availableChannels": {
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "Red fine": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "Green fine": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "Blue fine": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "White": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "White fine": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "Strobe": {
+                    "type": "Strobe"
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Red",
+                    "Red fine"
+                ],
+                [
+                    "Green",
+                    "Green fine"
+                ],
+                [
+                    "Blue",
+                    "Blue fine"
+                ],
+                [
+                    "White",
+                    "White fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "10-channel Mode",
+                    "shortName": "10ch",
+                    "channels": [
+                        "Intensity",
+                        "Red",
+                        "Red fine",
+                        "Green",
+                        "Green fine",
+                        "Blue",
+                        "Blue fine",
+                        "White",
+                        "White fine",
+                        "Strobe"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Spotlight",
+            "name": "Fresnel 250W TW",
+            "shortName": "FN250TW",
+            "comment": "Fresnel 250W TW (Tunable White) in 8bit",
+            "physical": {
+                "dimensions": [500, 450, 30],
+                "weight": 9,
+                "power": 250
+            },
+            "availableChannels": {
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "CTO": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 10],
+                            "name": "3000K",
+                            "center": true
+                        },
+                        {
+                            "range": [11, 60],
+                            "name": "3000-3200",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [61, 70],
+                            "name": "3200K",
+                            "center": true
+                        },
+                        {
+                            "range": [71, 120],
+                            "name": "3200-4000",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [121, 130],
+                            "name": "4000K",
+                            "center": true
+                        },
+                        {
+                            "range": [131, 180],
+                            "name": "4000-5600",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [181, 190],
+                            "name": "5600K",
+                            "center": true
+                        },
+                        {
+                            "range": [191, 240],
+                            "name": "5600-6500",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [241, 255],
+                            "name": "6500K",
+                            "center": true
+                        }
+                    ]
+                },
+                "Strobe": {
+                    "type": "Strobe"
+                }
+            },
+            "modes": [
+                {
+                    "name": "3-channel Mode",
+                    "shortName": "3ch",
+                    "channels": [
+                        "Intensity",
+                        "CTO",
+                        "Strobe"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Spotlight",
+            "name": "RGB 25W mini",
+            "shortName": "mini",
+            "physical": {
+                "dimensions": [60, 60, 240],
+                "weight": 2,
+                "power": 25
+            },
+            "availableChannels": {
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Strobe": {
+                    "type": "Strobe"
+                }
+            },
+            "modes": [
+                {
+                    "name": "5-channel Mode",
+                    "shortName": "5ch",
+                    "channels": [
+                        "Red",
+                        "Green",
+                        "Blue",
+                        "Intensity",
+                        "Strobe"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Spotlight",
+            "name": "Zoomprofile 250W CCT 8bit",
+            "shortName": "PR250CCT",
+            "comment": "Fresnel 250W CCT in 8bit",
+            "physical": {
+                "dimensions": [500, 450, 30],
+                "weight": 9,
+                "power": 250
+            },
+            "availableChannels": {
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "CCT": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 50],
+                            "name": "3000K",
+                            "center": true
+                        },
+                        {
+                            "range": [51, 100],
+                            "name": "3200K",
+                            "center": true
+                        },
+                        {
+                            "range": [101, 150],
+                            "name": "4000K",
+                            "center": true
+                        },
+                        {
+                            "range": [151, 200],
+                            "name": "5600K",
+                            "center": true
+                        },
+                        {
+                            "range": [201, 255],
+                            "name": "6500K",
+                            "center": true
+                        }
+                    ]
+                },
+                "Strobe": {
+                    "type": "Strobe"
+                }
+            },
+            "modes": [
+                {
+                    "name": "3-channel Mode",
+                    "shortName": "3ch",
+                    "channels": [
+                        "Intensity",
+                        "CCT",
+                        "Strobe"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Spotlight",
+            "name": "Zoomprofile 250W CMYW  8bit",
+            "shortName": "PR250CYMW",
+            "comment": "Fresnel 250W RGBW in 8bit",
+            "physical": {
+                "dimensions": [500, 450, 30],
+                "weight": 9,
+                "power": 250
+            },
+            "availableChannels": {
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Cyan": {
+                    "type": "SingleColor",
+                    "color": "Cyan",
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Magenta": {
+                    "type": "SingleColor",
+                    "color": "Magenta",
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Yellow": {
+                    "type": "SingleColor",
+                    "color": "Yellow",
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "White": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Strobe": {
+                    "type": "Strobe"
+                }
+            },
+            "modes": [
+                {
+                    "name": "6-channel Mode",
+                    "shortName": "6ch",
+                    "channels": [
+                        "Intensity",
+                        "Cyan",
+                        "Magenta",
+                        "Yellow",
+                        "White",
+                        "Strobe"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Spotlight",
+            "name": "Zoomprofile 250W HSI 8bit",
+            "shortName": "PR250HSI",
+            "comment": "Fresnel 250W HSI in 8bit",
+            "physical": {
+                "dimensions": [500, 450, 30],
+                "weight": 9,
+                "power": 250
+            },
+            "availableChannels": {
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Hue": {
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Saturation": {
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Strobe": {
+                    "type": "Strobe"
+                }
+            },
+            "modes": [
+                {
+                    "name": "4-channel Mode",
+                    "shortName": "4ch",
+                    "channels": [
+                        "Intensity",
+                        "Hue",
+                        "Saturation",
+                        "Strobe"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Spotlight",
+            "name": "Zoomprofile 250W RGBW + CCT 8bit",
+            "shortName": "PR250RGBWC8",
+            "comment": "Zoomprofile250W RGBW in 8bit with CCT",
+            "physical": {
+                "dimensions": [500, 450, 30],
+                "weight": 14,
+                "power": 250
+            },
+            "availableChannels": {
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "White": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "CCT": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 50],
+                            "name": "2900K",
+                            "center": true
+                        },
+                        {
+                            "range": [51, 100],
+                            "name": "3200K",
+                            "center": true
+                        },
+                        {
+                            "range": [101, 150],
+                            "name": "4000K",
+                            "center": true
+                        },
+                        {
+                            "range": [151, 200],
+                            "name": "5600K",
+                            "center": true
+                        },
+                        {
+                            "range": [201, 255],
+                            "name": "6500K",
+                            "center": true
+                        }
+                    ]
+                },
+                "Strobe": {
+                    "type": "Strobe"
+                }
+            },
+            "modes": [
+                {
+                    "name": "7-channel Mode",
+                    "shortName": "7ch",
+                    "channels": [
+                        "Intensity",
+                        "Red",
+                        "Green",
+                        "Blue",
+                        "White",
+                        "CCT",
+                        "Strobe"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Spotlight",
+            "name": "Zoomprofile 250W RGBW 16bit",
+            "shortName": "PR250RGBW",
+            "comment": "Fresnel 250W RGBW in 16bit",
+            "physical": {
+                "dimensions": [500, 450, 30],
+                "weight": 9,
+                "power": 250
+            },
+            "availableChannels": {
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "Red fine": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "Green fine": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "Blue fine": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "White": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "White fine": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "Strobe": {
+                    "type": "Strobe"
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Red",
+                    "Red fine"
+                ],
+                [
+                    "Green",
+                    "Green fine"
+                ],
+                [
+                    "Blue",
+                    "Blue fine"
+                ],
+                [
+                    "White",
+                    "White fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "10-channel Mode",
+                    "shortName": "10ch",
+                    "channels": [
+                        "Intensity",
+                        "Red",
+                        "Red fine",
+                        "Green",
+                        "Green fine",
+                        "Blue",
+                        "Blue fine",
+                        "White",
+                        "White fine",
+                        "Strobe"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Spotlight",
+            "name": "Zoomproflle 250W RGBW  8bit",
+            "shortName": "PR250RGBW8",
+            "comment": "Zoomprofile 250W RGBW in 8bit",
+            "physical": {
+                "dimensions": [500, 450, 30],
+                "weight": 14,
+                "power": 250
+            },
+            "availableChannels": {
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "White": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Strobe": {
+                    "type": "Strobe"
+                }
+            },
+            "modes": [
+                {
+                    "name": "6-channel Mode",
+                    "shortName": "6ch",
+                    "channels": [
+                        "Intensity",
+                        "Red",
+                        "Green",
+                        "Blue",
+                        "White",
+                        "Strobe"
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/fixtures/imports/ecue-MainLibrary/Stairville.json
+++ b/fixtures/imports/ecue-MainLibrary/Stairville.json
@@ -1,0 +1,339 @@
+{
+    "manufacturers": {
+        "Stairville": {
+            "name": "Stairville",
+            "website": "http://www.thomann.de/de/stairville.html"
+        }
+    },
+    "fixtures": [
+        {
+            "manufacturer": "Stairville",
+            "name": "MH-575 S 16bit",
+            "shortName": "MH-575 S",
+            "comment": "http://images6.thomann.de/pics/prod/stairville_mh575_manual.pdf",
+            "physical": {
+                "dimensions": [450, 450, 600],
+                "weight": 29,
+                "power": 800
+            },
+            "availableChannels": {
+                "Dimmer": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Shutter/Strobe": {
+                    "type": "Shutter",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 1],
+                            "name": "blackout"
+                        },
+                        {
+                            "range": [2, 7],
+                            "name": "open"
+                        },
+                        {
+                            "range": [8, 63],
+                            "name": "Strobe: slow>fa"
+                        },
+                        {
+                            "range": [64, 71],
+                            "name": "open"
+                        },
+                        {
+                            "range": [72, 127],
+                            "name": "Pulse Strobe"
+                        },
+                        {
+                            "range": [128, 135],
+                            "name": "open"
+                        },
+                        {
+                            "range": [136, 191],
+                            "name": "Pulse Strobe"
+                        },
+                        {
+                            "range": [192, 199],
+                            "name": "open"
+                        },
+                        {
+                            "range": [200, 253],
+                            "name": "Random Strobe"
+                        },
+                        {
+                            "range": [254, 255],
+                            "name": "open"
+                        }
+                    ]
+                },
+                "Color Wheel": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 13],
+                            "name": "white",
+                            "color": "#ffffff"
+                        },
+                        {
+                            "range": [14, 27],
+                            "name": "Steel Blue",
+                            "color": "#4682b4"
+                        },
+                        {
+                            "range": [28, 41],
+                            "name": "Orange",
+                            "color": "#ff7f00"
+                        },
+                        {
+                            "range": [42, 55],
+                            "name": "Green Blue",
+                            "color": "#1164b4"
+                        },
+                        {
+                            "range": [56, 69],
+                            "name": "Bright Blue"
+                        },
+                        {
+                            "range": [70, 83],
+                            "name": "Bright Pink"
+                        },
+                        {
+                            "range": [84, 97],
+                            "name": "Red",
+                            "color": "#ff0000"
+                        },
+                        {
+                            "range": [98, 111],
+                            "name": "Deep Blue",
+                            "color": "#220878"
+                        },
+                        {
+                            "range": [112, 125],
+                            "name": "Yellow",
+                            "color": "#ffff00"
+                        },
+                        {
+                            "range": [126, 139],
+                            "name": "Dark Pink",
+                            "color": "#e75480"
+                        },
+                        {
+                            "range": [140, 153],
+                            "name": "Moos Green"
+                        },
+                        {
+                            "range": [154, 167],
+                            "name": "Light Blue",
+                            "color": "#add8e6"
+                        },
+                        {
+                            "range": [168, 255],
+                            "name": "Rainbow"
+                        }
+                    ]
+                },
+                "Rot. Gobo": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 23],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [24, 47],
+                            "name": "Gobo1"
+                        },
+                        {
+                            "range": [48, 71],
+                            "name": "Gobo2"
+                        },
+                        {
+                            "range": [72, 95],
+                            "name": "Gobo3"
+                        },
+                        {
+                            "range": [96, 119],
+                            "name": "Gobo4"
+                        },
+                        {
+                            "range": [120, 143],
+                            "name": "Gobo5"
+                        },
+                        {
+                            "range": [144, 167],
+                            "name": "Gobo6"
+                        },
+                        {
+                            "range": [168, 255],
+                            "name": "Gobo Spin"
+                        }
+                    ]
+                },
+                "Gobo Rotation": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "Gobo Index"
+                        },
+                        {
+                            "range": [128, 191],
+                            "name": "Clockwise Rotat"
+                        },
+                        {
+                            "range": [192, 255],
+                            "name": "Count. Clockwis"
+                        }
+                    ]
+                },
+                "Prism": {
+                    "type": "Prism",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 1],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [2, 255],
+                            "name": "Prism (static)"
+                        }
+                    ]
+                },
+                "Focus": {
+                    "type": "Beam",
+                    "defaultValue": 128,
+                    "crossfade": true
+                },
+                "Zoom": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "18"
+                        },
+                        {
+                            "range": [128, 255],
+                            "name": "14"
+                        }
+                    ]
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "highlightValue": null
+                },
+                "Pan fine fine": {
+                    "type": "Pan",
+                    "defaultValue": 0,
+                    "crossfade": true,
+                    "highlightValue": null
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "highlightValue": null
+                },
+                "Tilt fine fine": {
+                    "type": "Tilt",
+                    "defaultValue": 0,
+                    "crossfade": true,
+                    "highlightValue": null
+                },
+                "Control": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 7],
+                            "name": "Tracking Mode"
+                        },
+                        {
+                            "range": [8, 63],
+                            "name": "Vector Mode"
+                        },
+                        {
+                            "range": [64, 127],
+                            "name": "Reserved"
+                        },
+                        {
+                            "range": [128, 255],
+                            "name": "Mech. Reset"
+                        }
+                    ]
+                },
+                "Lamp On/Off": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 47],
+                            "name": "Standby"
+                        },
+                        {
+                            "range": [48, 0],
+                            "name": "Lamp On (3sec.)"
+                        },
+                        {
+                            "range": [96, 159],
+                            "name": "Standby"
+                        },
+                        {
+                            "range": [160, 207],
+                            "name": "Lamp off (3sec."
+                        },
+                        {
+                            "range": [208, 255],
+                            "name": "Standby"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan fine",
+                    "Pan fine fine"
+                ],
+                [
+                    "Tilt fine",
+                    "Tilt fine fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "14-channel Mode",
+                    "shortName": "14ch",
+                    "channels": [
+                        "Dimmer",
+                        "Shutter/Strobe",
+                        "Color Wheel",
+                        "Rot. Gobo",
+                        "Gobo Rotation",
+                        "Prism",
+                        "Focus",
+                        "Zoom",
+                        "Pan fine",
+                        "Tilt fine",
+                        "Pan fine fine",
+                        "Tilt fine fine",
+                        "Control",
+                        "Lamp On/Off"
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/fixtures/imports/ecue-MainLibrary/Starlite.json
+++ b/fixtures/imports/ecue-MainLibrary/Starlite.json
@@ -1,0 +1,570 @@
+{
+    "manufacturers": {
+        "Starlite": {
+            "name": "Starlite",
+            "website": "www.starlite.co.uk"
+        }
+    },
+    "fixtures": [
+        {
+            "manufacturer": "Starlite",
+            "name": "Starlite MK5",
+            "shortName": "StarL5",
+            "physical": {
+                "dimensions": [100, 100, 100]
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Colour": {
+                    "type": "MultiColor",
+                    "capabilities": [
+                        {
+                            "range": [0, 7],
+                            "name": "White",
+                            "color": "#ffffff"
+                        },
+                        {
+                            "range": [8, 15],
+                            "name": "Blue",
+                            "color": "#0000ff"
+                        },
+                        {
+                            "range": [16, 23],
+                            "name": "Green",
+                            "color": "#00ff00"
+                        },
+                        {
+                            "range": [24, 31],
+                            "name": "Red",
+                            "color": "#ff0000"
+                        },
+                        {
+                            "range": [32, 39],
+                            "name": "Orange CTC"
+                        },
+                        {
+                            "range": [40, 63],
+                            "name": "Blue CTC"
+                        },
+                        {
+                            "range": [64, 71],
+                            "name": "White",
+                            "color": "#ffffff",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [72, 79],
+                            "name": "Scr Blue",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [80, 87],
+                            "name": "Scr Green",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [88, 95],
+                            "name": "Scr Red",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [96, 103],
+                            "name": "Scr Organe CTC",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [104, 127],
+                            "name": "Scr Blue CTC",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [128, 255],
+                            "name": "Scroll Speed",
+                            "center": true
+                        }
+                    ]
+                },
+                "Cyan": {
+                    "type": "SingleColor",
+                    "color": "Cyan",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Magenta": {
+                    "type": "SingleColor",
+                    "color": "Magenta",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Yellow": {
+                    "type": "SingleColor",
+                    "color": "Yellow",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Gobo 1<>": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Gobo1": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 7],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [8, 15],
+                            "name": "Bump Rot 1"
+                        },
+                        {
+                            "range": [16, 23],
+                            "name": "Bump Rot 2"
+                        },
+                        {
+                            "range": [24, 31],
+                            "name": "Bump Rot 3"
+                        },
+                        {
+                            "range": [32, 39],
+                            "name": "Bump Rot 4"
+                        },
+                        {
+                            "range": [40, 63],
+                            "name": "Bump Rot 5"
+                        },
+                        {
+                            "range": [64, 71],
+                            "name": "Open",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [72, 79],
+                            "name": "Scroll Rot 1",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [80, 87],
+                            "name": "Scroll Rot 2",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [88, 95],
+                            "name": "Scroll Rot 3",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [96, 103],
+                            "name": "Scroll Rot 4",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [104, 127],
+                            "name": "Scroll Rot 5",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [128, 135],
+                            "name": "Open",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [136, 143],
+                            "name": "Bump Index 1",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [144, 151],
+                            "name": "Bump Index 2",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [152, 159],
+                            "name": "Bump Index 3",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [160, 167],
+                            "name": "Bump Index 4",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [168, 191],
+                            "name": "Bump Index 5",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [192, 199],
+                            "name": "Open",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [200, 207],
+                            "name": "Scroll Index 1",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [208, 215],
+                            "name": "Scroll Index 2",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [216, 223],
+                            "name": "Scroll Index 3",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [224, 231],
+                            "name": "Scroll Index 4",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [232, 255],
+                            "name": "Scroll Index 5",
+                            "showInMenu": false
+                        }
+                    ]
+                },
+                "Gobo2<>": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Gobo2": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 7],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [8, 15],
+                            "name": "Bump Rot 1"
+                        },
+                        {
+                            "range": [16, 23],
+                            "name": "Bump Rot 2"
+                        },
+                        {
+                            "range": [24, 31],
+                            "name": "Bump Rot 3"
+                        },
+                        {
+                            "range": [32, 39],
+                            "name": "Bump Rot 4"
+                        },
+                        {
+                            "range": [40, 63],
+                            "name": "Bump Rot 5"
+                        },
+                        {
+                            "range": [64, 71],
+                            "name": "Open",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [72, 79],
+                            "name": "Scroll Rot 1",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [80, 87],
+                            "name": "Scroll Rot 2",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [88, 95],
+                            "name": "Scroll Rot 3",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [96, 103],
+                            "name": "Scroll Rot 4",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [104, 127],
+                            "name": "Scroll Rot 5",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [128, 135],
+                            "name": "Open",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [136, 143],
+                            "name": "Bump Index 1",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [144, 151],
+                            "name": "Bump Index 2",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [152, 159],
+                            "name": "Bump Index 3",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [160, 167],
+                            "name": "Bump Index 4",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [168, 191],
+                            "name": "Bump Index 5",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [192, 199],
+                            "name": "Open",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [200, 207],
+                            "name": "Scroll Index 1",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [208, 215],
+                            "name": "Scroll Index 2",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [216, 223],
+                            "name": "Scroll Index 3",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [224, 231],
+                            "name": "Scroll Index 4",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [232, 255],
+                            "name": "Scroll Index 5",
+                            "showInMenu": false
+                        }
+                    ]
+                },
+                "Focus": {
+                    "type": "Beam",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "Distance"
+                        }
+                    ]
+                },
+                "Iris": {
+                    "type": "Beam",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Prism": {
+                    "type": "Prism",
+                    "capabilities": [
+                        {
+                            "range": [0, 1],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [2, 122],
+                            "name": "Prism Rot Right",
+                            "showInMenu": false,
+                            "center": true
+                        },
+                        {
+                            "range": [123, 131],
+                            "name": "Stop"
+                        },
+                        {
+                            "range": [132, 255],
+                            "name": "Prism Rot Left",
+                            "showInMenu": false,
+                            "center": true
+                        }
+                    ]
+                },
+                "Frost": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Strobe": {
+                    "type": "Strobe",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "capabilities": [
+                        {
+                            "range": [0, 254],
+                            "name": "Closed",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [255, 14],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [15, 247],
+                            "name": "Strobe",
+                            "center": true
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Speed": {
+                    "type": "Speed",
+                    "highlightValue": 255,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "19-channel Mode",
+                    "shortName": "19ch",
+                    "channels": [
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "Colour",
+                        "Cyan",
+                        "Magenta",
+                        "Yellow",
+                        "Gobo 1<>",
+                        "Gobo1",
+                        "Gobo2<>",
+                        "Gobo2",
+                        "Focus",
+                        "Iris",
+                        "Prism",
+                        "Frost",
+                        "Strobe",
+                        "Intensity",
+                        "Speed"
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/fixtures/imports/ecue-MainLibrary/Studio-Due.json
+++ b/fixtures/imports/ecue-MainLibrary/Studio-Due.json
@@ -1,0 +1,853 @@
+{
+    "manufacturers": {
+        "Studio Due": {
+            "name": "Studio Due"
+        }
+    },
+    "fixtures": [
+        {
+            "manufacturer": "Studio Due",
+            "name": "City Colour",
+            "shortName": "CityColor",
+            "physical": {
+                "dimensions": [780, 560, 740],
+                "weight": 67,
+                "power": 3000
+            },
+            "availableChannels": {
+                "Motor": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 63],
+                            "name": "Slow"
+                        },
+                        {
+                            "range": [64, 127],
+                            "name": "Mid 2"
+                        },
+                        {
+                            "range": [128, 191],
+                            "name": "Mid 1"
+                        },
+                        {
+                            "range": [192, 255],
+                            "name": "Fast"
+                        }
+                    ]
+                },
+                "Cyan": {
+                    "type": "SingleColor",
+                    "color": "Cyan",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "Cyan",
+                            "color": "#00ffff"
+                        }
+                    ]
+                },
+                "Yellow": {
+                    "type": "SingleColor",
+                    "color": "Yellow",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "Yellow",
+                            "color": "#ffff00"
+                        }
+                    ]
+                },
+                "Magenta": {
+                    "type": "SingleColor",
+                    "color": "Magenta",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "Magenta",
+                            "color": "#ca1f7b"
+                        }
+                    ]
+                },
+                "Dimmer": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "Dimmer"
+                        }
+                    ]
+                },
+                "Color": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 25],
+                            "name": "Colour Mixing"
+                        },
+                        {
+                            "range": [26, 51],
+                            "name": "Cyan",
+                            "color": "#00ffff"
+                        },
+                        {
+                            "range": [52, 77],
+                            "name": "Yellow",
+                            "color": "#ffff00"
+                        },
+                        {
+                            "range": [78, 103],
+                            "name": "Magenta",
+                            "color": "#ca1f7b"
+                        },
+                        {
+                            "range": [104, 129],
+                            "name": "Blue",
+                            "color": "#0000ff"
+                        },
+                        {
+                            "range": [130, 150],
+                            "name": "Red",
+                            "color": "#ff0000"
+                        },
+                        {
+                            "range": [165, 181],
+                            "name": "Green",
+                            "color": "#00ff00"
+                        },
+                        {
+                            "range": [182, 207],
+                            "name": "ColorMix slow"
+                        },
+                        {
+                            "range": [208, 233],
+                            "name": "ColorMix mid"
+                        },
+                        {
+                            "range": [234, 255],
+                            "name": "ColorMix fast"
+                        }
+                    ]
+                },
+                "Control": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [128, 191],
+                            "name": "RESET"
+                        },
+                        {
+                            "range": [251, 255],
+                            "name": "Lamp OFF"
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "7-channel Mode",
+                    "shortName": "7ch",
+                    "channels": [
+                        "Motor",
+                        "Cyan",
+                        "Yellow",
+                        "Magenta",
+                        "Dimmer",
+                        "Color",
+                        "Control"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Studio Due",
+            "name": "CityBeam",
+            "shortName": "CityBeam",
+            "physical": {
+                "dimensions": [780, 560, 740],
+                "weight": 51,
+                "power": 2000
+            },
+            "availableChannels": {
+                "Motor": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 63],
+                            "name": "Slow"
+                        },
+                        {
+                            "range": [64, 127],
+                            "name": "Mid 2"
+                        },
+                        {
+                            "range": [128, 191],
+                            "name": "Mid 1"
+                        },
+                        {
+                            "range": [192, 255],
+                            "name": "Fast"
+                        }
+                    ]
+                },
+                "Cyan": {
+                    "type": "SingleColor",
+                    "color": "Cyan",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "Cyan",
+                            "color": "#00ffff"
+                        }
+                    ]
+                },
+                "Yellow": {
+                    "type": "SingleColor",
+                    "color": "Yellow",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "Yellow",
+                            "color": "#ffff00"
+                        }
+                    ]
+                },
+                "Magenta": {
+                    "type": "SingleColor",
+                    "color": "Magenta",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "Magenta",
+                            "color": "#ca1f7b"
+                        }
+                    ]
+                },
+                "Dimmer": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "Dimmer"
+                        }
+                    ]
+                },
+                "Beam": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Control": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [128, 191],
+                            "name": "RESET"
+                        },
+                        {
+                            "range": [251, 255],
+                            "name": "Lamp OFF"
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "7-channel Mode",
+                    "shortName": "7ch",
+                    "channels": [
+                        "Motor",
+                        "Cyan",
+                        "Yellow",
+                        "Magenta",
+                        "Dimmer",
+                        "Beam",
+                        "Control"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Studio Due",
+            "name": "Excess 700",
+            "shortName": "Exc700",
+            "physical": {
+                "dimensions": [100, 100, 100]
+            },
+            "availableChannels": {
+                "Iris": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Color": {
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "crossfade": true
+                },
+                "New Channel": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "crossfade": true
+                }
+            },
+            "modes": [
+                {
+                    "name": "3-channel Mode",
+                    "shortName": "3ch",
+                    "channels": [
+                        "Iris",
+                        "Color",
+                        "New Channel"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Studio Due",
+            "name": "Hercule 800e",
+            "shortName": "Herc800",
+            "comment": "cd",
+            "physical": {
+                "dimensions": [675, 600, 830],
+                "weight": 59,
+                "power": 1000
+            },
+            "availableChannels": {
+                "Speed": {
+                    "type": "Speed",
+                    "defaultValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 31],
+                            "name": "speed1 (min)"
+                        },
+                        {
+                            "range": [32, 63],
+                            "name": "speed2"
+                        },
+                        {
+                            "range": [64, 95],
+                            "name": "speed3"
+                        },
+                        {
+                            "range": [96, 127],
+                            "name": "speed4"
+                        },
+                        {
+                            "range": [128, 159],
+                            "name": "speed5"
+                        },
+                        {
+                            "range": [160, 191],
+                            "name": "speed6"
+                        },
+                        {
+                            "range": [192, 223],
+                            "name": "speed7"
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "speed8 (max)"
+                        }
+                    ]
+                },
+                "Color1": {
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "crossfade": true
+                },
+                "Color2": {
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "crossfade": true
+                },
+                "Color3": {
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "crossfade": true
+                },
+                "Color4": {
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "crossfade": true
+                },
+                "Color5": {
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "crossfade": true
+                },
+                "Color6": {
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "crossfade": true
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Focus": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Reset": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "idle"
+                        },
+                        {
+                            "range": [128, 191],
+                            "name": "motor reset"
+                        },
+                        {
+                            "range": [192, 239],
+                            "name": "idle"
+                        },
+                        {
+                            "range": [240, 250],
+                            "name": "lamp off"
+                        },
+                        {
+                            "range": [251, 255],
+                            "name": "idle"
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "10-channel Mode",
+                    "shortName": "10ch",
+                    "channels": [
+                        "Speed",
+                        "Color1",
+                        "Color2",
+                        "Color3",
+                        "Color4",
+                        "Color5",
+                        "Color6",
+                        "Intensity",
+                        "Focus",
+                        "Reset"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Studio Due",
+            "name": "Light Deflector",
+            "shortName": "Light Deflector",
+            "physical": {
+                "dimensions": [100, 100, 100]
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "highlightValue": null
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 0,
+                    "crossfade": true,
+                    "highlightValue": null
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 103,
+                    "crossfade": true,
+                    "highlightValue": null
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 147,
+                    "crossfade": true,
+                    "highlightValue": null
+                },
+                "Tilt Spin": {
+                    "type": "Tilt",
+                    "crossfade": true
+                },
+                "P/T Speed": {
+                    "type": "Speed",
+                    "defaultValue": 255,
+                    "crossfade": true
+                },
+                "Reset": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 31],
+                            "name": "Park"
+                        },
+                        {
+                            "range": [32, 63],
+                            "name": "Home Pos"
+                        },
+                        {
+                            "range": [64, 255],
+                            "name": "Park"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "5-channel Mode",
+                    "shortName": "5ch",
+                    "channels": [
+                        "Pan",
+                        "Tilt",
+                        "Tilt Spin",
+                        "P/T Speed",
+                        "Reset"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Studio Due",
+            "name": "MiniCity 150",
+            "shortName": "MCity150",
+            "physical": {
+                "dimensions": [415, 360, 540],
+                "weight": 13,
+                "power": 250
+            },
+            "availableChannels": {
+                "Motor": {
+                    "type": "Beam",
+                    "defaultValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 63],
+                            "name": "slow"
+                        },
+                        {
+                            "range": [64, 127],
+                            "name": "mid 2"
+                        },
+                        {
+                            "range": [128, 191],
+                            "name": "mid 1"
+                        },
+                        {
+                            "range": [192, 255],
+                            "name": "fast"
+                        }
+                    ]
+                },
+                "Cyan": {
+                    "type": "SingleColor",
+                    "color": "Cyan",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Yellow": {
+                    "type": "SingleColor",
+                    "color": "Yellow",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Magenta": {
+                    "type": "SingleColor",
+                    "color": "Magenta",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Color": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 25],
+                            "name": "mixing"
+                        },
+                        {
+                            "range": [26, 51],
+                            "name": "Cyan",
+                            "color": "#00ffff"
+                        },
+                        {
+                            "range": [52, 77],
+                            "name": "Yellow",
+                            "color": "#ffff00"
+                        },
+                        {
+                            "range": [78, 103],
+                            "name": "Magenta",
+                            "color": "#ca1f7b"
+                        },
+                        {
+                            "range": [104, 129],
+                            "name": "Blue",
+                            "color": "#0000ff"
+                        },
+                        {
+                            "range": [130, 155],
+                            "name": "Red",
+                            "color": "#ff0000"
+                        },
+                        {
+                            "range": [156, 181],
+                            "name": "Green",
+                            "color": "#00ff00"
+                        },
+                        {
+                            "range": [182, 207],
+                            "name": "sequence slow"
+                        },
+                        {
+                            "range": [208, 233],
+                            "name": "sequence mid"
+                        },
+                        {
+                            "range": [234, 255],
+                            "name": "sequence fast"
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "6-channel Mode",
+                    "shortName": "6ch",
+                    "channels": [
+                        "Motor",
+                        "Cyan",
+                        "Yellow",
+                        "Magenta",
+                        "Intensity",
+                        "Color"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Studio Due",
+            "name": "NanoIC",
+            "shortName": "nano",
+            "physical": {
+                "dimensions": [100, 100, 100]
+            },
+            "availableChannels": {
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "crossfade": true
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "crossfade": true
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "crossfade": true
+                },
+                "Strobe": {
+                    "type": "Strobe",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 128],
+                            "name": "New Range"
+                        },
+                        {
+                            "range": [129, 255],
+                            "name": "New Range"
+                        }
+                    ]
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "crossfade": true,
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "crossfade": true,
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "crossfade": true,
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "crossfade": true,
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "Dimmer": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Speed": {
+                    "type": "Speed",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 31],
+                            "name": "New Range"
+                        },
+                        {
+                            "range": [32, 64],
+                            "name": "New Range"
+                        },
+                        {
+                            "range": [64, 95],
+                            "name": "New Range"
+                        },
+                        {
+                            "range": [96, 127],
+                            "name": "New Range"
+                        },
+                        {
+                            "range": [128, 159],
+                            "name": "New Range"
+                        },
+                        {
+                            "range": [160, 191],
+                            "name": "New Range"
+                        },
+                        {
+                            "range": [192, 233],
+                            "name": "New Range"
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "New Range"
+                        }
+                    ]
+                },
+                "Led Fade time": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Reset Remote": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "New Range"
+                        },
+                        {
+                            "range": [128, 191],
+                            "name": "New Range"
+                        },
+                        {
+                            "range": [192, 255],
+                            "name": "New Range"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "12-channel Mode",
+                    "shortName": "12ch",
+                    "channels": [
+                        "Red",
+                        "Green",
+                        "Blue",
+                        "Strobe",
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "Dimmer",
+                        "Speed",
+                        "Led Fade time",
+                        "Reset Remote"
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/fixtures/imports/ecue-MainLibrary/T-Lighting.json
+++ b/fixtures/imports/ecue-MainLibrary/T-Lighting.json
@@ -1,0 +1,442 @@
+{
+    "manufacturers": {
+        "T-Lighting": {
+            "name": "T-Lighting",
+            "comment": "??",
+            "website": "http://www.tlighting.com"
+        }
+    },
+    "fixtures": [
+        {
+            "manufacturer": "T-Lighting",
+            "name": "T-Lighting 251AR",
+            "shortName": "T251AR",
+            "comment": "Mode 1",
+            "physical": {
+                "dimensions": [100, 100, 100]
+            },
+            "availableChannels": {
+                "PAN": {
+                    "type": "Pan",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "PAN fine": {
+                    "type": "Pan",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "TILT": {
+                    "type": "Tilt",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "TILT fine": {
+                    "type": "Tilt",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Speed p/t": {
+                    "type": "Speed",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "Max. Speed"
+                        },
+                        {
+                            "range": [1, 249],
+                            "name": "speed vector"
+                        },
+                        {
+                            "range": [250, 255],
+                            "name": "dbo move"
+                        }
+                    ]
+                },
+                "Control": {
+                    "type": "Beam",
+                    "defaultValue": 170,
+                    "highlightValue": 170,
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "fan speed"
+                        },
+                        {
+                            "range": [128, 139],
+                            "name": "reset"
+                        },
+                        {
+                            "range": [140, 229],
+                            "name": "nofunction"
+                        },
+                        {
+                            "range": [230, 239],
+                            "name": "Lamp off"
+                        },
+                        {
+                            "range": [240, 255],
+                            "name": "no functions"
+                        }
+                    ]
+                },
+                "Colours": {
+                    "type": "MultiColor",
+                    "capabilities": [
+                        {
+                            "range": [0, 9],
+                            "name": "open white"
+                        },
+                        {
+                            "range": [10, 20],
+                            "name": "Turquoise",
+                            "color": "#40e0d0"
+                        },
+                        {
+                            "range": [21, 31],
+                            "name": "Red",
+                            "color": "#ff0000"
+                        },
+                        {
+                            "range": [32, 41],
+                            "name": "Cyan",
+                            "color": "#00ffff"
+                        },
+                        {
+                            "range": [42, 52],
+                            "name": "Green",
+                            "color": "#00ff00"
+                        },
+                        {
+                            "range": [53, 63],
+                            "name": "Magenta",
+                            "color": "#ca1f7b"
+                        },
+                        {
+                            "range": [64, 73],
+                            "name": "Light Blue",
+                            "color": "#add8e6"
+                        },
+                        {
+                            "range": [74, 84],
+                            "name": "Yellow",
+                            "color": "#ffff00"
+                        },
+                        {
+                            "range": [85, 95],
+                            "name": "Green",
+                            "color": "#00ff00"
+                        },
+                        {
+                            "range": [96, 105],
+                            "name": "Pink",
+                            "color": "#ffc0cb"
+                        },
+                        {
+                            "range": [106, 116],
+                            "name": "Blue",
+                            "color": "#0000ff"
+                        },
+                        {
+                            "range": [117, 127],
+                            "name": "orange",
+                            "color": "#ff7f00"
+                        },
+                        {
+                            "range": [128, 189],
+                            "name": "rainbow for"
+                        },
+                        {
+                            "range": [190, 193],
+                            "name": "rainbow"
+                        },
+                        {
+                            "range": [194, 255],
+                            "name": "rainbow back"
+                        }
+                    ]
+                },
+                "no function": {
+                    "type": "Beam"
+                },
+                "Eff. Wheel": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 95],
+                            "name": "open"
+                        },
+                        {
+                            "range": [96, 159],
+                            "name": "prism"
+                        },
+                        {
+                            "range": [160, 255],
+                            "name": "prism gobo"
+                        },
+                        {
+                            "range": [160, 167],
+                            "name": "Macro 1"
+                        },
+                        {
+                            "range": [168, 175],
+                            "name": "Macro 2"
+                        },
+                        {
+                            "range": [176, 183],
+                            "name": "Macro 3"
+                        },
+                        {
+                            "range": [184, 191],
+                            "name": "Macro 4"
+                        },
+                        {
+                            "range": [192, 199],
+                            "name": "Macro 5"
+                        },
+                        {
+                            "range": [200, 207],
+                            "name": "Macro 6"
+                        },
+                        {
+                            "range": [208, 215],
+                            "name": "Macro 7"
+                        },
+                        {
+                            "range": [216, 228],
+                            "name": "Macro 8"
+                        },
+                        {
+                            "range": [224, 231],
+                            "name": "Macro 9"
+                        },
+                        {
+                            "range": [232, 239],
+                            "name": "Macro 10"
+                        },
+                        {
+                            "range": [240, 247],
+                            "name": "Macro 11"
+                        },
+                        {
+                            "range": [248, 255],
+                            "name": "Macro 12"
+                        }
+                    ]
+                },
+                "prism rot": {
+                    "type": "Prism",
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "no rotation"
+                        },
+                        {
+                            "range": [1, 126],
+                            "name": "foward"
+                        },
+                        {
+                            "range": [127, 128],
+                            "name": "no rotation"
+                        },
+                        {
+                            "range": [129, 255],
+                            "name": "backwards"
+                        }
+                    ]
+                },
+                "Gobo rot": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 31],
+                            "name": "open"
+                        },
+                        {
+                            "range": [32, 63],
+                            "name": "Rot gobo1"
+                        },
+                        {
+                            "range": [64, 95],
+                            "name": "Rot gobo2"
+                        },
+                        {
+                            "range": [96, 127],
+                            "name": "Rot gobo3"
+                        },
+                        {
+                            "range": [128, 159],
+                            "name": "Rot gobo4"
+                        },
+                        {
+                            "range": [160, 191],
+                            "name": "Rot gobo5"
+                        },
+                        {
+                            "range": [192, 223],
+                            "name": "Rot gobo6"
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "Rotation"
+                        }
+                    ]
+                },
+                "rot Gobo": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "index"
+                        },
+                        {
+                            "range": [128, 190],
+                            "name": "foward"
+                        },
+                        {
+                            "range": [191, 192],
+                            "name": "no rotation"
+                        },
+                        {
+                            "range": [193, 255],
+                            "name": "backwards"
+                        }
+                    ]
+                },
+                "nofunction": {
+                    "type": "Beam"
+                },
+                "Focus": {
+                    "type": "Intensity",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Shutter": {
+                    "type": "Shutter",
+                    "defaultValue": 40,
+                    "highlightValue": 40,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 31],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [32, 63],
+                            "name": "open"
+                        },
+                        {
+                            "range": [64, 95],
+                            "name": "strobe"
+                        },
+                        {
+                            "range": [96, 127],
+                            "name": "open"
+                        },
+                        {
+                            "range": [128, 159],
+                            "name": "pulse"
+                        },
+                        {
+                            "range": [160, 191],
+                            "name": "open"
+                        },
+                        {
+                            "range": [192, 223],
+                            "name": "random"
+                        },
+                        {
+                            "range": [224, 225],
+                            "name": "open"
+                        }
+                    ]
+                },
+                "intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "PAN",
+                    "PAN fine"
+                ],
+                [
+                    "TILT",
+                    "TILT fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "16-channel Mode",
+                    "shortName": "16ch",
+                    "channels": [
+                        "PAN",
+                        "TILT",
+                        "PAN fine",
+                        "TILT fine",
+                        "Speed p/t",
+                        "Control",
+                        "Colours",
+                        "no function",
+                        "Eff. Wheel",
+                        "prism rot",
+                        "Gobo rot",
+                        "rot Gobo",
+                        "nofunction",
+                        "Focus",
+                        "Shutter",
+                        "intensity"
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/fixtures/imports/ecue-MainLibrary/TAS.json
+++ b/fixtures/imports/ecue-MainLibrary/TAS.json
@@ -1,0 +1,61 @@
+{
+    "manufacturers": {
+        "TAS": {
+            "name": "TAS",
+            "comment": "?"
+        }
+    },
+    "fixtures": [
+        {
+            "manufacturer": "TAS",
+            "name": "Versicolore",
+            "shortName": "Versicolore",
+            "comment": "250W MSD",
+            "physical": {
+                "dimensions": [285, 285, 585],
+                "weight": 17,
+                "power": 250
+            },
+            "availableChannels": {
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Effects": {
+                    "type": "Effect",
+                    "crossfade": true
+                },
+                "Color 1": {
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "crossfade": true
+                },
+                "Color 2": {
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "crossfade": true
+                },
+                "Reset": {
+                    "type": "Beam",
+                    "crossfade": true
+                }
+            },
+            "modes": [
+                {
+                    "name": "5-channel Mode",
+                    "shortName": "5ch",
+                    "channels": [
+                        "Intensity",
+                        "Effects",
+                        "Color 1",
+                        "Color 2",
+                        "Reset"
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/fixtures/imports/ecue-MainLibrary/TEC.json
+++ b/fixtures/imports/ecue-MainLibrary/TEC.json
@@ -1,0 +1,65 @@
+{
+    "manufacturers": {
+        "TEC": {
+            "name": "TEC"
+        }
+    },
+    "fixtures": [
+        {
+            "manufacturer": "TEC",
+            "name": "Punto Color 150",
+            "shortName": "Punto150",
+            "physical": {
+                "dimensions": [265, 445, 345],
+                "weight": 10.5,
+                "power": 300
+            },
+            "availableChannels": {
+                "Cyan": {
+                    "type": "SingleColor",
+                    "color": "Cyan",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Magenta": {
+                    "type": "SingleColor",
+                    "color": "Magenta",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Yellow": {
+                    "type": "SingleColor",
+                    "color": "Yellow",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "3-channel Mode",
+                    "shortName": "3ch",
+                    "channels": [
+                        "Cyan",
+                        "Magenta",
+                        "Yellow"
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/fixtures/imports/ecue-MainLibrary/Teclumen.json
+++ b/fixtures/imports/ecue-MainLibrary/Teclumen.json
@@ -1,0 +1,87 @@
+{
+    "manufacturers": {
+        "Teclumen": {
+            "name": "Teclumen",
+            "website": "www.ldde.com"
+        }
+    },
+    "fixtures": [
+        {
+            "manufacturer": "Teclumen",
+            "name": "FC6 8Ch",
+            "shortName": "FC6 8Ch",
+            "comment": "cd",
+            "physical": {
+                "dimensions": [130, 130, 155],
+                "weight": 1.6,
+                "power": 48
+            },
+            "availableChannels": {
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "White": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Strobe": {
+                    "type": "Strobe",
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Color": {
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "highlightValue": 255,
+                    "constant": true,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                }
+            },
+            "modes": [
+                {
+                    "name": "8-channel Mode",
+                    "shortName": "8ch",
+                    "channels": [
+                        "Red",
+                        "Green",
+                        "Blue",
+                        "White",
+                        null,
+                        "Strobe",
+                        "Intensity",
+                        "Color"
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/fixtures/imports/ecue-MainLibrary/Traxon-Technologies.json
+++ b/fixtures/imports/ecue-MainLibrary/Traxon-Technologies.json
@@ -1,0 +1,100 @@
+{
+    "manufacturers": {
+        "Traxon Technologies": {
+            "name": "Traxon Technologies",
+            "website": "http://www.traxontechnologies.eu/"
+        }
+    },
+    "fixtures": [
+        {
+            "manufacturer": "Traxon Technologies",
+            "name": "CW-Fixture",
+            "shortName": "CWFixture",
+            "comment": "Cold White Fixture",
+            "physical": {
+                "dimensions": [100, 100, 100]
+            },
+            "availableChannels": {
+                "Cold White": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                }
+            },
+            "modes": [
+                {
+                    "name": "3-channel Mode",
+                    "shortName": "3ch",
+                    "channels": [
+                        null,
+                        "Cold White"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Traxon Technologies",
+            "name": "DW-Fixture",
+            "shortName": "DWFixture",
+            "comment": "Dynamic White Fixture",
+            "physical": {
+                "dimensions": [100, 100, 100]
+            },
+            "availableChannels": {
+                "Warm White": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Cold White": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                }
+            },
+            "modes": [
+                {
+                    "name": "3-channel Mode",
+                    "shortName": "3ch",
+                    "channels": [
+                        "Warm White",
+                        "Cold White"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Traxon Technologies",
+            "name": "WW-Fixture",
+            "shortName": "WWFixture",
+            "comment": "Warm White Fixture",
+            "physical": {
+                "dimensions": [100, 100, 100]
+            },
+            "availableChannels": {
+                "Warm White": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                }
+            },
+            "modes": [
+                {
+                    "name": "3-channel Mode",
+                    "shortName": "3ch",
+                    "channels": [
+                        "Warm White"
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/fixtures/imports/ecue-MainLibrary/Triton-Blue.json
+++ b/fixtures/imports/ecue-MainLibrary/Triton-Blue.json
@@ -1,0 +1,834 @@
+{
+    "manufacturers": {
+        "Triton Blue": {
+            "name": "Triton Blue",
+            "website": "www.triton-blue.com"
+        }
+    },
+    "fixtures": [
+        {
+            "manufacturer": "Triton Blue",
+            "name": "Spot Pro 575",
+            "shortName": "SPro575",
+            "comment": "cd",
+            "physical": {
+                "dimensions": [650, 650, 750],
+                "weight": 34,
+                "power": 575
+            },
+            "availableChannels": {
+                "Color": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 13],
+                            "name": "open"
+                        },
+                        {
+                            "range": [14, 27],
+                            "name": "slot1"
+                        },
+                        {
+                            "range": [28, 41],
+                            "name": "slot2"
+                        },
+                        {
+                            "range": [42, 55],
+                            "name": "slot3"
+                        },
+                        {
+                            "range": [56, 69],
+                            "name": "slot4"
+                        },
+                        {
+                            "range": [70, 83],
+                            "name": "slot5"
+                        },
+                        {
+                            "range": [84, 97],
+                            "name": "slot6"
+                        },
+                        {
+                            "range": [98, 111],
+                            "name": "slot7"
+                        },
+                        {
+                            "range": [112, 128],
+                            "name": "slot8"
+                        },
+                        {
+                            "range": [129, 187],
+                            "name": ">>"
+                        },
+                        {
+                            "range": [188, 193],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [194, 255],
+                            "name": "<<"
+                        }
+                    ]
+                },
+                "Gobo1": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 9],
+                            "name": "open"
+                        },
+                        {
+                            "range": [10, 19],
+                            "name": "slot1"
+                        },
+                        {
+                            "range": [20, 29],
+                            "name": "slot2"
+                        },
+                        {
+                            "range": [30, 39],
+                            "name": "slot3"
+                        },
+                        {
+                            "range": [40, 49],
+                            "name": "slot4"
+                        },
+                        {
+                            "range": [50, 59],
+                            "name": "slot5"
+                        },
+                        {
+                            "range": [60, 69],
+                            "name": "slot6"
+                        },
+                        {
+                            "range": [70, 89],
+                            "name": "slot1 sh."
+                        },
+                        {
+                            "range": [90, 109],
+                            "name": "slot2 sh."
+                        },
+                        {
+                            "range": [110, 129],
+                            "name": "slot3 sh."
+                        },
+                        {
+                            "range": [130, 149],
+                            "name": "slot4 sh."
+                        },
+                        {
+                            "range": [150, 169],
+                            "name": "slot5 sh."
+                        },
+                        {
+                            "range": [170, 189],
+                            "name": "slot6 sh."
+                        },
+                        {
+                            "range": [190, 255],
+                            "name": ">>"
+                        }
+                    ]
+                },
+                "Gobo1 rot.": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "index"
+                        },
+                        {
+                            "range": [128, 187],
+                            "name": ">>"
+                        },
+                        {
+                            "range": [188, 193],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [194, 255],
+                            "name": "<<"
+                        }
+                    ]
+                },
+                "Gobo2": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 13],
+                            "name": "open"
+                        },
+                        {
+                            "range": [14, 27],
+                            "name": "slot1"
+                        },
+                        {
+                            "range": [28, 41],
+                            "name": "slot2"
+                        },
+                        {
+                            "range": [42, 55],
+                            "name": "slot3"
+                        },
+                        {
+                            "range": [56, 69],
+                            "name": "slot4"
+                        },
+                        {
+                            "range": [70, 83],
+                            "name": "slot5"
+                        },
+                        {
+                            "range": [84, 97],
+                            "name": "slot6"
+                        },
+                        {
+                            "range": [98, 111],
+                            "name": "slot7"
+                        },
+                        {
+                            "range": [112, 127],
+                            "name": "slot1 sh."
+                        },
+                        {
+                            "range": [128, 143],
+                            "name": "slot2 sh."
+                        },
+                        {
+                            "range": [144, 159],
+                            "name": "slot3 sh."
+                        },
+                        {
+                            "range": [160, 175],
+                            "name": "slot4 sh."
+                        },
+                        {
+                            "range": [176, 191],
+                            "name": "slot5 sh."
+                        },
+                        {
+                            "range": [192, 207],
+                            "name": "slot6 sh."
+                        },
+                        {
+                            "range": [208, 223],
+                            "name": "slot7 sh."
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": ">>"
+                        }
+                    ]
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "highlightValue": null
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 0,
+                    "crossfade": true,
+                    "highlightValue": null
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "highlightValue": null
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 0,
+                    "crossfade": true,
+                    "highlightValue": null
+                },
+                "Speed": {
+                    "type": "Speed",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 225],
+                            "name": "speed"
+                        },
+                        {
+                            "range": [226, 235],
+                            "name": "MIB"
+                        },
+                        {
+                            "range": [236, 245],
+                            "name": "G/C MIB"
+                        },
+                        {
+                            "range": [246, 255],
+                            "name": "no funtion"
+                        }
+                    ]
+                },
+                "Prisma": {
+                    "type": "Prism",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 3],
+                            "name": "open"
+                        },
+                        {
+                            "range": [4, 63],
+                            "name": ">>"
+                        },
+                        {
+                            "range": [64, 67],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [68, 127],
+                            "name": "<<"
+                        },
+                        {
+                            "range": [128, 135],
+                            "name": "macro1"
+                        },
+                        {
+                            "range": [136, 143],
+                            "name": "macro2"
+                        },
+                        {
+                            "range": [144, 151],
+                            "name": "macro3"
+                        },
+                        {
+                            "range": [152, 159],
+                            "name": "macro4"
+                        },
+                        {
+                            "range": [160, 167],
+                            "name": "macro5"
+                        },
+                        {
+                            "range": [168, 175],
+                            "name": "macro6"
+                        },
+                        {
+                            "range": [176, 183],
+                            "name": "macro7"
+                        },
+                        {
+                            "range": [184, 191],
+                            "name": "macro8"
+                        },
+                        {
+                            "range": [192, 199],
+                            "name": "macro9"
+                        },
+                        {
+                            "range": [200, 207],
+                            "name": "macro10"
+                        },
+                        {
+                            "range": [208, 215],
+                            "name": "macro11"
+                        },
+                        {
+                            "range": [216, 223],
+                            "name": "macro12"
+                        },
+                        {
+                            "range": [224, 231],
+                            "name": "macro13"
+                        },
+                        {
+                            "range": [232, 239],
+                            "name": "macro14"
+                        },
+                        {
+                            "range": [240, 247],
+                            "name": "macro15"
+                        },
+                        {
+                            "range": [248, 255],
+                            "name": "macro16"
+                        }
+                    ]
+                },
+                "Focus": {
+                    "type": "Beam",
+                    "defaultValue": 128,
+                    "crossfade": true
+                },
+                "Shutter": {
+                    "type": "Shutter",
+                    "highlightValue": 63,
+                    "capabilities": [
+                        {
+                            "range": [0, 31],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [32, 63],
+                            "name": "open"
+                        },
+                        {
+                            "range": [64, 95],
+                            "name": "strobe"
+                        },
+                        {
+                            "range": [96, 127],
+                            "name": "open"
+                        },
+                        {
+                            "range": [128, 159],
+                            "name": "pulse"
+                        },
+                        {
+                            "range": [160, 191],
+                            "name": "open"
+                        },
+                        {
+                            "range": [192, 223],
+                            "name": "random strobe"
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "open"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Iris": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Iris pulse": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 31],
+                            "name": "idle"
+                        },
+                        {
+                            "range": [32, 143],
+                            "name": "pulse closed"
+                        },
+                        {
+                            "range": [144, 255],
+                            "name": "pulse opend"
+                        }
+                    ]
+                },
+                "Reset": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 39],
+                            "name": "idle"
+                        },
+                        {
+                            "range": [40, 59],
+                            "name": "lamp on"
+                        },
+                        {
+                            "range": [60, 79],
+                            "name": "lamp off"
+                        },
+                        {
+                            "range": [80, 99],
+                            "name": "reset"
+                        },
+                        {
+                            "range": [100, 119],
+                            "name": "macro1"
+                        },
+                        {
+                            "range": [120, 139],
+                            "name": "macro2"
+                        },
+                        {
+                            "range": [140, 159],
+                            "name": "macro3"
+                        },
+                        {
+                            "range": [160, 179],
+                            "name": "macro4"
+                        },
+                        {
+                            "range": [180, 199],
+                            "name": "macro5"
+                        },
+                        {
+                            "range": [200, 219],
+                            "name": "macro6"
+                        },
+                        {
+                            "range": [220, 239],
+                            "name": "macro7"
+                        },
+                        {
+                            "range": [240, 255],
+                            "name": "macro8"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "16-channel Mode",
+                    "shortName": "16ch",
+                    "channels": [
+                        "Color",
+                        "Gobo1",
+                        "Gobo1 rot.",
+                        "Gobo2",
+                        "Pan",
+                        "Tilt",
+                        "Speed",
+                        "Prisma",
+                        "Focus",
+                        "Shutter",
+                        "Intensity",
+                        "Iris",
+                        "Iris pulse",
+                        "Reset",
+                        "Pan fine",
+                        "Tilt fine"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Triton Blue",
+            "name": "SY-250",
+            "shortName": "SY250",
+            "comment": "cd Single Yoke 250",
+            "physical": {
+                "dimensions": [450, 450, 600],
+                "weight": 16,
+                "power": 250
+            },
+            "availableChannels": {
+                "Color": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 13],
+                            "name": "open"
+                        },
+                        {
+                            "range": [14, 27],
+                            "name": "slot1"
+                        },
+                        {
+                            "range": [28, 41],
+                            "name": "slot2"
+                        },
+                        {
+                            "range": [42, 55],
+                            "name": "slot3"
+                        },
+                        {
+                            "range": [56, 69],
+                            "name": "slot4"
+                        },
+                        {
+                            "range": [70, 83],
+                            "name": "slot5"
+                        },
+                        {
+                            "range": [84, 97],
+                            "name": "slot6"
+                        },
+                        {
+                            "range": [98, 111],
+                            "name": "slot7"
+                        },
+                        {
+                            "range": [112, 128],
+                            "name": "slot8"
+                        },
+                        {
+                            "range": [129, 187],
+                            "name": ">>"
+                        },
+                        {
+                            "range": [188, 193],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [194, 255],
+                            "name": "<<"
+                        }
+                    ]
+                },
+                "Gobo": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 9],
+                            "name": "open"
+                        },
+                        {
+                            "range": [10, 19],
+                            "name": "slot1"
+                        },
+                        {
+                            "range": [20, 29],
+                            "name": "slot2"
+                        },
+                        {
+                            "range": [30, 39],
+                            "name": "slot3"
+                        },
+                        {
+                            "range": [40, 49],
+                            "name": "slot4"
+                        },
+                        {
+                            "range": [50, 59],
+                            "name": "slot5"
+                        },
+                        {
+                            "range": [60, 69],
+                            "name": "slot6"
+                        },
+                        {
+                            "range": [70, 89],
+                            "name": "slot1 sh."
+                        },
+                        {
+                            "range": [90, 109],
+                            "name": "slot2 sh."
+                        },
+                        {
+                            "range": [110, 129],
+                            "name": "slot3 sh."
+                        },
+                        {
+                            "range": [130, 149],
+                            "name": "slot4 sh."
+                        },
+                        {
+                            "range": [150, 169],
+                            "name": "slot5 sh."
+                        },
+                        {
+                            "range": [170, 189],
+                            "name": "slot6 sh."
+                        },
+                        {
+                            "range": [190, 255],
+                            "name": ">>"
+                        }
+                    ]
+                },
+                "Gobo rot.": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "index"
+                        },
+                        {
+                            "range": [128, 187],
+                            "name": ">>"
+                        },
+                        {
+                            "range": [188, 193],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [194, 255],
+                            "name": "<<"
+                        }
+                    ]
+                },
+                "Shutter": {
+                    "type": "Shutter",
+                    "highlightValue": 255,
+                    "capabilities": [
+                        {
+                            "range": [0, 31],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [32, 63],
+                            "name": "dimm"
+                        },
+                        {
+                            "range": [64, 95],
+                            "name": "strobe"
+                        },
+                        {
+                            "range": [96, 127],
+                            "name": "open"
+                        },
+                        {
+                            "range": [128, 159],
+                            "name": "pulse"
+                        },
+                        {
+                            "range": [160, 191],
+                            "name": "open"
+                        },
+                        {
+                            "range": [192, 223],
+                            "name": "random strobe"
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "open"
+                        }
+                    ]
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "highlightValue": null
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 0,
+                    "crossfade": true,
+                    "highlightValue": null
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "highlightValue": null
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 0,
+                    "crossfade": true,
+                    "highlightValue": null
+                },
+                "Speed": {
+                    "type": "Speed",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 225],
+                            "name": "speed"
+                        },
+                        {
+                            "range": [226, 235],
+                            "name": "MIB"
+                        },
+                        {
+                            "range": [236, 245],
+                            "name": "G/C MIB"
+                        },
+                        {
+                            "range": [246, 255],
+                            "name": "no funtion"
+                        }
+                    ]
+                },
+                "Reset": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 39],
+                            "name": "idle"
+                        },
+                        {
+                            "range": [40, 59],
+                            "name": "lamp on"
+                        },
+                        {
+                            "range": [60, 79],
+                            "name": "lamp off"
+                        },
+                        {
+                            "range": [80, 99],
+                            "name": "reset"
+                        },
+                        {
+                            "range": [100, 119],
+                            "name": "macro1"
+                        },
+                        {
+                            "range": [120, 139],
+                            "name": "macro2"
+                        },
+                        {
+                            "range": [140, 159],
+                            "name": "macro3"
+                        },
+                        {
+                            "range": [160, 179],
+                            "name": "macro4"
+                        },
+                        {
+                            "range": [180, 199],
+                            "name": "macro5"
+                        },
+                        {
+                            "range": [200, 219],
+                            "name": "macro6"
+                        },
+                        {
+                            "range": [220, 239],
+                            "name": "macro7"
+                        },
+                        {
+                            "range": [240, 255],
+                            "name": "macro8"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "10-channel Mode",
+                    "shortName": "10ch",
+                    "channels": [
+                        "Color",
+                        "Gobo",
+                        "Gobo rot.",
+                        "Shutter",
+                        "Pan",
+                        "Tilt",
+                        "Speed",
+                        "Reset",
+                        "Pan fine",
+                        "Tilt fine"
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/fixtures/imports/ecue-MainLibrary/VLED.json
+++ b/fixtures/imports/ecue-MainLibrary/VLED.json
@@ -1,0 +1,100 @@
+{
+    "manufacturers": {
+        "VLED": {
+            "name": "VLED",
+            "website": "http://lmp.de/front_content.php?idcat=36"
+        }
+    },
+    "fixtures": [
+        {
+            "manufacturer": "VLED",
+            "name": "USC-300 DMX",
+            "shortName": "USC-300",
+            "comment": "3 Channel Mode",
+            "physical": {
+                "dimensions": [120, 120, 40],
+                "weight": 0.5,
+                "power": 5
+            },
+            "availableChannels": {
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                }
+            },
+            "modes": [
+                {
+                    "name": "3-channel Mode",
+                    "shortName": "3ch",
+                    "channels": [
+                        "Red",
+                        "Green",
+                        "Blue"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "VLED",
+            "name": "USC-500 DMX",
+            "shortName": "USC-500",
+            "comment": "3 Channel Mode",
+            "physical": {
+                "dimensions": [120, 120, 40],
+                "weight": 0.5,
+                "power": 5
+            },
+            "availableChannels": {
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                }
+            },
+            "modes": [
+                {
+                    "name": "3-channel Mode",
+                    "shortName": "3ch",
+                    "channels": [
+                        "Red",
+                        "Green",
+                        "Blue"
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/fixtures/imports/ecue-MainLibrary/VMS.json
+++ b/fixtures/imports/ecue-MainLibrary/VMS.json
@@ -1,0 +1,335 @@
+{
+    "manufacturers": {
+        "VMS": {
+            "name": "VMS",
+            "website": "http://www.vms-at.com"
+        }
+    },
+    "fixtures": [
+        {
+            "manufacturer": "VMS",
+            "name": "VMU 5 13 Ch",
+            "shortName": "VMU5",
+            "comment": "13 DMX Ch.",
+            "physical": {
+                "dimensions": [112, 455, 160],
+                "weight": 4.4
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "highlightValue": null
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 0,
+                    "crossfade": true,
+                    "highlightValue": null
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "highlightValue": null
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 0,
+                    "crossfade": true,
+                    "highlightValue": null
+                },
+                "Reset": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 254],
+                            "name": "idle"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "mirror reset"
+                        }
+                    ]
+                },
+                "Mute": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 254],
+                            "name": "off"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "on"
+                        }
+                    ]
+                },
+                "Freeze": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 254],
+                            "name": "off"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "on"
+                        }
+                    ]
+                },
+                "Zoom": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Key hor.": {
+                    "type": "Beam",
+                    "defaultValue": 128,
+                    "crossfade": true
+                },
+                "Key ver.": {
+                    "type": "Beam",
+                    "defaultValue": 128,
+                    "crossfade": true
+                },
+                "Orientation": {
+                    "type": "Beam",
+                    "defaultValue": 140,
+                    "capabilities": [
+                        {
+                            "range": [0, 63],
+                            "name": "Mir. up rev.",
+                            "center": true
+                        },
+                        {
+                            "range": [64, 127],
+                            "name": "Mir. down",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 191],
+                            "name": "Mir. up",
+                            "center": true
+                        },
+                        {
+                            "range": [192, 255],
+                            "name": "Mir. down rev.",
+                            "center": true
+                        }
+                    ]
+                },
+                "Source": {
+                    "type": "Beam",
+                    "defaultValue": 30,
+                    "capabilities": [
+                        {
+                            "range": [0, 64],
+                            "name": "video",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 150],
+                            "name": "s-video",
+                            "center": true
+                        },
+                        {
+                            "range": [192, 255],
+                            "name": "VGA",
+                            "center": true
+                        }
+                    ]
+                },
+                "Lamp": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [128, 192],
+                            "name": "on",
+                            "center": true
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "off"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "13-channel Mode",
+                    "shortName": "13ch",
+                    "channels": [
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "Reset",
+                        "Mute",
+                        "Freeze",
+                        "Zoom",
+                        "Key hor.",
+                        "Key ver.",
+                        "Orientation",
+                        "Source",
+                        "Lamp"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "VMS",
+            "name": "VMU 5 5 Ch",
+            "shortName": "VMU5.1",
+            "comment": "5 DMX Ch.",
+            "physical": {
+                "dimensions": [112, 455, 160],
+                "weight": 4.4
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "highlightValue": null
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 0,
+                    "crossfade": true,
+                    "highlightValue": null
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "highlightValue": null
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 0,
+                    "crossfade": true,
+                    "highlightValue": null
+                },
+                "Reset": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 254],
+                            "name": "idle"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "mirror reset"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "5-channel Mode",
+                    "shortName": "5ch",
+                    "channels": [
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "Reset"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "VMS",
+            "name": "VMU 5-5",
+            "shortName": "VMU5-5",
+            "comment": "cd",
+            "physical": {
+                "dimensions": [112, 455, 160],
+                "weight": 4.4
+            },
+            "availableChannels": {
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "highlightValue": null
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 0,
+                    "crossfade": true,
+                    "highlightValue": null
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "highlightValue": null
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 0,
+                    "crossfade": true,
+                    "highlightValue": null
+                },
+                "Reset": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 254],
+                            "name": "idle"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "mirror reset"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "5-channel Mode",
+                    "shortName": "5ch",
+                    "channels": [
+                        "Pan",
+                        "Tilt",
+                        "Pan fine",
+                        "Tilt fine",
+                        "Reset"
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/fixtures/imports/ecue-MainLibrary/Varilite.json
+++ b/fixtures/imports/ecue-MainLibrary/Varilite.json
@@ -1,0 +1,7359 @@
+{
+    "manufacturers": {
+        "Varilite": {
+            "name": "Varilite",
+            "website": "www.vari-lite.com"
+        }
+    },
+    "fixtures": [
+        {
+            "manufacturer": "Varilite",
+            "name": "Irideon AR5 Hi8Ch",
+            "shortName": "AR 5 Hi",
+            "physical": {
+                "dimensions": [100, 100, 100]
+            },
+            "availableChannels": {
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 0,
+                    "highlightValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 0,
+                    "highlightValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Cyan": {
+                    "type": "SingleColor",
+                    "color": "Cyan",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Yellow": {
+                    "type": "SingleColor",
+                    "color": "Yellow",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Magenta": {
+                    "type": "SingleColor",
+                    "color": "Magenta",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "8-channel Mode",
+                    "shortName": "8ch",
+                    "channels": [
+                        "Intensity",
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "Cyan",
+                        "Yellow",
+                        "Magenta"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Varilite",
+            "name": "Irideon AR500",
+            "shortName": "AR500",
+            "physical": {
+                "dimensions": [100, 100, 100]
+            },
+            "availableChannels": {
+                "Cyan": {
+                    "type": "SingleColor",
+                    "color": "Cyan",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Yellow": {
+                    "type": "SingleColor",
+                    "color": "Yellow",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Magenta": {
+                    "type": "SingleColor",
+                    "color": "Magenta",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "4-channel Mode",
+                    "shortName": "4ch",
+                    "channels": [
+                        "Cyan",
+                        "Yellow",
+                        "Magenta",
+                        "Intensity"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Varilite",
+            "name": "VL1000",
+            "shortName": "Vl1000",
+            "comment": "VL 1000 T & VL 1000 A",
+            "physical": {
+                "dimensions": [680, 680, 880],
+                "weight": 27
+            },
+            "availableChannels": {
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 0,
+                    "highlightValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 0,
+                    "highlightValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Edge": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Zoom": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Diffusion": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Cyan": {
+                    "type": "SingleColor",
+                    "color": "Cyan",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Yellow": {
+                    "type": "SingleColor",
+                    "color": "Yellow",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Magenta": {
+                    "type": "SingleColor",
+                    "color": "Magenta",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Gobo": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 17],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [18, 40],
+                            "name": "Gobo1"
+                        },
+                        {
+                            "range": [41, 62],
+                            "name": "Gobo2"
+                        },
+                        {
+                            "range": [63, 85],
+                            "name": "Gobo3"
+                        },
+                        {
+                            "range": [86, 107],
+                            "name": "Gobo4"
+                        },
+                        {
+                            "range": [108, 127],
+                            "name": "Gobo5"
+                        },
+                        {
+                            "range": [128, 145],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [146, 168],
+                            "name": "Gobo1Rot"
+                        },
+                        {
+                            "range": [169, 190],
+                            "name": "Gobo2Rot"
+                        },
+                        {
+                            "range": [191, 213],
+                            "name": "Gobo3Rot"
+                        },
+                        {
+                            "range": [214, 235],
+                            "name": "Gobo4Rot"
+                        },
+                        {
+                            "range": [236, 255],
+                            "name": "Gobo5Rot"
+                        }
+                    ]
+                },
+                "Gobo Rot": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "Gobo Rot fine": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "Frame 1A": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Frame 1B": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Frame 2A": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Frame 2B": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Frame 3A": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Frame 3B": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Frame 4A": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Frame 4B": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Frame Rot": {
+                    "type": "Beam",
+                    "defaultValue": 128,
+                    "crossfade": true
+                },
+                "Focus Time": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Color Time": {
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "crossfade": true
+                },
+                "Beam Time": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Control": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 80],
+                            "name": "Standard"
+                        },
+                        {
+                            "range": [81, 87],
+                            "name": "Reset",
+                            "center": true
+                        },
+                        {
+                            "range": [165, 171],
+                            "name": "Lamp Off",
+                            "center": true
+                        },
+                        {
+                            "range": [249, 255],
+                            "name": "Lamp On",
+                            "center": true
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ],
+                [
+                    "Gobo Rot",
+                    "Gobo Rot fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "27-channel Mode",
+                    "shortName": "27ch",
+                    "channels": [
+                        "Intensity",
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "Edge",
+                        "Zoom",
+                        "Diffusion",
+                        "Cyan",
+                        "Yellow",
+                        "Magenta",
+                        "Gobo",
+                        "Gobo Rot",
+                        "Gobo Rot fine",
+                        "Frame 1A",
+                        "Frame 1B",
+                        "Frame 2A",
+                        "Frame 2B",
+                        "Frame 3A",
+                        "Frame 3B",
+                        "Frame 4A",
+                        "Frame 4B",
+                        "Frame Rot",
+                        "Focus Time",
+                        "Color Time",
+                        "Beam Time",
+                        "Control"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Varilite",
+            "name": "VL2000 Spot",
+            "shortName": "VL2000S",
+            "comment": "Standard 16bit (16)",
+            "physical": {
+                "dimensions": [500, 500, 700]
+            },
+            "availableChannels": {
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Gobo": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 16],
+                            "name": "frame1"
+                        },
+                        {
+                            "range": [17, 34],
+                            "name": "frame2"
+                        },
+                        {
+                            "range": [35, 52],
+                            "name": "frame3"
+                        },
+                        {
+                            "range": [53, 70],
+                            "name": "frame4"
+                        },
+                        {
+                            "range": [71, 88],
+                            "name": "frame5"
+                        },
+                        {
+                            "range": [89, 106],
+                            "name": "frame6"
+                        },
+                        {
+                            "range": [107, 124],
+                            "name": "frame7"
+                        },
+                        {
+                            "range": [125, 142],
+                            "name": "frame8"
+                        },
+                        {
+                            "range": [143, 160],
+                            "name": "frame9"
+                        },
+                        {
+                            "range": [161, 178],
+                            "name": "frame10"
+                        },
+                        {
+                            "range": [179, 196],
+                            "name": "frame11"
+                        },
+                        {
+                            "range": [197, 215],
+                            "name": "frame12"
+                        },
+                        {
+                            "range": [216, 233],
+                            "name": "Spin CCW"
+                        },
+                        {
+                            "range": [234, 236],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [237, 255],
+                            "name": "spin CW"
+                        }
+                    ]
+                },
+                "Color": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 16],
+                            "name": "frame1"
+                        },
+                        {
+                            "range": [17, 34],
+                            "name": "frame2"
+                        },
+                        {
+                            "range": [35, 52],
+                            "name": "frame3"
+                        },
+                        {
+                            "range": [53, 70],
+                            "name": "frame4"
+                        },
+                        {
+                            "range": [71, 88],
+                            "name": "frame5"
+                        },
+                        {
+                            "range": [89, 106],
+                            "name": "frame6"
+                        },
+                        {
+                            "range": [107, 124],
+                            "name": "frame7"
+                        },
+                        {
+                            "range": [125, 142],
+                            "name": "frame8"
+                        },
+                        {
+                            "range": [143, 160],
+                            "name": "frame9"
+                        },
+                        {
+                            "range": [161, 178],
+                            "name": "frame10"
+                        },
+                        {
+                            "range": [179, 196],
+                            "name": "frame11"
+                        },
+                        {
+                            "range": [197, 215],
+                            "name": "frame12"
+                        },
+                        {
+                            "range": [216, 233],
+                            "name": "Spin CCW"
+                        },
+                        {
+                            "range": [234, 236],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [237, 255],
+                            "name": "spin CW"
+                        }
+                    ]
+                },
+                "Iris": {
+                    "type": "Beam",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Edge": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Strobe": {
+                    "type": "Strobe",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 2],
+                            "name": "open"
+                        },
+                        {
+                            "range": [3, 5],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [6, 12],
+                            "name": "random"
+                        },
+                        {
+                            "range": [13, 255],
+                            "name": "speed range"
+                        }
+                    ]
+                },
+                "Zoom": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "GoboRot": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 50],
+                            "name": "open"
+                        },
+                        {
+                            "range": [51, 101],
+                            "name": "position2"
+                        },
+                        {
+                            "range": [102, 152],
+                            "name": "position3"
+                        },
+                        {
+                            "range": [153, 203],
+                            "name": "position4"
+                        },
+                        {
+                            "range": [204, 254],
+                            "name": "position5"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "position6"
+                        }
+                    ]
+                },
+                "Gobo.Pos": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 215],
+                            "name": "index"
+                        },
+                        {
+                            "range": [216, 232],
+                            "name": "spin cw"
+                        },
+                        {
+                            "range": [234, 237],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [238, 255],
+                            "name": "spin ccw"
+                        }
+                    ]
+                },
+                "Control": {
+                    "type": "Beam",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "capabilities": [
+                        {
+                            "range": [1, 4],
+                            "name": "display.on"
+                        },
+                        {
+                            "range": [81, 87],
+                            "name": "reset"
+                        },
+                        {
+                            "range": [165, 171],
+                            "name": "lamp.off"
+                        },
+                        {
+                            "range": [249, 255],
+                            "name": "lamp.on"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "14-channel Mode",
+                    "shortName": "14ch",
+                    "channels": [
+                        "Intensity",
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "Gobo",
+                        "Color",
+                        "Iris",
+                        "Edge",
+                        "Strobe",
+                        "Zoom",
+                        "GoboRot",
+                        "Gobo.Pos",
+                        "Control"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Varilite",
+            "name": "VL2000 Wash",
+            "shortName": "VL2000W",
+            "comment": "Standard 16-bit",
+            "physical": {
+                "dimensions": [500, 500, 700]
+            },
+            "availableChannels": {
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Cyan": {
+                    "type": "SingleColor",
+                    "color": "Cyan",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Yellow": {
+                    "type": "SingleColor",
+                    "color": "Yellow",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Magenta": {
+                    "type": "SingleColor",
+                    "color": "Magenta",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Color": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 30],
+                            "name": "color1"
+                        },
+                        {
+                            "range": [31, 61],
+                            "name": "color2"
+                        },
+                        {
+                            "range": [62, 92],
+                            "name": "color3"
+                        },
+                        {
+                            "range": [93, 123],
+                            "name": "color4"
+                        },
+                        {
+                            "range": [124, 154],
+                            "name": "color5"
+                        },
+                        {
+                            "range": [155, 185],
+                            "name": "color6"
+                        },
+                        {
+                            "range": [186, 255],
+                            "name": "color7"
+                        }
+                    ]
+                },
+                "Diffusion": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Strobe": {
+                    "type": "Strobe",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Control": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "nofunction"
+                        },
+                        {
+                            "range": [84, 84],
+                            "name": "Reset"
+                        },
+                        {
+                            "range": [166, 166],
+                            "name": "lamp on"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "lamp off"
+                        },
+                        {
+                            "range": [102, 102],
+                            "name": "color reset"
+                        },
+                        {
+                            "range": [128, 128],
+                            "name": "lens reset"
+                        },
+                        {
+                            "range": [140, 140],
+                            "name": "dimmer reset"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "12-channel Mode",
+                    "shortName": "12ch",
+                    "channels": [
+                        "Intensity",
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "Cyan",
+                        "Yellow",
+                        "Magenta",
+                        "Color",
+                        "Diffusion",
+                        "Strobe",
+                        "Control"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Varilite",
+            "name": "VL2200 Series",
+            "shortName": "VL2202",
+            "comment": "Enhanced 16-bit Mode (E16)",
+            "physical": {
+                "dimensions": [500, 500, 700]
+            },
+            "availableChannels": {
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 0,
+                    "highlightValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 0,
+                    "highlightValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Gobo": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 9],
+                            "name": "open"
+                        },
+                        {
+                            "range": [9, 26],
+                            "name": "Frame2",
+                            "center": true
+                        },
+                        {
+                            "range": [27, 44],
+                            "name": "Frame3",
+                            "center": true
+                        },
+                        {
+                            "range": [45, 62],
+                            "name": "Frame4",
+                            "center": true
+                        },
+                        {
+                            "range": [63, 80],
+                            "name": "Frame5",
+                            "center": true
+                        },
+                        {
+                            "range": [81, 98],
+                            "name": "Frame6",
+                            "center": true
+                        },
+                        {
+                            "range": [99, 116],
+                            "name": "Frame7",
+                            "center": true
+                        },
+                        {
+                            "range": [117, 134],
+                            "name": "Frame8",
+                            "center": true
+                        },
+                        {
+                            "range": [135, 152],
+                            "name": "Frame9",
+                            "center": true
+                        },
+                        {
+                            "range": [153, 170],
+                            "name": "Frame10",
+                            "center": true
+                        },
+                        {
+                            "range": [171, 188],
+                            "name": "Frame11",
+                            "center": true
+                        },
+                        {
+                            "range": [189, 215],
+                            "name": "Frame12",
+                            "center": true
+                        },
+                        {
+                            "range": [216, 233],
+                            "name": "Spin CCW"
+                        },
+                        {
+                            "range": [234, 236],
+                            "name": "Stop"
+                        },
+                        {
+                            "range": [237, 255],
+                            "name": "Spin CW"
+                        }
+                    ]
+                },
+                "Color": {
+                    "type": "MultiColor",
+                    "capabilities": [
+                        {
+                            "range": [0, 9],
+                            "name": "open"
+                        },
+                        {
+                            "range": [9, 26],
+                            "name": "Frame2",
+                            "center": true
+                        },
+                        {
+                            "range": [27, 44],
+                            "name": "Frame3",
+                            "center": true
+                        },
+                        {
+                            "range": [45, 62],
+                            "name": "Frame4",
+                            "center": true
+                        },
+                        {
+                            "range": [63, 80],
+                            "name": "Frame5",
+                            "center": true
+                        },
+                        {
+                            "range": [81, 98],
+                            "name": "Frame6",
+                            "center": true
+                        },
+                        {
+                            "range": [99, 116],
+                            "name": "Frame7",
+                            "center": true
+                        },
+                        {
+                            "range": [117, 134],
+                            "name": "Frame8",
+                            "center": true
+                        },
+                        {
+                            "range": [135, 152],
+                            "name": "Frame9",
+                            "center": true
+                        },
+                        {
+                            "range": [153, 170],
+                            "name": "Frame10",
+                            "center": true
+                        },
+                        {
+                            "range": [171, 188],
+                            "name": "Frame11",
+                            "center": true
+                        },
+                        {
+                            "range": [189, 215],
+                            "name": "Frame12",
+                            "center": true
+                        },
+                        {
+                            "range": [216, 233],
+                            "name": "Spin CCW"
+                        },
+                        {
+                            "range": [234, 236],
+                            "name": "Stop"
+                        },
+                        {
+                            "range": [237, 255],
+                            "name": "Spin CW"
+                        }
+                    ]
+                },
+                "Iris": {
+                    "type": "Beam",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Edge": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Strobe": {
+                    "type": "Strobe",
+                    "capabilities": [
+                        {
+                            "range": [0, 2],
+                            "name": "open"
+                        },
+                        {
+                            "range": [3, 5],
+                            "name": "closed",
+                            "center": true
+                        },
+                        {
+                            "range": [6, 7],
+                            "name": "slow_rnd"
+                        },
+                        {
+                            "range": [8, 10],
+                            "name": "med_rnd"
+                        },
+                        {
+                            "range": [11, 12],
+                            "name": "fast_rnd"
+                        },
+                        {
+                            "range": [13, 255],
+                            "name": "speed"
+                        }
+                    ]
+                },
+                "Zoom": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "RotWheel": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 215],
+                            "name": "index"
+                        },
+                        {
+                            "range": [216, 233],
+                            "name": "Spin_CW"
+                        },
+                        {
+                            "range": [238, 255],
+                            "name": "Spin_CCW"
+                        },
+                        {
+                            "range": [234, 237],
+                            "name": "stop"
+                        }
+                    ]
+                },
+                "GoboIndex": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 215],
+                            "name": "index"
+                        },
+                        {
+                            "range": [216, 233],
+                            "name": "Spin_CW"
+                        },
+                        {
+                            "range": [238, 255],
+                            "name": "Spin_CCW"
+                        },
+                        {
+                            "range": [234, 237],
+                            "name": "stop"
+                        }
+                    ]
+                },
+                "FocusTime": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [1, 254],
+                            "name": "speed"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "tracking"
+                        },
+                        {
+                            "range": [0, 0],
+                            "name": "max"
+                        }
+                    ]
+                },
+                "ColorTime": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [1, 254],
+                            "name": "speed"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "tracking"
+                        },
+                        {
+                            "range": [0, 0],
+                            "name": "max"
+                        }
+                    ]
+                },
+                "BeamTime": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [1, 254],
+                            "name": "speed"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "tracking"
+                        },
+                        {
+                            "range": [0, 0],
+                            "name": "max"
+                        }
+                    ]
+                },
+                "Control": {
+                    "type": "Beam",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "capabilities": [
+                        {
+                            "range": [81, 87],
+                            "name": "Reset"
+                        },
+                        {
+                            "range": [165, 171],
+                            "name": "Lamp_off"
+                        },
+                        {
+                            "range": [249, 255],
+                            "name": "Lamp_on"
+                        },
+                        {
+                            "range": [1, 4],
+                            "name": "Display_on"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "17-channel Mode",
+                    "shortName": "17ch",
+                    "channels": [
+                        "Intensity",
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "Gobo",
+                        "Color",
+                        "Iris",
+                        "Edge",
+                        "Strobe",
+                        "Zoom",
+                        "RotWheel",
+                        "GoboIndex",
+                        "FocusTime",
+                        "ColorTime",
+                        "BeamTime",
+                        "Control"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Varilite",
+            "name": "VL2402 Wash",
+            "shortName": "VL2402W",
+            "comment": "Standard 16 Bit",
+            "physical": {
+                "dimensions": [610, 610, 850],
+                "weight": 25
+            },
+            "availableChannels": {
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 0,
+                    "highlightValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 0,
+                    "highlightValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Cyan": {
+                    "type": "SingleColor",
+                    "color": "Cyan",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Yellow": {
+                    "type": "SingleColor",
+                    "color": "Yellow",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Magenta": {
+                    "type": "SingleColor",
+                    "color": "Magenta",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "ColorWheel": {
+                    "type": "MultiColor",
+                    "capabilities": [
+                        {
+                            "range": [0, 8],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [9, 17],
+                            "name": "Half Frame"
+                        },
+                        {
+                            "range": [18, 25],
+                            "name": "Full Frame 2"
+                        },
+                        {
+                            "range": [26, 35],
+                            "name": "Half Frame"
+                        },
+                        {
+                            "range": [36, 43],
+                            "name": "Full Frame 3"
+                        },
+                        {
+                            "range": [44, 53],
+                            "name": "Half Frame"
+                        },
+                        {
+                            "range": [54, 61],
+                            "name": "Full Frame 4"
+                        },
+                        {
+                            "range": [62, 71],
+                            "name": "Half Frame"
+                        },
+                        {
+                            "range": [72, 79],
+                            "name": "Full Frame 5"
+                        },
+                        {
+                            "range": [80, 89],
+                            "name": "Half Frame"
+                        },
+                        {
+                            "range": [90, 97],
+                            "name": "Full Frame 6"
+                        },
+                        {
+                            "range": [98, 107],
+                            "name": "Half Frame"
+                        },
+                        {
+                            "range": [108, 115],
+                            "name": "Full Frame 7"
+                        },
+                        {
+                            "range": [116, 125],
+                            "name": "Half Frame"
+                        },
+                        {
+                            "range": [126, 133],
+                            "name": "Full Frame 8"
+                        },
+                        {
+                            "range": [134, 143],
+                            "name": "Half Frame"
+                        },
+                        {
+                            "range": [144, 151],
+                            "name": "Full Frame 9"
+                        },
+                        {
+                            "range": [152, 161],
+                            "name": "Half Frame"
+                        },
+                        {
+                            "range": [162, 169],
+                            "name": "Full Frame 10"
+                        },
+                        {
+                            "range": [170, 179],
+                            "name": "Half Frame"
+                        },
+                        {
+                            "range": [180, 187],
+                            "name": "Full Frame 11"
+                        },
+                        {
+                            "range": [188, 196],
+                            "name": "Half Frame"
+                        },
+                        {
+                            "range": [197, 205],
+                            "name": "Full Frame 12"
+                        },
+                        {
+                            "range": [206, 215],
+                            "name": "Half Frame"
+                        },
+                        {
+                            "range": [216, 233],
+                            "name": "Spin Left",
+                            "center": true
+                        },
+                        {
+                            "range": [234, 236],
+                            "name": "Stop",
+                            "center": true
+                        },
+                        {
+                            "range": [237, 255],
+                            "name": "Spin Right",
+                            "center": true
+                        }
+                    ]
+                },
+                "Diffusion": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Strobe": {
+                    "type": "Strobe",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 2],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [3, 5],
+                            "name": "Closed"
+                        },
+                        {
+                            "range": [6, 7],
+                            "name": "Slow Rnd"
+                        },
+                        {
+                            "range": [8, 10],
+                            "name": "Med Rnd"
+                        },
+                        {
+                            "range": [11, 12],
+                            "name": "Fast Rnd"
+                        },
+                        {
+                            "range": [13, 255],
+                            "name": "Speed"
+                        }
+                    ]
+                },
+                "Lamp Ctrl": {
+                    "type": "Beam",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [1, 4],
+                            "name": "Disp On"
+                        },
+                        {
+                            "range": [20, 25],
+                            "name": "Snap On"
+                        },
+                        {
+                            "range": [30, 35],
+                            "name": "Snap Off"
+                        },
+                        {
+                            "range": [81, 87],
+                            "name": "Reset"
+                        },
+                        {
+                            "range": [165, 171],
+                            "name": "Lamp Off"
+                        },
+                        {
+                            "range": [249, 255],
+                            "name": "Lamp On"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "12-channel Mode",
+                    "shortName": "12ch",
+                    "channels": [
+                        "Intensity",
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "Cyan",
+                        "Yellow",
+                        "Magenta",
+                        "ColorWheel",
+                        "Diffusion",
+                        "Strobe",
+                        "Lamp Ctrl"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Varilite",
+            "name": "VL2416 Wash",
+            "shortName": "VL2416W",
+            "comment": "Standard 16 Bit",
+            "physical": {
+                "dimensions": [610, 610, 850],
+                "weight": 25
+            },
+            "availableChannels": {
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 0,
+                    "highlightValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 0,
+                    "highlightValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Cyan": {
+                    "type": "SingleColor",
+                    "color": "Cyan",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Yellow": {
+                    "type": "SingleColor",
+                    "color": "Yellow",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Magenta": {
+                    "type": "SingleColor",
+                    "color": "Magenta",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Beam": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Strobe": {
+                    "type": "Strobe",
+                    "capabilities": [
+                        {
+                            "range": [0, 2],
+                            "name": "open"
+                        },
+                        {
+                            "range": [3, 5],
+                            "name": "closed"
+                        },
+                        {
+                            "range": [6, 7],
+                            "name": "Slow_rnd"
+                        },
+                        {
+                            "range": [8, 10],
+                            "name": "Med_rnd"
+                        },
+                        {
+                            "range": [11, 12],
+                            "name": "Fast_rnd"
+                        },
+                        {
+                            "range": [13, 255],
+                            "name": "Speed"
+                        }
+                    ]
+                },
+                "Rot_Lens": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 215],
+                            "name": "index"
+                        },
+                        {
+                            "range": [216, 233],
+                            "name": "Spin_CW"
+                        },
+                        {
+                            "range": [234, 237],
+                            "name": "Stop"
+                        },
+                        {
+                            "range": [238, 255],
+                            "name": "Spin_CCW"
+                        }
+                    ]
+                },
+                "Lamp Ctrl": {
+                    "type": "Beam",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "capabilities": [
+                        {
+                            "range": [1, 4],
+                            "name": "Disp On"
+                        },
+                        {
+                            "range": [20, 25],
+                            "name": "Snap On"
+                        },
+                        {
+                            "range": [30, 35],
+                            "name": "Snap Off"
+                        },
+                        {
+                            "range": [81, 87],
+                            "name": "Reset"
+                        },
+                        {
+                            "range": [165, 171],
+                            "name": "Lamp Off"
+                        },
+                        {
+                            "range": [249, 255],
+                            "name": "Lamp On"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "12-channel Mode",
+                    "shortName": "12ch",
+                    "channels": [
+                        "Intensity",
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "Cyan",
+                        "Yellow",
+                        "Magenta",
+                        "Beam",
+                        "Strobe",
+                        "Rot_Lens",
+                        "Lamp Ctrl"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Varilite",
+            "name": "VL2500 Spot",
+            "shortName": "VL 2500 Spot",
+            "physical": {
+                "dimensions": [485, 485, 702]
+            },
+            "availableChannels": {
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Cyan": {
+                    "type": "SingleColor",
+                    "color": "Cyan",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Yellow": {
+                    "type": "SingleColor",
+                    "color": "Yellow",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Magenta": {
+                    "type": "SingleColor",
+                    "color": "Magenta",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Color": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 16],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [17, 34],
+                            "name": "Light red"
+                        },
+                        {
+                            "range": [35, 52],
+                            "name": "Blue",
+                            "color": "#0000ff"
+                        },
+                        {
+                            "range": [53, 70],
+                            "name": "Yellow",
+                            "color": "#ffff00"
+                        },
+                        {
+                            "range": [71, 88],
+                            "name": "Light blue",
+                            "color": "#add8e6"
+                        },
+                        {
+                            "range": [89, 106],
+                            "name": "Pink",
+                            "color": "#ffc0cb"
+                        },
+                        {
+                            "range": [107, 124],
+                            "name": "Green",
+                            "color": "#00ff00"
+                        },
+                        {
+                            "range": [125, 142],
+                            "name": "Magenta",
+                            "color": "#ca1f7b"
+                        },
+                        {
+                            "range": [143, 160],
+                            "name": "Lavender",
+                            "color": "#b57edc"
+                        },
+                        {
+                            "range": [161, 178],
+                            "name": "Amber",
+                            "color": "#ffbf00"
+                        },
+                        {
+                            "range": [179, 196],
+                            "name": "Orange",
+                            "color": "#ff7f00"
+                        },
+                        {
+                            "range": [197, 215],
+                            "name": "UV"
+                        },
+                        {
+                            "range": [216, 216],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [217, 233],
+                            "name": "Spin CCW"
+                        },
+                        {
+                            "range": [234, 236],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [237, 255],
+                            "name": "spin CW"
+                        }
+                    ]
+                },
+                "Focus": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Strobe": {
+                    "type": "Strobe",
+                    "capabilities": [
+                        {
+                            "range": [0, 1],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [1, 255],
+                            "name": "Strobe"
+                        }
+                    ]
+                },
+                "Zoom": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Gobo1": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 2],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [2, 25],
+                            "name": "Slot1"
+                        },
+                        {
+                            "range": [26, 43],
+                            "name": "Slot2"
+                        },
+                        {
+                            "range": [44, 62],
+                            "name": "Slot3"
+                        },
+                        {
+                            "range": [63, 80],
+                            "name": "Slot4"
+                        },
+                        {
+                            "range": [81, 97],
+                            "name": "Slot5"
+                        },
+                        {
+                            "range": [98, 116],
+                            "name": "Slot6"
+                        },
+                        {
+                            "range": [117, 134],
+                            "name": "Slot7"
+                        },
+                        {
+                            "range": [135, 151],
+                            "name": "Slot8"
+                        },
+                        {
+                            "range": [152, 170],
+                            "name": "Slot9"
+                        },
+                        {
+                            "range": [171, 188],
+                            "name": "Slot10"
+                        },
+                        {
+                            "range": [189, 215],
+                            "name": "Slot11"
+                        },
+                        {
+                            "range": [216, 216],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [217, 235],
+                            "name": ">>"
+                        },
+                        {
+                            "range": [236, 236],
+                            "name": "Stop"
+                        },
+                        {
+                            "range": [237, 255],
+                            "name": "<<"
+                        }
+                    ]
+                },
+                "Gobo2": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 18],
+                            "name": "Open",
+                            "center": true
+                        },
+                        {
+                            "range": [19, 36],
+                            "name": "Slot1 ind.",
+                            "center": true
+                        },
+                        {
+                            "range": [37, 54],
+                            "name": "Slot2 ind.",
+                            "center": true
+                        },
+                        {
+                            "range": [55, 72],
+                            "name": "Slot3 ind.",
+                            "center": true
+                        },
+                        {
+                            "range": [73, 90],
+                            "name": "Slot4 ind.",
+                            "center": true
+                        },
+                        {
+                            "range": [91, 109],
+                            "name": "Slot5 ind.",
+                            "center": true
+                        },
+                        {
+                            "range": [110, 127],
+                            "name": "Open",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 144],
+                            "name": "Slot1 rot.",
+                            "center": true
+                        },
+                        {
+                            "range": [145, 162],
+                            "name": "Slot2 rot.",
+                            "center": true
+                        },
+                        {
+                            "range": [163, 180],
+                            "name": "Slot3 rot.",
+                            "center": true
+                        },
+                        {
+                            "range": [181, 199],
+                            "name": "Slot4 rot.",
+                            "center": true
+                        },
+                        {
+                            "range": [200, 215],
+                            "name": "Slot5 rot.",
+                            "center": true
+                        },
+                        {
+                            "range": [216, 217],
+                            "name": "Open",
+                            "center": true
+                        },
+                        {
+                            "range": [217, 233],
+                            "name": ">>"
+                        },
+                        {
+                            "range": [234, 238],
+                            "name": "Stop",
+                            "center": true
+                        },
+                        {
+                            "range": [239, 255],
+                            "name": "<<"
+                        }
+                    ]
+                },
+                "Rot. Gobo2": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 3106],
+                            "name": ">>",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [3107, 3107],
+                            "name": "Stop",
+                            "warning": "Out of range!",
+                            "center": true
+                        },
+                        {
+                            "range": [3108, 65535],
+                            "name": "<<",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "Rot. Gobo2 fine": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 3106],
+                            "name": ">>",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [3107, 3107],
+                            "name": "Stop",
+                            "warning": "Out of range!",
+                            "center": true
+                        },
+                        {
+                            "range": [3108, 65535],
+                            "name": "<<",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "Iris": {
+                    "type": "Beam",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 1],
+                            "name": "Closed"
+                        },
+                        {
+                            "range": [1, 254],
+                            "name": "%"
+                        },
+                        {
+                            "range": [254, 255],
+                            "name": "Open"
+                        }
+                    ]
+                },
+                "Focus time": {
+                    "type": "Beam",
+                    "defaultValue": 255,
+                    "highlightValue": 255
+                },
+                "Color time": {
+                    "type": "Beam",
+                    "defaultValue": 255,
+                    "highlightValue": 255
+                },
+                "Beam time": {
+                    "type": "Beam",
+                    "defaultValue": 255,
+                    "highlightValue": 255
+                },
+                "Gobo time": {
+                    "type": "Gobo",
+                    "defaultValue": 255,
+                    "highlightValue": 255
+                },
+                "Control": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [1, 4],
+                            "name": "Display on"
+                        },
+                        {
+                            "range": [81, 87],
+                            "name": "Reset"
+                        },
+                        {
+                            "range": [165, 171],
+                            "name": "Lamp off"
+                        },
+                        {
+                            "range": [249, 255],
+                            "name": "Lamp on"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ],
+                [
+                    "Rot. Gobo2",
+                    "Rot. Gobo2 fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "22-channel Mode",
+                    "shortName": "22ch",
+                    "channels": [
+                        "Intensity",
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "Cyan",
+                        "Yellow",
+                        "Magenta",
+                        "Color",
+                        "Focus",
+                        "Strobe",
+                        "Zoom",
+                        "Gobo1",
+                        "Gobo2",
+                        "Rot. Gobo2",
+                        "Rot. Gobo2 fine",
+                        "Iris",
+                        "Focus time",
+                        "Color time",
+                        "Beam time",
+                        "Gobo time",
+                        "Control"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Varilite",
+            "name": "VL3000 Spot",
+            "shortName": "VL3000Spot",
+            "comment": "Enhanced 16 Bit Mode",
+            "physical": {
+                "dimensions": [660, 660, 802]
+            },
+            "availableChannels": {
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Edge": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Zoom": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "CTO Mixer": {
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "crossfade": true
+                },
+                "Cyan": {
+                    "type": "SingleColor",
+                    "color": "Cyan",
+                    "crossfade": true
+                },
+                "Yellow": {
+                    "type": "SingleColor",
+                    "color": "Yellow",
+                    "crossfade": true
+                },
+                "Magenta": {
+                    "type": "SingleColor",
+                    "color": "Magenta",
+                    "crossfade": true
+                },
+                "Color": {
+                    "type": "MultiColor",
+                    "capabilities": [
+                        {
+                            "range": [0, 216],
+                            "name": "Color"
+                        },
+                        {
+                            "range": [217, 255],
+                            "name": "Spin"
+                        }
+                    ]
+                },
+                "Gobo1": {
+                    "type": "Gobo"
+                },
+                "Gobo1Idx": {
+                    "type": "Gobo",
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "Gobo1Idx fine": {
+                    "type": "Gobo",
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "Gobo2": {
+                    "type": "Gobo"
+                },
+                "Gobo2Idx": {
+                    "type": "Gobo",
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "Gobo2Idx fine": {
+                    "type": "Gobo",
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "Gobo3": {
+                    "type": "Gobo"
+                },
+                "Gobo3Idx": {
+                    "type": "Gobo",
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "Gobo3Idx fine": {
+                    "type": "Gobo",
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "Iris": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Strobe": {
+                    "type": "Strobe"
+                },
+                "Focus Time": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Color Time": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Beam Time": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Gobo Time": {
+                    "type": "Gobo",
+                    "crossfade": true
+                },
+                "Control": {
+                    "type": "Beam"
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ],
+                [
+                    "Gobo1Idx",
+                    "Gobo1Idx fine"
+                ],
+                [
+                    "Gobo2Idx",
+                    "Gobo2Idx fine"
+                ],
+                [
+                    "Gobo3Idx",
+                    "Gobo3Idx fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "28-channel Mode",
+                    "shortName": "28ch",
+                    "channels": [
+                        "Intensity",
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "Edge",
+                        "Zoom",
+                        "CTO Mixer",
+                        "Cyan",
+                        "Yellow",
+                        "Magenta",
+                        "Color",
+                        "Gobo1",
+                        "Gobo1Idx",
+                        "Gobo1Idx fine",
+                        "Gobo2",
+                        "Gobo2Idx",
+                        "Gobo2Idx fine",
+                        "Gobo3",
+                        "Gobo3Idx",
+                        "Gobo3Idx fine",
+                        "Iris",
+                        "Strobe",
+                        "Focus Time",
+                        "Color Time",
+                        "Beam Time",
+                        "Gobo Time",
+                        "Control"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Varilite",
+            "name": "VL3000 Wash",
+            "shortName": "VL3000W",
+            "physical": {
+                "dimensions": [660, 660, 802]
+            },
+            "availableChannels": {
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 0,
+                    "highlightValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 0,
+                    "highlightValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Spreader": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "CTOMix": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Cyan": {
+                    "type": "SingleColor",
+                    "color": "Cyan",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Yellow": {
+                    "type": "SingleColor",
+                    "color": "Yellow",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Magenta": {
+                    "type": "SingleColor",
+                    "color": "Magenta",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Color": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 30],
+                            "name": "color1"
+                        },
+                        {
+                            "range": [31, 61],
+                            "name": "color2"
+                        },
+                        {
+                            "range": [62, 92],
+                            "name": "color3"
+                        },
+                        {
+                            "range": [93, 123],
+                            "name": "color4"
+                        },
+                        {
+                            "range": [124, 154],
+                            "name": "color5"
+                        },
+                        {
+                            "range": [155, 185],
+                            "name": "color6"
+                        },
+                        {
+                            "range": [186, 255],
+                            "name": "color7"
+                        }
+                    ]
+                },
+                "Strobe": {
+                    "type": "Strobe",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Focus T": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Color T": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Beam T": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Control": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "nofunction"
+                        },
+                        {
+                            "range": [84, 84],
+                            "name": "Reset"
+                        },
+                        {
+                            "range": [166, 166],
+                            "name": "lamp on"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "lamp off"
+                        },
+                        {
+                            "range": [102, 102],
+                            "name": "color reset"
+                        },
+                        {
+                            "range": [128, 128],
+                            "name": "lens reset"
+                        },
+                        {
+                            "range": [140, 140],
+                            "name": "dimmer reset"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "16-channel Mode",
+                    "shortName": "16ch",
+                    "channels": [
+                        "Intensity",
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "Spreader",
+                        "CTOMix",
+                        "Cyan",
+                        "Yellow",
+                        "Magenta",
+                        "Color",
+                        "Strobe",
+                        "Focus T",
+                        "Color T",
+                        "Beam T",
+                        "Control"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Varilite",
+            "name": "VL3500 Spot",
+            "shortName": "VL 3500 Spot",
+            "physical": {
+                "dimensions": [660, 660, 802]
+            },
+            "availableChannels": {
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Focus": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Zoom": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "CTO": {
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Cyan": {
+                    "type": "SingleColor",
+                    "color": "Cyan",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Yellow": {
+                    "type": "SingleColor",
+                    "color": "Yellow",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Magenta": {
+                    "type": "SingleColor",
+                    "color": "Magenta",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Color": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 14],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [15, 47],
+                            "name": "Congo blue"
+                        },
+                        {
+                            "range": [48, 76],
+                            "name": "Orange",
+                            "color": "#ff7f00"
+                        },
+                        {
+                            "range": [77, 108],
+                            "name": "Kelly green",
+                            "color": "#4cbb17"
+                        },
+                        {
+                            "range": [109, 139],
+                            "name": "Dark fuchsia"
+                        },
+                        {
+                            "range": [140, 170],
+                            "name": "Magenta",
+                            "color": "#ca1f7b"
+                        },
+                        {
+                            "range": [171, 201],
+                            "name": "Deep red",
+                            "color": "#850101"
+                        },
+                        {
+                            "range": [216, 216],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [217, 233],
+                            "name": "<<"
+                        },
+                        {
+                            "range": [234, 236],
+                            "name": "stop"
+                        },
+                        {
+                            "range": [237, 255],
+                            "name": ">>"
+                        }
+                    ]
+                },
+                "Gobo1": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 7],
+                            "name": "Open",
+                            "center": true
+                        },
+                        {
+                            "range": [8, 25],
+                            "name": "Slot1 ind.",
+                            "center": true
+                        },
+                        {
+                            "range": [26, 44],
+                            "name": "Slot2 ind.",
+                            "center": true
+                        },
+                        {
+                            "range": [45, 63],
+                            "name": "Slot3 ind.",
+                            "center": true
+                        },
+                        {
+                            "range": [64, 82],
+                            "name": "Slot4 ind.",
+                            "center": true
+                        },
+                        {
+                            "range": [83, 99],
+                            "name": "Slot5 ind.",
+                            "center": true
+                        },
+                        {
+                            "range": [100, 116],
+                            "name": "Open",
+                            "center": true
+                        },
+                        {
+                            "range": [117, 134],
+                            "name": "Slot1 rot.",
+                            "center": true
+                        },
+                        {
+                            "range": [135, 153],
+                            "name": "Slot2 rot.",
+                            "center": true
+                        },
+                        {
+                            "range": [154, 172],
+                            "name": "Slot3 rot.",
+                            "center": true
+                        },
+                        {
+                            "range": [173, 191],
+                            "name": "Slot4 rot.",
+                            "center": true
+                        },
+                        {
+                            "range": [192, 209],
+                            "name": "Slot5 rot.",
+                            "center": true
+                        },
+                        {
+                            "range": [210, 216],
+                            "name": "Open",
+                            "center": true
+                        },
+                        {
+                            "range": [217, 233],
+                            "name": ">>"
+                        },
+                        {
+                            "range": [234, 238],
+                            "name": "Stop",
+                            "center": true
+                        },
+                        {
+                            "range": [239, 255],
+                            "name": "<<"
+                        }
+                    ]
+                },
+                "Rot. Gobo1": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 3106],
+                            "name": ">>",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [3107, 3107],
+                            "name": "Stop",
+                            "warning": "Out of range!",
+                            "center": true
+                        },
+                        {
+                            "range": [3108, 65535],
+                            "name": "<<",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "Rot. Gobo1 fine": {
+                    "type": "Gobo",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 3106],
+                            "name": ">>",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [3107, 3107],
+                            "name": "Stop",
+                            "warning": "Out of range!",
+                            "center": true
+                        },
+                        {
+                            "range": [3108, 65535],
+                            "name": "<<",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "Gobo2": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 13],
+                            "name": "Open",
+                            "center": true
+                        },
+                        {
+                            "range": [14, 43],
+                            "name": "Slot1",
+                            "center": true
+                        },
+                        {
+                            "range": [44, 75],
+                            "name": "Slot2",
+                            "center": true
+                        },
+                        {
+                            "range": [76, 108],
+                            "name": "Slot3",
+                            "center": true
+                        },
+                        {
+                            "range": [109, 140],
+                            "name": "Slot4",
+                            "center": true
+                        },
+                        {
+                            "range": [141, 172],
+                            "name": "Slot5",
+                            "center": true
+                        },
+                        {
+                            "range": [173, 202],
+                            "name": "Slot6",
+                            "center": true
+                        },
+                        {
+                            "range": [216, 216],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [217, 235],
+                            "name": ">>"
+                        },
+                        {
+                            "range": [236, 236],
+                            "name": "Stop"
+                        },
+                        {
+                            "range": [237, 255],
+                            "name": "<<"
+                        }
+                    ]
+                },
+                "Strobe": {
+                    "type": "Strobe",
+                    "capabilities": [
+                        {
+                            "range": [0, 1],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [1, 255],
+                            "name": "Strobe"
+                        }
+                    ]
+                },
+                "Barn door 1a": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "Out"
+                        },
+                        {
+                            "range": [1, 254],
+                            "name": "%"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "In"
+                        }
+                    ]
+                },
+                "Barn door 1b": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "Out"
+                        },
+                        {
+                            "range": [1, 254],
+                            "name": "%"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "In"
+                        }
+                    ]
+                },
+                "Barn door 2a": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "Out"
+                        },
+                        {
+                            "range": [1, 254],
+                            "name": "%"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "In"
+                        }
+                    ]
+                },
+                "Barn door 2b": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "Out"
+                        },
+                        {
+                            "range": [1, 254],
+                            "name": "%"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "In"
+                        }
+                    ]
+                },
+                "Barn door 3a": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "Out"
+                        },
+                        {
+                            "range": [1, 254],
+                            "name": "%"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "In"
+                        }
+                    ]
+                },
+                "Barn door 3b": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "Out"
+                        },
+                        {
+                            "range": [1, 254],
+                            "name": "%"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "In"
+                        }
+                    ]
+                },
+                "Barn door 4a": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "Out"
+                        },
+                        {
+                            "range": [1, 254],
+                            "name": "%"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "In"
+                        }
+                    ]
+                },
+                "Barn door 4b": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "Out"
+                        },
+                        {
+                            "range": [1, 254],
+                            "name": "%"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "In"
+                        }
+                    ]
+                },
+                "Barn door rot.": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "Right"
+                        },
+                        {
+                            "range": [128, 128],
+                            "name": "128",
+                            "center": true
+                        },
+                        {
+                            "range": [129, 255],
+                            "name": "Left"
+                        }
+                    ]
+                },
+                "Focus time": {
+                    "type": "Beam",
+                    "defaultValue": 255,
+                    "highlightValue": 255
+                },
+                "Color time": {
+                    "type": "Beam",
+                    "defaultValue": 255,
+                    "highlightValue": 255
+                },
+                "Beam time": {
+                    "type": "Beam",
+                    "defaultValue": 255,
+                    "highlightValue": 255
+                },
+                "Gobo time": {
+                    "type": "Gobo",
+                    "defaultValue": 255,
+                    "highlightValue": 255
+                },
+                "Control": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [1, 4],
+                            "name": "Display on"
+                        },
+                        {
+                            "range": [81, 87],
+                            "name": "Reset"
+                        },
+                        {
+                            "range": [165, 171],
+                            "name": "Lamp off"
+                        },
+                        {
+                            "range": [249, 255],
+                            "name": "Lamp on"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ],
+                [
+                    "Rot. Gobo1",
+                    "Rot. Gobo1 fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "31-channel Mode",
+                    "shortName": "31ch",
+                    "channels": [
+                        "Intensity",
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "Focus",
+                        "Zoom",
+                        "CTO",
+                        "Cyan",
+                        "Yellow",
+                        "Magenta",
+                        "Color",
+                        "Gobo1",
+                        "Rot. Gobo1",
+                        "Rot. Gobo1 fine",
+                        "Gobo2",
+                        "Strobe",
+                        "Barn door 1a",
+                        "Barn door 1b",
+                        "Barn door 2a",
+                        "Barn door 2b",
+                        "Barn door 3a",
+                        "Barn door 3b",
+                        "Barn door 4a",
+                        "Barn door 4b",
+                        "Barn door rot.",
+                        "Focus time",
+                        "Color time",
+                        "Beam time",
+                        "Gobo time",
+                        "Control"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Varilite",
+            "name": "VL3500 Wash",
+            "shortName": "VL3500W",
+            "physical": {
+                "dimensions": [660, 660, 802]
+            },
+            "availableChannels": {
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 0,
+                    "highlightValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 0,
+                    "highlightValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Vari*Brite": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Zoom": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "CTO": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Cyan": {
+                    "type": "SingleColor",
+                    "color": "Cyan",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Yellow": {
+                    "type": "SingleColor",
+                    "color": "Yellow",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Magenta": {
+                    "type": "SingleColor",
+                    "color": "Magenta",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Color 1": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 36],
+                            "name": "open"
+                        },
+                        {
+                            "range": [37, 71],
+                            "name": "Red",
+                            "color": "#ff0000"
+                        },
+                        {
+                            "range": [72, 106],
+                            "name": "Yellow",
+                            "color": "#ffff00"
+                        },
+                        {
+                            "range": [107, 142],
+                            "name": "Magenta",
+                            "color": "#ca1f7b"
+                        },
+                        {
+                            "range": [143, 178],
+                            "name": "K. Green"
+                        },
+                        {
+                            "range": [179, 216],
+                            "name": "Co. Blue"
+                        },
+                        {
+                            "range": [217, 255],
+                            "name": "Speed"
+                        }
+                    ]
+                },
+                "Color 2": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 36],
+                            "name": "open"
+                        },
+                        {
+                            "range": [37, 71],
+                            "name": "Blue",
+                            "color": "#0000ff"
+                        },
+                        {
+                            "range": [72, 106],
+                            "name": "Amber",
+                            "color": "#ffbf00"
+                        },
+                        {
+                            "range": [107, 142],
+                            "name": "Drk. Fuch."
+                        },
+                        {
+                            "range": [143, 178],
+                            "name": "Orange",
+                            "color": "#ff7f00"
+                        },
+                        {
+                            "range": [179, 216],
+                            "name": "Green",
+                            "color": "#00ff00"
+                        },
+                        {
+                            "range": [217, 255],
+                            "name": "Speed"
+                        }
+                    ]
+                },
+                "Strobe": {
+                    "type": "Strobe",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 2],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [3, 5],
+                            "name": "Closed"
+                        },
+                        {
+                            "range": [6, 7],
+                            "name": "Sl. Random"
+                        },
+                        {
+                            "range": [8, 10],
+                            "name": "Me. Random"
+                        },
+                        {
+                            "range": [11, 12],
+                            "name": "Fa. Random"
+                        },
+                        {
+                            "range": [13, 255],
+                            "name": "Range"
+                        }
+                    ]
+                },
+                "Aper. Wheel": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 43],
+                            "name": "Pos. 1-52mm"
+                        },
+                        {
+                            "range": [44, 86],
+                            "name": "Pos. 2-40mm"
+                        },
+                        {
+                            "range": [87, 129],
+                            "name": "Pos. 3-35mm"
+                        },
+                        {
+                            "range": [130, 172],
+                            "name": "Pos. 4-30mm"
+                        },
+                        {
+                            "range": [173, 216],
+                            "name": "Pos. 5-25mm"
+                        },
+                        {
+                            "range": [217, 255],
+                            "name": "speed"
+                        }
+                    ]
+                },
+                "Focus T": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Color T": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Beam T": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Control": {
+                    "type": "Beam",
+                    "defaultValue": 255,
+                    "capabilities": [
+                        {
+                            "range": [0, 19],
+                            "name": "nofunction"
+                        },
+                        {
+                            "range": [20, 25],
+                            "name": "Col. Sn. On"
+                        },
+                        {
+                            "range": [30, 35],
+                            "name": "Col. Sn. Off"
+                        },
+                        {
+                            "range": [40, 45],
+                            "name": "Dim. Sn. On"
+                        },
+                        {
+                            "range": [50, 55],
+                            "name": "Dim. Sn. Off"
+                        },
+                        {
+                            "range": [60, 65],
+                            "name": "Zoom Norm"
+                        },
+                        {
+                            "range": [70, 75],
+                            "name": "Zoom Studio"
+                        },
+                        {
+                            "range": [81, 87],
+                            "name": "Full Lum. Res."
+                        },
+                        {
+                            "range": [100, 104],
+                            "name": "ReCal Col."
+                        },
+                        {
+                            "range": [126, 130],
+                            "name": "ReCal Beam"
+                        },
+                        {
+                            "range": [138, 142],
+                            "name": "ReCal Dim/ Str."
+                        },
+                        {
+                            "range": [165, 171],
+                            "name": "Lamp Off"
+                        },
+                        {
+                            "range": [176, 184],
+                            "name": "@ 900 W"
+                        },
+                        {
+                            "range": [189, 194],
+                            "name": "@ 1200W"
+                        },
+                        {
+                            "range": [199, 204],
+                            "name": "@ 1500"
+                        },
+                        {
+                            "range": [249, 255],
+                            "name": "Lamp On"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "19-channel Mode",
+                    "shortName": "19ch",
+                    "channels": [
+                        "Intensity",
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "Vari*Brite",
+                        "Zoom",
+                        "CTO",
+                        "Cyan",
+                        "Yellow",
+                        "Magenta",
+                        "Color 1",
+                        "Color 2",
+                        "Strobe",
+                        "Aper. Wheel",
+                        "Focus T",
+                        "Color T",
+                        "Beam T",
+                        "Control"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Varilite",
+            "name": "VL3500 Wash-FX",
+            "shortName": "VL3500W-FX",
+            "physical": {
+                "dimensions": [711, 711, 711]
+            },
+            "availableChannels": {
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 0,
+                    "highlightValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 0,
+                    "highlightValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Vari*Brite": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Zoom": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "CTO": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Cyan": {
+                    "type": "SingleColor",
+                    "color": "Cyan",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Yellow": {
+                    "type": "SingleColor",
+                    "color": "Yellow",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Magenta": {
+                    "type": "SingleColor",
+                    "color": "Magenta",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Color 1": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 36],
+                            "name": "open"
+                        },
+                        {
+                            "range": [37, 71],
+                            "name": "Red",
+                            "color": "#ff0000"
+                        },
+                        {
+                            "range": [72, 106],
+                            "name": "Yellow",
+                            "color": "#ffff00"
+                        },
+                        {
+                            "range": [107, 142],
+                            "name": "Magenta",
+                            "color": "#ca1f7b"
+                        },
+                        {
+                            "range": [143, 178],
+                            "name": "K. Green"
+                        },
+                        {
+                            "range": [179, 216],
+                            "name": "Co. Blue"
+                        },
+                        {
+                            "range": [217, 255],
+                            "name": "Speed"
+                        }
+                    ]
+                },
+                "Color 2": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 36],
+                            "name": "open"
+                        },
+                        {
+                            "range": [37, 71],
+                            "name": "Blue",
+                            "color": "#0000ff"
+                        },
+                        {
+                            "range": [72, 106],
+                            "name": "Straw",
+                            "color": "#e4d96f"
+                        },
+                        {
+                            "range": [107, 142],
+                            "name": "Drk. Fuch."
+                        },
+                        {
+                            "range": [143, 178],
+                            "name": "Orange",
+                            "color": "#ff7f00"
+                        },
+                        {
+                            "range": [179, 216],
+                            "name": "Green",
+                            "color": "#00ff00"
+                        },
+                        {
+                            "range": [217, 255],
+                            "name": "Speed"
+                        }
+                    ]
+                },
+                "Strobe": {
+                    "type": "Strobe",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 2],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [3, 5],
+                            "name": "Closed"
+                        },
+                        {
+                            "range": [6, 7],
+                            "name": "Sl. Random"
+                        },
+                        {
+                            "range": [8, 10],
+                            "name": "Me. Random"
+                        },
+                        {
+                            "range": [11, 12],
+                            "name": "Fa. Random"
+                        },
+                        {
+                            "range": [13, 255],
+                            "name": "Range"
+                        }
+                    ]
+                },
+                "FX Wheel": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 10],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [11, 32],
+                            "name": "Spokes"
+                        },
+                        {
+                            "range": [33, 54],
+                            "name": "Night Sky"
+                        },
+                        {
+                            "range": [55, 75],
+                            "name": "Hole Ray"
+                        },
+                        {
+                            "range": [76, 97],
+                            "name": "Triangle"
+                        },
+                        {
+                            "range": [98, 119],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [120, 141],
+                            "name": "Spokes"
+                        },
+                        {
+                            "range": [142, 163],
+                            "name": "Night Sky"
+                        },
+                        {
+                            "range": [164, 184],
+                            "name": "Hole Ray"
+                        },
+                        {
+                            "range": [185, 206],
+                            "name": "Triangle"
+                        },
+                        {
+                            "range": [207, 216],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [217, 255],
+                            "name": "Speed"
+                        }
+                    ]
+                },
+                "FX Index": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "FX Index fine": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "Focus T": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Color T": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Beam T": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "FX Time": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ],
+                [
+                    "FX Index",
+                    "FX Index fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "21-channel Mode",
+                    "shortName": "21ch",
+                    "channels": [
+                        "Intensity",
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "Vari*Brite",
+                        "Zoom",
+                        "CTO",
+                        "Cyan",
+                        "Yellow",
+                        "Magenta",
+                        "Color 1",
+                        "Color 2",
+                        "Strobe",
+                        "FX Wheel",
+                        "FX Index",
+                        "FX Index fine",
+                        "Focus T",
+                        "Color T",
+                        "Beam T",
+                        "FX Time"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Varilite",
+            "name": "Vl5 Arc Mode 3",
+            "shortName": "Vl5am3",
+            "physical": {
+                "dimensions": [460, 460, 680]
+            },
+            "availableChannels": {
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 0,
+                    "highlightValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 0,
+                    "highlightValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Cyan": {
+                    "type": "SingleColor",
+                    "color": "Cyan",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Yellow": {
+                    "type": "SingleColor",
+                    "color": "Yellow",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Magenta": {
+                    "type": "SingleColor",
+                    "color": "Magenta",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Diffusion": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Reset": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 83],
+                            "name": "idle",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [84, 251],
+                            "name": "reset",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [252, 167],
+                            "name": "start",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [168, 255],
+                            "name": "douse",
+                            "showInMenu": false
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "10-channel Mode",
+                    "shortName": "10ch",
+                    "channels": [
+                        "Intensity",
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "Cyan",
+                        "Yellow",
+                        "Magenta",
+                        "Diffusion",
+                        "Reset"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Varilite",
+            "name": "Vl5 Arc Mode 5",
+            "shortName": "Vl5am5",
+            "physical": {
+                "dimensions": [460, 460, 680]
+            },
+            "availableChannels": {
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 0,
+                    "highlightValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 0,
+                    "highlightValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Cyan": {
+                    "type": "SingleColor",
+                    "color": "Cyan",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Yellow": {
+                    "type": "SingleColor",
+                    "color": "Yellow",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Magenta": {
+                    "type": "SingleColor",
+                    "color": "Magenta",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Diffusion": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Reset": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 83],
+                            "name": "idle",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [84, 251],
+                            "name": "reset",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [252, 167],
+                            "name": "start",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [168, 255],
+                            "name": "douse",
+                            "showInMenu": false
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "14-channel Mode",
+                    "shortName": "14ch",
+                    "channels": [
+                        "Intensity",
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "Cyan",
+                        "Yellow",
+                        "Magenta",
+                        "Diffusion",
+                        "Reset"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Varilite",
+            "name": "Vl5 Mode 3",
+            "shortName": "Vl5m3",
+            "physical": {
+                "dimensions": [460, 460, 680]
+            },
+            "availableChannels": {
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "invert": true,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 0,
+                    "highlightValue": 0,
+                    "invert": true,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 0,
+                    "highlightValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Cyan": {
+                    "type": "SingleColor",
+                    "color": "Cyan",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Yellow": {
+                    "type": "SingleColor",
+                    "color": "Yellow",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Magenta": {
+                    "type": "SingleColor",
+                    "color": "Magenta",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Diffusion": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Reset": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 83],
+                            "name": "idle",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [84, 255],
+                            "name": "reset",
+                            "showInMenu": false
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "10-channel Mode",
+                    "shortName": "10ch",
+                    "channels": [
+                        "Intensity",
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "Cyan",
+                        "Yellow",
+                        "Magenta",
+                        "Diffusion",
+                        "Reset"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Varilite",
+            "name": "Vl5 Mode 3 Split",
+            "shortName": "Vl5m3S",
+            "comment": "Mode 3. Seperate Intensity Channel. No color mixing",
+            "physical": {
+                "dimensions": [460, 460, 680]
+            },
+            "availableChannels": {
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "invert": true,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 0,
+                    "highlightValue": 0,
+                    "invert": true,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 0,
+                    "highlightValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Amber": {
+                    "type": "SingleColor",
+                    "color": "Amber",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Magenta": {
+                    "type": "SingleColor",
+                    "color": "Magenta",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Diffusion": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Reset": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 83],
+                            "name": "idle",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [84, 255],
+                            "name": "reset",
+                            "showInMenu": false
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "10-channel Mode",
+                    "shortName": "10ch",
+                    "channels": [
+                        "Intensity",
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "Blue",
+                        "Amber",
+                        "Magenta",
+                        "Diffusion",
+                        "Reset"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Varilite",
+            "name": "Vl5 Mode 3 Split CMY",
+            "shortName": "Vl5m3Sx",
+            "comment": "Mode 3. Seperate Intensity Channel. Corrected CMY Color Mixing",
+            "physical": {
+                "dimensions": [460, 460, 680]
+            },
+            "availableChannels": {
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "invert": true,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 0,
+                    "highlightValue": 0,
+                    "invert": true,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 0,
+                    "highlightValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Cyan": {
+                    "type": "SingleColor",
+                    "color": "Cyan",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Yellow": {
+                    "type": "SingleColor",
+                    "color": "Yellow",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Magenta": {
+                    "type": "SingleColor",
+                    "color": "Magenta",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Diffusion": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Reset": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 83],
+                            "name": "idle",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [84, 255],
+                            "name": "reset",
+                            "showInMenu": false
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "10-channel Mode",
+                    "shortName": "10ch",
+                    "channels": [
+                        "Intensity",
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "Cyan",
+                        "Yellow",
+                        "Magenta",
+                        "Diffusion",
+                        "Reset"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Varilite",
+            "name": "Vl5 Mode 5",
+            "shortName": "Vl5m5",
+            "physical": {
+                "dimensions": [460, 460, 680]
+            },
+            "availableChannels": {
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "invert": true,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 0,
+                    "highlightValue": 0,
+                    "invert": true,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 0,
+                    "highlightValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Cyan": {
+                    "type": "SingleColor",
+                    "color": "Cyan",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Yellow": {
+                    "type": "SingleColor",
+                    "color": "Yellow",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Magenta": {
+                    "type": "SingleColor",
+                    "color": "Magenta",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Diffusion": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Reset": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 83],
+                            "name": "idle",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [84, 255],
+                            "name": "reset",
+                            "showInMenu": false
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "14-channel Mode",
+                    "shortName": "14ch",
+                    "channels": [
+                        "Intensity",
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "Cyan",
+                        "Yellow",
+                        "Magenta",
+                        "Diffusion",
+                        "Reset"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Varilite",
+            "name": "VL6 Mode 5",
+            "shortName": "VL6",
+            "physical": {
+                "dimensions": [508, 508, 673]
+            },
+            "availableChannels": {
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 32768,
+                    "highlightValue": 32768,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 32758,
+                    "highlightValue": 32758,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Gobo": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 20],
+                            "name": "open"
+                        },
+                        {
+                            "range": [21, 40],
+                            "name": "Pebbles"
+                        },
+                        {
+                            "range": [41, 61],
+                            "name": "Globular Breaku"
+                        },
+                        {
+                            "range": [62, 81],
+                            "name": "Circle"
+                        },
+                        {
+                            "range": [82, 101],
+                            "name": "Night Sky"
+                        },
+                        {
+                            "range": [102, 122],
+                            "name": "Leaves"
+                        },
+                        {
+                            "range": [123, 142],
+                            "name": "Vertical Bars"
+                        },
+                        {
+                            "range": [143, 163],
+                            "name": "Horizontal Bars"
+                        },
+                        {
+                            "range": [164, 183],
+                            "name": "Block Breakup"
+                        },
+                        {
+                            "range": [184, 203],
+                            "name": "Waves"
+                        },
+                        {
+                            "range": [204, 224],
+                            "name": "Simulated Trian"
+                        },
+                        {
+                            "range": [225, 244],
+                            "name": "Circle of holes"
+                        },
+                        {
+                            "range": [245, 247],
+                            "name": "Spin1"
+                        },
+                        {
+                            "range": [248, 249],
+                            "name": "Spin2"
+                        },
+                        {
+                            "range": [250, 252],
+                            "name": "Spin3"
+                        },
+                        {
+                            "range": [253, 254],
+                            "name": "Spin4"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "Spin5"
+                        }
+                    ]
+                },
+                "Color": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 20],
+                            "name": "open"
+                        },
+                        {
+                            "range": [21, 40],
+                            "name": "Magenta",
+                            "color": "#ca1f7b"
+                        },
+                        {
+                            "range": [41, 61],
+                            "name": "Cool Pink"
+                        },
+                        {
+                            "range": [62, 81],
+                            "name": "Light Red"
+                        },
+                        {
+                            "range": [82, 101],
+                            "name": "Flesh Pink"
+                        },
+                        {
+                            "range": [102, 122],
+                            "name": "Orange",
+                            "color": "#ff7f00"
+                        },
+                        {
+                            "range": [123, 142],
+                            "name": "Yellow",
+                            "color": "#ffff00"
+                        },
+                        {
+                            "range": [143, 163],
+                            "name": "Green",
+                            "color": "#00ff00"
+                        },
+                        {
+                            "range": [164, 183],
+                            "name": "Blue-Green"
+                        },
+                        {
+                            "range": [184, 203],
+                            "name": "Dark Blue",
+                            "color": "#00008b"
+                        },
+                        {
+                            "range": [204, 224],
+                            "name": "Deep Lavender"
+                        },
+                        {
+                            "range": [225, 244],
+                            "name": "Congo Blue"
+                        },
+                        {
+                            "range": [245, 247],
+                            "name": "Spin1"
+                        },
+                        {
+                            "range": [248, 249],
+                            "name": "Spin2"
+                        },
+                        {
+                            "range": [250, 252],
+                            "name": "Spin3"
+                        },
+                        {
+                            "range": [253, 254],
+                            "name": "Spin4"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "Spin5"
+                        }
+                    ]
+                },
+                "Iris": {
+                    "type": "Beam",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Lens": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Strobe": {
+                    "type": "Strobe",
+                    "capabilities": [
+                        {
+                            "range": [0, 2],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [3, 5],
+                            "name": "Closed"
+                        },
+                        {
+                            "range": [6, 12],
+                            "name": "Random"
+                        },
+                        {
+                            "range": [13, 255],
+                            "name": "strobe"
+                        }
+                    ]
+                },
+                "Reset": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 83],
+                            "name": "idle",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [84, 251],
+                            "name": "reset",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [252, 167],
+                            "name": "start",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [168, 255],
+                            "name": "douse",
+                            "showInMenu": false
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "14-channel Mode",
+                    "shortName": "14ch",
+                    "channels": [
+                        "Intensity",
+                        "Pan",
+                        "Tilt",
+                        "Gobo",
+                        "Color",
+                        "Iris",
+                        "Lens",
+                        "Strobe",
+                        "Reset"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Varilite",
+            "name": "VL6B Mode 7",
+            "shortName": "VL6B",
+            "physical": {
+                "dimensions": [508, 508, 673]
+            },
+            "availableChannels": {
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 0,
+                    "highlightValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 246,
+                    "highlightValue": 246,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Gobo": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 20],
+                            "name": "open"
+                        },
+                        {
+                            "range": [21, 40],
+                            "name": "Pebbles"
+                        },
+                        {
+                            "range": [41, 61],
+                            "name": "Globular Breaku"
+                        },
+                        {
+                            "range": [62, 81],
+                            "name": "Circle"
+                        },
+                        {
+                            "range": [82, 101],
+                            "name": "Night Sky"
+                        },
+                        {
+                            "range": [102, 122],
+                            "name": "Leaves"
+                        },
+                        {
+                            "range": [123, 142],
+                            "name": "Vertical Bars"
+                        },
+                        {
+                            "range": [143, 163],
+                            "name": "Horizontal Bars"
+                        },
+                        {
+                            "range": [164, 183],
+                            "name": "Block Breakup"
+                        },
+                        {
+                            "range": [184, 203],
+                            "name": "Waves"
+                        },
+                        {
+                            "range": [204, 224],
+                            "name": "Simulated Trian"
+                        },
+                        {
+                            "range": [225, 244],
+                            "name": "Circle of holes"
+                        },
+                        {
+                            "range": [245, 247],
+                            "name": "Spin1"
+                        },
+                        {
+                            "range": [248, 249],
+                            "name": "Spin2"
+                        },
+                        {
+                            "range": [250, 252],
+                            "name": "Spin3"
+                        },
+                        {
+                            "range": [253, 254],
+                            "name": "Spin4"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "Spin5"
+                        }
+                    ]
+                },
+                "Color": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 20],
+                            "name": "open"
+                        },
+                        {
+                            "range": [21, 40],
+                            "name": "Magenta",
+                            "color": "#ca1f7b"
+                        },
+                        {
+                            "range": [41, 61],
+                            "name": "Cool Pink"
+                        },
+                        {
+                            "range": [62, 81],
+                            "name": "Light Red"
+                        },
+                        {
+                            "range": [82, 101],
+                            "name": "Flesh Pink"
+                        },
+                        {
+                            "range": [102, 122],
+                            "name": "Orange",
+                            "color": "#ff7f00"
+                        },
+                        {
+                            "range": [123, 142],
+                            "name": "Yellow",
+                            "color": "#ffff00"
+                        },
+                        {
+                            "range": [143, 163],
+                            "name": "Green",
+                            "color": "#00ff00"
+                        },
+                        {
+                            "range": [164, 183],
+                            "name": "Blue-Green"
+                        },
+                        {
+                            "range": [184, 203],
+                            "name": "Dark Blue",
+                            "color": "#00008b"
+                        },
+                        {
+                            "range": [204, 224],
+                            "name": "Deep Lavender"
+                        },
+                        {
+                            "range": [225, 244],
+                            "name": "Congo Blue"
+                        },
+                        {
+                            "range": [245, 247],
+                            "name": "Spin1"
+                        },
+                        {
+                            "range": [248, 249],
+                            "name": "Spin2"
+                        },
+                        {
+                            "range": [250, 252],
+                            "name": "Spin3"
+                        },
+                        {
+                            "range": [253, 254],
+                            "name": "Spin4"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "Spin5"
+                        }
+                    ]
+                },
+                "Iris": {
+                    "type": "Beam",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Lens": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Strobe": {
+                    "type": "Strobe",
+                    "capabilities": [
+                        {
+                            "range": [0, 2],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [3, 5],
+                            "name": "Closed"
+                        },
+                        {
+                            "range": [6, 12],
+                            "name": "Random"
+                        },
+                        {
+                            "range": [13, 255],
+                            "name": "strobe"
+                        }
+                    ]
+                },
+                "Zoom": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Gobo Rot.": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 26],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [27, 52],
+                            "name": "Facet Prism"
+                        },
+                        {
+                            "range": [53, 76],
+                            "name": "Circle of ovals"
+                        },
+                        {
+                            "range": [77, 102],
+                            "name": "Spiral"
+                        },
+                        {
+                            "range": [103, 128],
+                            "name": "Spiral Stones"
+                        },
+                        {
+                            "range": [129, 155],
+                            "name": "Pinwheel"
+                        },
+                        {
+                            "range": [156, 255],
+                            "name": "Open"
+                        }
+                    ]
+                },
+                "Index": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 201],
+                            "name": "Index"
+                        },
+                        {
+                            "range": [205, 225],
+                            "name": "CW"
+                        },
+                        {
+                            "range": [229, 232],
+                            "name": "Stop"
+                        },
+                        {
+                            "range": [232, 255],
+                            "name": "CCW"
+                        }
+                    ]
+                },
+                "Reset": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 83],
+                            "name": "idle",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [84, 251],
+                            "name": "reset",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [252, 167],
+                            "name": "start",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [168, 255],
+                            "name": "douse",
+                            "showInMenu": false
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "17-channel Mode",
+                    "shortName": "17ch",
+                    "channels": [
+                        "Intensity",
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "Gobo",
+                        "Color",
+                        "Iris",
+                        "Lens",
+                        "Strobe",
+                        "Zoom",
+                        "Gobo Rot.",
+                        "Index",
+                        "Reset"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Varilite",
+            "name": "VL6m3",
+            "shortName": "VL6.1",
+            "comment": "Mode 3 16bit",
+            "physical": {
+                "dimensions": [508, 508, 673]
+            },
+            "availableChannels": {
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 0,
+                    "highlightValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 127,
+                    "highlightValue": 127,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 246,
+                    "highlightValue": 246,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Gobo": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 20],
+                            "name": "open"
+                        },
+                        {
+                            "range": [21, 40],
+                            "name": "Pebbles"
+                        },
+                        {
+                            "range": [41, 61],
+                            "name": "Globular Breaku"
+                        },
+                        {
+                            "range": [62, 81],
+                            "name": "Circle"
+                        },
+                        {
+                            "range": [82, 101],
+                            "name": "Night Sky"
+                        },
+                        {
+                            "range": [102, 122],
+                            "name": "Leaves"
+                        },
+                        {
+                            "range": [123, 142],
+                            "name": "Vertical Bars"
+                        },
+                        {
+                            "range": [143, 163],
+                            "name": "Horizontal Bars"
+                        },
+                        {
+                            "range": [164, 183],
+                            "name": "Block Breakup"
+                        },
+                        {
+                            "range": [184, 203],
+                            "name": "Waves"
+                        },
+                        {
+                            "range": [204, 224],
+                            "name": "Simulated Trian"
+                        },
+                        {
+                            "range": [225, 244],
+                            "name": "Circle of holes"
+                        },
+                        {
+                            "range": [245, 247],
+                            "name": "Spin1"
+                        },
+                        {
+                            "range": [248, 249],
+                            "name": "Spin2"
+                        },
+                        {
+                            "range": [250, 252],
+                            "name": "Spin3"
+                        },
+                        {
+                            "range": [253, 254],
+                            "name": "Spin4"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "Spin5"
+                        }
+                    ]
+                },
+                "Color": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 20],
+                            "name": "open"
+                        },
+                        {
+                            "range": [21, 40],
+                            "name": "Magenta",
+                            "color": "#ca1f7b"
+                        },
+                        {
+                            "range": [41, 61],
+                            "name": "Cool Pink"
+                        },
+                        {
+                            "range": [62, 81],
+                            "name": "Light Red"
+                        },
+                        {
+                            "range": [82, 101],
+                            "name": "Flesh Pink"
+                        },
+                        {
+                            "range": [102, 122],
+                            "name": "Orange",
+                            "color": "#ff7f00"
+                        },
+                        {
+                            "range": [123, 142],
+                            "name": "Yellow",
+                            "color": "#ffff00"
+                        },
+                        {
+                            "range": [143, 163],
+                            "name": "Green",
+                            "color": "#00ff00"
+                        },
+                        {
+                            "range": [164, 183],
+                            "name": "Blue-Green"
+                        },
+                        {
+                            "range": [184, 203],
+                            "name": "Dark Blue",
+                            "color": "#00008b"
+                        },
+                        {
+                            "range": [204, 224],
+                            "name": "Deep Lavender"
+                        },
+                        {
+                            "range": [225, 244],
+                            "name": "Congo Blue"
+                        },
+                        {
+                            "range": [245, 247],
+                            "name": "Spin1"
+                        },
+                        {
+                            "range": [248, 249],
+                            "name": "Spin2"
+                        },
+                        {
+                            "range": [250, 252],
+                            "name": "Spin3"
+                        },
+                        {
+                            "range": [253, 254],
+                            "name": "Spin4"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "Spin5"
+                        }
+                    ]
+                },
+                "Iris": {
+                    "type": "Beam",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Lens": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Strobe": {
+                    "type": "Strobe",
+                    "capabilities": [
+                        {
+                            "range": [0, 2],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [3, 5],
+                            "name": "Closed"
+                        },
+                        {
+                            "range": [6, 12],
+                            "name": "Random"
+                        },
+                        {
+                            "range": [13, 255],
+                            "name": "strobe"
+                        }
+                    ]
+                },
+                "Reset": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 83],
+                            "name": "idle",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [84, 251],
+                            "name": "reset",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [252, 167],
+                            "name": "start",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [168, 255],
+                            "name": "douse",
+                            "showInMenu": false
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "14-channel Mode",
+                    "shortName": "14ch",
+                    "channels": [
+                        "Intensity",
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "Gobo",
+                        "Color",
+                        "Iris",
+                        "Lens",
+                        "Strobe",
+                        "Reset"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Varilite",
+            "name": "VL7 Mode 7",
+            "shortName": "VL7",
+            "physical": {
+                "dimensions": [660, 660, 775]
+            },
+            "availableChannels": {
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 0,
+                    "highlightValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 0,
+                    "highlightValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Color1": {
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Color Sat1": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Color2": {
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Solor Sat2": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Iris": {
+                    "type": "Beam",
+                    "defaultValue": 255,
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Lens": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Zoom": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Strobe": {
+                    "type": "Strobe",
+                    "capabilities": [
+                        {
+                            "range": [0, 2],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [3, 5],
+                            "name": "Closed"
+                        },
+                        {
+                            "range": [6, 12],
+                            "name": "Random"
+                        },
+                        {
+                            "range": [13, 255],
+                            "name": "strobe"
+                        }
+                    ]
+                },
+                "Gobo": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 20],
+                            "name": "open"
+                        },
+                        {
+                            "range": [21, 40],
+                            "name": "Pebbles"
+                        },
+                        {
+                            "range": [41, 61],
+                            "name": "Globular Breaku"
+                        },
+                        {
+                            "range": [62, 81],
+                            "name": "Circle"
+                        },
+                        {
+                            "range": [82, 101],
+                            "name": "Night Sky"
+                        },
+                        {
+                            "range": [102, 122],
+                            "name": "Leaves"
+                        },
+                        {
+                            "range": [123, 142],
+                            "name": "Vertical Bars"
+                        },
+                        {
+                            "range": [143, 163],
+                            "name": "Horizontal Bars"
+                        },
+                        {
+                            "range": [164, 183],
+                            "name": "Block Breakup"
+                        },
+                        {
+                            "range": [184, 203],
+                            "name": "Waves"
+                        },
+                        {
+                            "range": [204, 224],
+                            "name": "Simulated Trian"
+                        },
+                        {
+                            "range": [225, 244],
+                            "name": "Circle of holes"
+                        },
+                        {
+                            "range": [245, 247],
+                            "name": "Spin1"
+                        },
+                        {
+                            "range": [248, 249],
+                            "name": "Spin2"
+                        },
+                        {
+                            "range": [250, 252],
+                            "name": "Spin3"
+                        },
+                        {
+                            "range": [253, 254],
+                            "name": "Spin4"
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "Spin5"
+                        }
+                    ]
+                },
+                "Gobo Rot.": {
+                    "type": "Gobo",
+                    "capabilities": [
+                        {
+                            "range": [0, 26],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [27, 52],
+                            "name": "Facet Prism"
+                        },
+                        {
+                            "range": [53, 76],
+                            "name": "Circle of ovals"
+                        },
+                        {
+                            "range": [77, 102],
+                            "name": "Spiral"
+                        },
+                        {
+                            "range": [103, 128],
+                            "name": "Spiral Stones"
+                        },
+                        {
+                            "range": [129, 155],
+                            "name": "Pinwheel"
+                        },
+                        {
+                            "range": [156, 255],
+                            "name": "Open"
+                        }
+                    ]
+                },
+                "Index": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 201],
+                            "name": "Index"
+                        },
+                        {
+                            "range": [205, 225],
+                            "name": "CW"
+                        },
+                        {
+                            "range": [229, 232],
+                            "name": "Stop"
+                        },
+                        {
+                            "range": [232, 255],
+                            "name": "CCW"
+                        }
+                    ]
+                },
+                "Reset": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 83],
+                            "name": "idle",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [84, 251],
+                            "name": "reset",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [252, 167],
+                            "name": "start",
+                            "showInMenu": false
+                        },
+                        {
+                            "range": [168, 255],
+                            "name": "douse",
+                            "showInMenu": false
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "17-channel Mode",
+                    "shortName": "17ch",
+                    "channels": [
+                        "Intensity",
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "Color1",
+                        "Color Sat1",
+                        "Color2",
+                        "Solor Sat2",
+                        "Iris",
+                        "Lens",
+                        "Zoom",
+                        "Strobe",
+                        "Gobo",
+                        "Gobo Rot.",
+                        "Index",
+                        "Reset"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Varilite",
+            "name": "VLX_Wash_Mode1",
+            "shortName": "VLX_Wash_M1",
+            "physical": {
+                "dimensions": [443, 443, 462]
+            },
+            "availableChannels": {
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 0,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ],
+                    "defaultValue": null
+                },
+                "Intensity fine": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ],
+                    "defaultValue": null
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 0,
+                    "highlightValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "highlightValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 0,
+                    "highlightValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ]
+                },
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ],
+                    "defaultValue": null
+                },
+                "Red fine": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ],
+                    "defaultValue": null
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ],
+                    "defaultValue": null
+                },
+                "Green fine": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ],
+                    "defaultValue": null
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ],
+                    "defaultValue": null
+                },
+                "Blue fine": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ],
+                    "defaultValue": null
+                },
+                "White": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ],
+                    "defaultValue": null
+                },
+                "White fine": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ],
+                    "defaultValue": null
+                },
+                "Beam Spreader": {
+                    "type": "Beam",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Strobe": {
+                    "type": "Strobe",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 2],
+                            "name": "Open"
+                        },
+                        {
+                            "range": [3, 5],
+                            "name": "Closed"
+                        },
+                        {
+                            "range": [6, 7],
+                            "name": "Sl. Random"
+                        },
+                        {
+                            "range": [8, 10],
+                            "name": "Me. Random"
+                        },
+                        {
+                            "range": [11, 12],
+                            "name": "Fa. Random"
+                        },
+                        {
+                            "range": [13, 127],
+                            "name": "Strobe Range"
+                        },
+                        {
+                            "range": [128, 129],
+                            "name": "Pulse Slow Rnd"
+                        },
+                        {
+                            "range": [130, 131],
+                            "name": "Pulse Med Rnd"
+                        },
+                        {
+                            "range": [132, 133],
+                            "name": "Pulse fast Rnd"
+                        },
+                        {
+                            "range": [134, 191],
+                            "name": "Pulse Range"
+                        },
+                        {
+                            "range": [192, 193],
+                            "name": "Pulse-Slow Rnd"
+                        },
+                        {
+                            "range": [194, 195],
+                            "name": "Pulse- Med Rnd"
+                        },
+                        {
+                            "range": [196, 197],
+                            "name": "Pulse-fast Rnd"
+                        },
+                        {
+                            "range": [198, 255],
+                            "name": "Pulse-Range"
+                        }
+                    ]
+                },
+                "Intensity Time": {
+                    "type": "Beam",
+                    "defaultValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Focus Time": {
+                    "type": "Beam",
+                    "defaultValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Color Time": {
+                    "type": "Beam",
+                    "defaultValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Beam Time": {
+                    "type": "Beam",
+                    "defaultValue": 255,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Control": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 4],
+                            "name": "Default"
+                        },
+                        {
+                            "range": [5, 7],
+                            "name": "Reset all"
+                        },
+                        {
+                            "range": [11, 13],
+                            "name": "Quite Mode"
+                        },
+                        {
+                            "range": [14, 16],
+                            "name": "Levl lightMode "
+                        },
+                        {
+                            "range": [17, 19],
+                            "name": "Const Fan Mode"
+                        },
+                        {
+                            "range": [20, 22],
+                            "name": "Norm Mode"
+                        },
+                        {
+                            "range": [34, 35],
+                            "name": "Dimm Cur square"
+                        },
+                        {
+                            "range": [81, 87],
+                            "name": "Full Lum. Res."
+                        },
+                        {
+                            "range": [116, 117],
+                            "name": "Cal Col off"
+                        },
+                        {
+                            "range": [118, 120],
+                            "name": "ReCal on"
+                        },
+                        {
+                            "range": [245, 249],
+                            "name": "Fixture sleep"
+                        },
+                        {
+                            "range": [250, 255],
+                            "name": "Fixture wake up"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Intensity",
+                    "Intensity fine"
+                ],
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ],
+                [
+                    "Red",
+                    "Red fine"
+                ],
+                [
+                    "Green",
+                    "Green fine"
+                ],
+                [
+                    "Blue",
+                    "Blue fine"
+                ],
+                [
+                    "White",
+                    "White fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "23-channel Mode",
+                    "shortName": "23ch",
+                    "channels": [
+                        "Intensity",
+                        "Intensity fine",
+                        "Pan",
+                        "Pan fine",
+                        "Tilt",
+                        "Tilt fine",
+                        "Red",
+                        "Red fine",
+                        "Green",
+                        "Green fine",
+                        "Blue",
+                        "Blue fine",
+                        "White",
+                        "White fine",
+                        null,
+                        null,
+                        "Beam Spreader",
+                        "Strobe",
+                        "Intensity Time",
+                        "Focus Time",
+                        "Color Time",
+                        "Beam Time",
+                        "Control"
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/fixtures/imports/ecue-MainLibrary/Xilver.json
+++ b/fixtures/imports/ecue-MainLibrary/Xilver.json
@@ -1,0 +1,433 @@
+{
+    "manufacturers": {
+        "Xilver": {
+            "name": "Xilver",
+            "website": "www.xilver.nl"
+        }
+    },
+    "fixtures": [
+        {
+            "manufacturer": "Xilver",
+            "name": "Droplet",
+            "shortName": "Droplet",
+            "comment": "RGB Normal Mode - DIP 10=1; 11=0",
+            "physical": {
+                "dimensions": [80, 80, 58],
+                "weight": 0.2,
+                "power": 5
+            },
+            "availableChannels": {
+                "Reset": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 249],
+                            "name": "nofunction"
+                        },
+                        {
+                            "range": [250, 255],
+                            "name": "reset"
+                        }
+                    ]
+                },
+                "Pan": {
+                    "type": "Pan",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Pan fine": {
+                    "type": "Pan",
+                    "defaultValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Tilt": {
+                    "type": "Tilt",
+                    "defaultValue": 128,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Tilt fine": {
+                    "type": "Tilt",
+                    "defaultValue": 0,
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "Speed": {
+                    "type": "Speed",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Strobe": {
+                    "type": "Strobe",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 4],
+                            "name": "full"
+                        },
+                        {
+                            "range": [5, 204],
+                            "name": "slow"
+                        },
+                        {
+                            "range": [205, 255],
+                            "name": "fast"
+                        }
+                    ]
+                },
+                "strobe_l": {
+                    "type": "Strobe",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Pan",
+                    "Pan fine"
+                ],
+                [
+                    "Tilt",
+                    "Tilt fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "12-channel Mode",
+                    "shortName": "12ch",
+                    "channels": [
+                        "Reset",
+                        "Pan",
+                        "Tilt",
+                        "Speed",
+                        "Pan fine",
+                        "Tilt fine",
+                        "Strobe",
+                        "strobe_l",
+                        "Red",
+                        "Green",
+                        "Blue",
+                        "Intensity"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Xilver",
+            "name": "Sparkle HSI",
+            "shortName": "SparkleHSI",
+            "comment": "Sparkle RGB with Dipswitch Nr. 10 set to 0 (HSI)",
+            "physical": {
+                "dimensions": [100, 100, 120],
+                "weight": 1,
+                "power": 20
+            },
+            "availableChannels": {
+                "Reset": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 249],
+                            "name": "Reserved"
+                        },
+                        {
+                            "range": [250, 255],
+                            "name": "Reset (hold 5s)"
+                        }
+                    ]
+                },
+                "StrobeFrq": {
+                    "type": "Strobe",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 4],
+                            "name": "no strobe"
+                        },
+                        {
+                            "range": [5, 204],
+                            "name": "Strobe 1-25Hz"
+                        },
+                        {
+                            "range": [205, 255],
+                            "name": "Strobe 25-50Hz"
+                        }
+                    ]
+                },
+                "StrobeDur": {
+                    "type": "Strobe",
+                    "crossfade": true
+                },
+                "Hue": {
+                    "type": "MultiColor",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "Red",
+                            "color": "#ff0000"
+                        },
+                        {
+                            "range": [1, 42],
+                            "name": "Red <> Yellow",
+                            "center": true
+                        },
+                        {
+                            "range": [43, 43],
+                            "name": "Yellow",
+                            "color": "#ffff00"
+                        },
+                        {
+                            "range": [44, 84],
+                            "name": "Yellow <> Green",
+                            "center": true
+                        },
+                        {
+                            "range": [85, 85],
+                            "name": "Green",
+                            "color": "#00ff00"
+                        },
+                        {
+                            "range": [86, 127],
+                            "name": "Green <> Cyan",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 128],
+                            "name": "Cyan",
+                            "color": "#00ffff"
+                        },
+                        {
+                            "range": [129, 170],
+                            "name": "Cyan <> Blue",
+                            "center": true
+                        },
+                        {
+                            "range": [171, 171],
+                            "name": "Blue",
+                            "color": "#0000ff"
+                        },
+                        {
+                            "range": [172, 212],
+                            "name": "Blue <> Magenta",
+                            "center": true
+                        },
+                        {
+                            "range": [213, 213],
+                            "name": "Magenta",
+                            "color": "#ca1f7b"
+                        },
+                        {
+                            "range": [214, 254],
+                            "name": "Magenta <> Red",
+                            "center": true
+                        },
+                        {
+                            "range": [255, 255],
+                            "name": "Red",
+                            "color": "#ff0000"
+                        }
+                    ]
+                },
+                "Saturation": {
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "crossfade": true
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                }
+            },
+            "modes": [
+                {
+                    "name": "6-channel Mode",
+                    "shortName": "6ch",
+                    "channels": [
+                        "Reset",
+                        "StrobeFrq",
+                        "StrobeDur",
+                        "Hue",
+                        "Saturation",
+                        "Intensity"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Xilver",
+            "name": "Sparkle RGB",
+            "shortName": "SparkleRGB",
+            "comment": "Sparkle RGB with Dipswitch Nr. 10 set to 1 (RGB)",
+            "physical": {
+                "dimensions": [100, 100, 120],
+                "weight": 1,
+                "power": 20
+            },
+            "availableChannels": {
+                "Reset": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 249],
+                            "name": "Reserved"
+                        },
+                        {
+                            "range": [250, 255],
+                            "name": "Reset (hold 5s)"
+                        }
+                    ]
+                },
+                "StrobeFrq": {
+                    "type": "Strobe",
+                    "crossfade": true,
+                    "capabilities": [
+                        {
+                            "range": [0, 4],
+                            "name": "no strobe"
+                        },
+                        {
+                            "range": [5, 204],
+                            "name": "strobe 1-25Hz"
+                        },
+                        {
+                            "range": [205, 255],
+                            "name": "strobe 25-50Hz"
+                        }
+                    ]
+                },
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP"
+                }
+            },
+            "modes": [
+                {
+                    "name": "6-channel Mode",
+                    "shortName": "6ch",
+                    "channels": [
+                        "Reset",
+                        "StrobeFrq",
+                        "Red",
+                        "Green",
+                        "Blue",
+                        "Intensity"
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/fixtures/imports/ecue-MainLibrary/ecue.json
+++ b/fixtures/imports/ecue-MainLibrary/ecue.json
@@ -1,0 +1,873 @@
+{
+    "manufacturers": {
+        "ecue": {
+            "name": "ecue",
+            "website": "www.ecue.com"
+        }
+    },
+    "fixtures": [
+        {
+            "manufacturer": "ecue",
+            "name": "DMX to DALI Converter",
+            "shortName": "DMXtoDALI",
+            "comment": "cd",
+            "physical": {
+                "dimensions": [110, 80, 60]
+            },
+            "availableChannels": {
+                "Channel 1": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Channel 2": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Channel 3": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Channel 4": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Channel 5": {
+                    "type": "Beam",
+                    "crossfade": true
+                },
+                "Channel 6": {
+                    "type": "Beam",
+                    "crossfade": true
+                }
+            },
+            "modes": [
+                {
+                    "name": "6-channel Mode",
+                    "shortName": "6ch",
+                    "channels": [
+                        "Channel 1",
+                        "Channel 2",
+                        "Channel 3",
+                        "Channel 4",
+                        "Channel 5",
+                        "Channel 6"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "ecue",
+            "name": "DMX2DALI 2010",
+            "shortName": "DMX2DALI",
+            "comment": "cd",
+            "physical": {
+                "dimensions": [110, 80, 60]
+            },
+            "availableChannels": {
+                "Channel 1": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Channel 2": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Channel 3": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Channel 4": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Channel 5": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "Channel 6": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true
+                }
+            },
+            "modes": [
+                {
+                    "name": "6-channel Mode",
+                    "shortName": "6ch",
+                    "channels": [
+                        "Channel 1",
+                        "Channel 2",
+                        "Channel 3",
+                        "Channel 4",
+                        "Channel 5",
+                        "Channel 6"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "ecue",
+            "name": "ecue CAM",
+            "shortName": "ecueCam",
+            "comment": "3D Camera",
+            "physical": {
+                "dimensions": [100, 100, 100]
+            },
+            "availableChannels": {
+                "Intensity": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "defaultValue": null
+                },
+                "Intensity fine": {
+                    "type": "Intensity",
+                    "warning": "Please check type!",
+                    "highlightValue": 255,
+                    "crossfade": true,
+                    "precendence": "HTP",
+                    "defaultValue": null
+                },
+                "PosX": {
+                    "type": "Intensity",
+                    "defaultValue": 127,
+                    "crossfade": true,
+                    "highlightValue": null
+                },
+                "PosX fine": {
+                    "type": "Intensity",
+                    "defaultValue": 255,
+                    "crossfade": true,
+                    "highlightValue": null
+                },
+                "PosY": {
+                    "type": "Intensity",
+                    "defaultValue": 127,
+                    "crossfade": true,
+                    "highlightValue": null
+                },
+                "PosY fine": {
+                    "type": "Intensity",
+                    "defaultValue": 255,
+                    "crossfade": true,
+                    "highlightValue": null
+                },
+                "PosZ": {
+                    "type": "Intensity",
+                    "defaultValue": 127,
+                    "crossfade": true,
+                    "highlightValue": null
+                },
+                "PosZ fine": {
+                    "type": "Intensity",
+                    "defaultValue": 255,
+                    "crossfade": true,
+                    "highlightValue": null
+                },
+                "RotX": {
+                    "type": "Intensity",
+                    "crossfade": true,
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "RotX fine": {
+                    "type": "Intensity",
+                    "crossfade": true,
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "RotY": {
+                    "type": "Intensity",
+                    "crossfade": true,
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "RotY fine": {
+                    "type": "Intensity",
+                    "crossfade": true,
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "RotZ": {
+                    "type": "Intensity",
+                    "crossfade": true,
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "RotZ fine": {
+                    "type": "Intensity",
+                    "crossfade": true,
+                    "defaultValue": null,
+                    "highlightValue": null
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "Intensity",
+                    "Intensity fine"
+                ],
+                [
+                    "PosX",
+                    "PosX fine"
+                ],
+                [
+                    "PosY",
+                    "PosY fine"
+                ],
+                [
+                    "PosZ",
+                    "PosZ fine"
+                ],
+                [
+                    "RotX",
+                    "RotX fine"
+                ],
+                [
+                    "RotY",
+                    "RotY fine"
+                ],
+                [
+                    "RotZ",
+                    "RotZ fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "14-channel Mode",
+                    "shortName": "14ch",
+                    "channels": [
+                        "Intensity",
+                        "Intensity fine",
+                        "PosX",
+                        "PosX fine",
+                        "PosY",
+                        "PosY fine",
+                        "PosZ",
+                        "PosZ fine",
+                        "RotX",
+                        "RotX fine",
+                        "RotY",
+                        "RotY fine",
+                        "RotZ",
+                        "RotZ fine"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "ecue",
+            "name": "ecue Programmer",
+            "shortName": "ecueProg",
+            "comment": "Remote control another e:cue Programmer via DMX",
+            "physical": {
+                "dimensions": [100, 100, 100]
+            },
+            "availableChannels": {
+                "QL": {
+                    "type": "Beam"
+                },
+                "Cue": {
+                    "type": "Beam"
+                },
+                "PlayCtrl": {
+                    "type": "Beam",
+                    "defaultValue": 160,
+                    "capabilities": [
+                        {
+                            "range": [0, 63],
+                            "name": "STOP",
+                            "center": true
+                        },
+                        {
+                            "range": [64, 127],
+                            "name": "PAUSE",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 191],
+                            "name": "--",
+                            "center": true
+                        },
+                        {
+                            "range": [192, 255],
+                            "name": "PLAY",
+                            "center": true
+                        }
+                    ]
+                },
+                "SkipCtrl": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 63],
+                            "name": "SkpBk",
+                            "center": true
+                        },
+                        {
+                            "range": [64, 191],
+                            "name": "--",
+                            "center": true
+                        },
+                        {
+                            "range": [192, 255],
+                            "name": "SkipFW",
+                            "center": true
+                        }
+                    ]
+                },
+                "GM": {
+                    "type": "SingleColor",
+                    "color": "Generic",
+                    "highlightValue": 255,
+                    "crossfade": true
+                },
+                "SM1": {
+                    "type": "Beam",
+                    "defaultValue": 12,
+                    "capabilities": [
+                        {
+                            "range": [0, 20721],
+                            "name": "Slow",
+                            "warning": "Out of range!",
+                            "center": true
+                        },
+                        {
+                            "range": [20722, 20722],
+                            "name": "Normal",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [20723, 255],
+                            "name": "Faster",
+                            "warning": "Out of range!",
+                            "center": true
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "SM1 fine": {
+                    "type": "Beam",
+                    "defaultValue": 90,
+                    "capabilities": [
+                        {
+                            "range": [0, 20721],
+                            "name": "Slow",
+                            "warning": "Out of range!",
+                            "center": true
+                        },
+                        {
+                            "range": [20722, 20722],
+                            "name": "Normal",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [20723, 255],
+                            "name": "Faster",
+                            "warning": "Out of range!",
+                            "center": true
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "SM2": {
+                    "type": "Beam",
+                    "defaultValue": 12,
+                    "capabilities": [
+                        {
+                            "range": [0, 20721],
+                            "name": "Slow",
+                            "warning": "Out of range!",
+                            "center": true
+                        },
+                        {
+                            "range": [20722, 20722],
+                            "name": "Normal",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [20723, 255],
+                            "name": "Faster",
+                            "warning": "Out of range!",
+                            "center": true
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "SM2 fine": {
+                    "type": "Beam",
+                    "defaultValue": 90,
+                    "capabilities": [
+                        {
+                            "range": [0, 20721],
+                            "name": "Slow",
+                            "warning": "Out of range!",
+                            "center": true
+                        },
+                        {
+                            "range": [20722, 20722],
+                            "name": "Normal",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [20723, 255],
+                            "name": "Faster",
+                            "warning": "Out of range!",
+                            "center": true
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "SM3": {
+                    "type": "Beam",
+                    "defaultValue": 12,
+                    "capabilities": [
+                        {
+                            "range": [0, 20721],
+                            "name": "Slow",
+                            "warning": "Out of range!",
+                            "center": true
+                        },
+                        {
+                            "range": [20722, 20722],
+                            "name": "Normal",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [20723, 255],
+                            "name": "Faster",
+                            "warning": "Out of range!",
+                            "center": true
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "SM3 fine": {
+                    "type": "Beam",
+                    "defaultValue": 90,
+                    "capabilities": [
+                        {
+                            "range": [0, 20721],
+                            "name": "Slow",
+                            "warning": "Out of range!",
+                            "center": true
+                        },
+                        {
+                            "range": [20722, 20722],
+                            "name": "Normal",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [20723, 255],
+                            "name": "Faster",
+                            "warning": "Out of range!",
+                            "center": true
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "SM4": {
+                    "type": "Beam",
+                    "defaultValue": 12,
+                    "capabilities": [
+                        {
+                            "range": [0, 20721],
+                            "name": "Slow",
+                            "warning": "Out of range!",
+                            "center": true
+                        },
+                        {
+                            "range": [20722, 20722],
+                            "name": "Normal",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [20723, 255],
+                            "name": "Faster",
+                            "warning": "Out of range!",
+                            "center": true
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "SM4 fine": {
+                    "type": "Beam",
+                    "defaultValue": 90,
+                    "capabilities": [
+                        {
+                            "range": [0, 20721],
+                            "name": "Slow",
+                            "warning": "Out of range!",
+                            "center": true
+                        },
+                        {
+                            "range": [20722, 20722],
+                            "name": "Normal",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [20723, 255],
+                            "name": "Faster",
+                            "warning": "Out of range!",
+                            "center": true
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "SM5": {
+                    "type": "Beam",
+                    "defaultValue": 12,
+                    "capabilities": [
+                        {
+                            "range": [0, 20721],
+                            "name": "Slow",
+                            "warning": "Out of range!",
+                            "center": true
+                        },
+                        {
+                            "range": [20722, 20722],
+                            "name": "Normal",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [20723, 255],
+                            "name": "Faster",
+                            "warning": "Out of range!",
+                            "center": true
+                        }
+                    ],
+                    "highlightValue": null
+                },
+                "SM5 fine": {
+                    "type": "Beam",
+                    "defaultValue": 90,
+                    "capabilities": [
+                        {
+                            "range": [0, 20721],
+                            "name": "Slow",
+                            "warning": "Out of range!",
+                            "center": true
+                        },
+                        {
+                            "range": [20722, 20722],
+                            "name": "Normal",
+                            "warning": "Out of range!"
+                        },
+                        {
+                            "range": [20723, 255],
+                            "name": "Faster",
+                            "warning": "Out of range!",
+                            "center": true
+                        }
+                    ],
+                    "highlightValue": null
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "SM1",
+                    "SM1 fine"
+                ],
+                [
+                    "SM2",
+                    "SM2 fine"
+                ],
+                [
+                    "SM3",
+                    "SM3 fine"
+                ],
+                [
+                    "SM4",
+                    "SM4 fine"
+                ],
+                [
+                    "SM5",
+                    "SM5 fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "15-channel Mode",
+                    "shortName": "15ch",
+                    "channels": [
+                        "QL",
+                        "Cue",
+                        "PlayCtrl",
+                        "SkipCtrl",
+                        "GM",
+                        "SM1",
+                        "SM1 fine",
+                        "SM2",
+                        "SM2 fine",
+                        "SM3",
+                        "SM3 fine",
+                        "SM4",
+                        "SM4 fine",
+                        "SM5",
+                        "SM5 fine"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "ecue",
+            "name": "Media Player 2D",
+            "shortName": "MP2D",
+            "comment": "Remote Control e:Player2D via DMX",
+            "physical": {
+                "dimensions": [100, 100, 100]
+            },
+            "availableChannels": {
+                "Track": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "default"
+                        },
+                        {
+                            "range": [1, 1],
+                            "name": "Track 1"
+                        },
+                        {
+                            "range": [2, 2],
+                            "name": "Track 2"
+                        },
+                        {
+                            "range": [3, 3],
+                            "name": "Track 3"
+                        },
+                        {
+                            "range": [4, 4],
+                            "name": "Track 4"
+                        },
+                        {
+                            "range": [5, 5],
+                            "name": "Track 5"
+                        },
+                        {
+                            "range": [6, 6],
+                            "name": "Track 6"
+                        },
+                        {
+                            "range": [7, 7],
+                            "name": "Track 7"
+                        },
+                        {
+                            "range": [8, 8],
+                            "name": "Track 8"
+                        },
+                        {
+                            "range": [9, 9],
+                            "name": "Track 9"
+                        },
+                        {
+                            "range": [10, 10],
+                            "name": "Track 10"
+                        },
+                        {
+                            "range": [11, 11],
+                            "name": "Track 11"
+                        },
+                        {
+                            "range": [12, 12],
+                            "name": "Track 12"
+                        },
+                        {
+                            "range": [13, 13],
+                            "name": "Track 13"
+                        },
+                        {
+                            "range": [14, 14],
+                            "name": "Track 14"
+                        },
+                        {
+                            "range": [15, 15],
+                            "name": "Track 15"
+                        },
+                        {
+                            "range": [16, 16],
+                            "name": "Track 16"
+                        },
+                        {
+                            "range": [17, 17],
+                            "name": "Track 17"
+                        },
+                        {
+                            "range": [18, 18],
+                            "name": "Track 18"
+                        },
+                        {
+                            "range": [19, 19],
+                            "name": "Track 19"
+                        },
+                        {
+                            "range": [20, 20],
+                            "name": "Track 20"
+                        },
+                        {
+                            "range": [21, 255],
+                            "name": "Track x"
+                        }
+                    ]
+                },
+                "Players": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 127],
+                            "name": "Player A",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 255],
+                            "name": "Player B",
+                            "center": true
+                        }
+                    ]
+                },
+                "Control": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 0],
+                            "name": "default"
+                        },
+                        {
+                            "range": [1, 50],
+                            "name": "Stop",
+                            "center": true
+                        },
+                        {
+                            "range": [51, 100],
+                            "name": "Pause",
+                            "center": true
+                        },
+                        {
+                            "range": [101, 255],
+                            "name": "Play Track",
+                            "center": true
+                        }
+                    ]
+                },
+                "Volume": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "%"
+                        }
+                    ]
+                },
+                "Playmode": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 63],
+                            "name": "Single",
+                            "center": true
+                        },
+                        {
+                            "range": [64, 127],
+                            "name": "Repeat Track",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 191],
+                            "name": "Repeat All",
+                            "center": true
+                        },
+                        {
+                            "range": [192, 255],
+                            "name": "Random",
+                            "center": true
+                        }
+                    ]
+                },
+                "SeekPos": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "SeekPos fine": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 65535],
+                            "name": "%",
+                            "warning": "Out of range!"
+                        }
+                    ],
+                    "defaultValue": null,
+                    "highlightValue": null
+                },
+                "Seek": {
+                    "type": "Beam",
+                    "capabilities": [
+                        {
+                            "range": [0, 63],
+                            "name": "default",
+                            "center": true
+                        },
+                        {
+                            "range": [64, 127],
+                            "name": "Tracking abs",
+                            "center": true
+                        },
+                        {
+                            "range": [128, 191],
+                            "name": "reserved",
+                            "center": true
+                        },
+                        {
+                            "range": [192, 255],
+                            "name": "Seek to",
+                            "center": true
+                        }
+                    ]
+                }
+            },
+            "multiByteChannels": [
+                [
+                    "SeekPos",
+                    "SeekPos fine"
+                ]
+            ],
+            "modes": [
+                {
+                    "name": "8-channel Mode",
+                    "shortName": "8ch",
+                    "channels": [
+                        "Track",
+                        "Players",
+                        "Control",
+                        "Volume",
+                        "Playmode",
+                        "SeekPos",
+                        "SeekPos fine",
+                        "Seek"
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/formats/ecue.js
+++ b/formats/ecue.js
@@ -5,6 +5,8 @@ const path = require('path');
 
 const defaults = require(path.join(__dirname, '..', 'fixtures_defaults.js'));
 
+module.exports.defaultFileName = 'UserLibrary.xml';
+
 module.exports.export = function formatEcue(manufacturers, fixtures, localOutDir) {
     const timestamp = new Date().toISOString().replace(/T/, '#').replace(/\..+/, '');
     let str = '<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>\n';

--- a/formats/qlcplus.js
+++ b/formats/qlcplus.js
@@ -5,6 +5,8 @@ const path = require('path');
 
 const defaults = require(path.join(__dirname, '..', 'fixtures_defaults.js'));
 
+module.exports.defaultFileName = '%MANUFACTURER%-%FIXTURE%.qxf';
+
 module.exports.export = function formatQLCplus(manufacturers, fixtures, localOutDir) {
     const allowedChannelTypes = ["Intensity", "Shutter", "Speed", "Gobo", "Prism", "Pan", "Tilt", "Beam", "Effect", "Maintenance", "Nothing"];
 


### PR DESCRIPTION
closes #27 

The tests still fail because they use the old `-d` parameter instead of the new `-o`. @fxedel could you please look into this?
