### PR TITLE
New fixtures, fixed e:cue export, QLC+ import

### DIFF
--- a/fixtures.json
+++ b/fixtures.json
@@ -3,6 +3,7 @@
         "fixtures/adj.json",
         "fixtures/cameo.json",
         "fixtures/eurolite.json",
+        "fixtures/futurelight.json",
         "fixtures/gruft.json",
         "fixtures/lightmaxx.json",
         "fixtures/martin.json",

--- a/fixtures/cameo.json
+++ b/fixtures/cameo.json
@@ -1,13 +1,195 @@
 {
     "manufacturers": {
-        "Cameo": {
-            "name": "Cameo",
+        "cameo": {
+            "name": "cameo",
             "website": "http://www.cameolight.com/"
         }
     },
     "fixtures": [
         {
-            "manufacturer": "Cameo",
+            "manufacturer": "cameo",
+            "name": "Outdoor PAR Tri 12",
+            "shortName": "OutTri12",
+            "type": "Color Changer",
+            "physical": {
+                "dimensions": [203, 203, 193],
+                "weight": 3.6,
+                "power": 50,
+                "DMXconnector": "3-pin",
+                "bulb": {
+                    "type": "LED"
+                },
+                "lens": {
+                    "degreesMinMax": [25, 25]
+                },
+                "focus": {
+                    "type": "Fixed"
+                }
+            },
+            "availableChannels": {
+                "Master dimmer": {
+                    "type": "Intensity",
+                    "crossfade": true
+                },
+                "Color Macro Simple": {
+                    "type": "MultiColor",
+                    "capabilities": [
+                        {
+                            "range": [0, 31],
+                            "name": "Blackout",
+                            "color": "#000000"
+                        },
+                        {
+                            "range": [32, 63],
+                            "name": "Red",
+                            "color": "#ff0000"
+                        },
+                        {
+                            "range": [64, 95],
+                            "name": "Green",
+                            "color": "#00ff00"
+                        },
+                        {
+                            "range": [96, 127],
+                            "name": "Blue",
+                            "color": "#0000ff"
+                        },
+                        {
+                            "range": [128, 159],
+                            "name": "Yellow",
+                            "color": "#ffff00"
+                        },
+                        {
+                            "range": [160, 191],
+                            "name": "Cyan",
+                            "color": "#00ffff"
+                        },
+                        {
+                            "range": [192, 223],
+                            "name": "Magenta",
+                            "color": "#ff00ff"
+                        },
+                        {
+                            "range": [224, 255],
+                            "name": "White",
+                            "color": "#ffffff"
+                        }
+                    ]
+                },
+                "Strobe": {
+                    "type": "Strobe"
+                },
+                "Color Macro Advanced": {
+                    "type": "MultiColor",
+                    "capabilities": [
+                        {
+                            "range": [0, 4],
+                            "name": "Blackout",
+                            "color": "#000000"
+                        },
+                        {
+                            "range": [5, 15],
+                            "name": "Red",
+                            "color": "#ff0000"
+                        },
+                        {
+                            "range": [16, 26],
+                            "name": "Green",
+                            "color": "#00ff00"
+                        },
+                        {
+                            "range": [27, 37],
+                            "name": "Blue",
+                            "color": "#0000ff"
+                        },
+                        {
+                            "range": [38, 48],
+                            "name": "Yellow",
+                            "color": "#ffff00"
+                        },
+                        {
+                            "range": [49, 59],
+                            "name": "Cyan",
+                            "color": "#00ffff"
+                        },
+                        {
+                            "range": [60, 70],
+                            "name": "Magenta",
+                            "color": "#ff00ff"
+                        },
+                        {
+                            "range": [71, 80],
+                            "name": "White",
+                            "color": "#ffffff"
+                        },
+                        {
+                            "range": [81, 150],
+                            "name": "Color change"
+                        },
+                        {
+                            "range": [151, 255],
+                            "name": "Color blending"
+                        }
+                    ]
+                },
+                "Red": {
+                    "type": "SingleColor",
+                    "crossfade": true,
+                    "color": "Red"
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "crossfade": true,
+                    "color": "Green"
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "crossfade": true,
+                    "color": "Blue"
+                }
+            },
+            "modes": [
+                {
+                    "name": "2-channel Mode",
+                    "shortName": "2ch",
+                    "channels": [
+                        "Master dimmer",
+                        "Color Macro Simple"
+                    ]
+                },
+                {
+                    "name": "3-channel Mode 1",
+                    "shortName": "3ch1",
+                    "channels": [
+                        "Master dimmer",
+                        "Color Macro Advanced"
+                    ]
+                },
+                {
+                    "name": "3-channel Mode 2",
+                    "shortName": "3ch2",
+                    "channels": [
+                        "Red",
+                        "Green",
+                        "Blue"
+                    ]
+                },
+                {
+                    "name": "6-channel Mode",
+                    "shortName": "6ch",
+                    "channels": [
+                        "Master dimmer",
+                        "Strobe",
+                        "Red",
+                        "Green",
+                        "Blue",
+                        "Color Macro Advanced"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "cameo",
             "name": "Thunderwash 100 W",
             "shortName": "CLTW100W",
             "type": "Strobe",
@@ -172,7 +354,7 @@
             ]
         },
         {
-            "manufacturer": "Cameo",
+            "manufacturer": "cameo",
             "name": "Thunderwash 100 RGB",
             "shortName": "CLTW100RGB",
             "type": "Strobe",
@@ -473,7 +655,7 @@
             ]
         },
         {
-            "manufacturer": "Cameo",
+            "manufacturer": "cameo",
             "name": "Thunderwash 600 W",
             "shortName": "CLTW600W",
             "type": "Strobe",
@@ -682,7 +864,7 @@
             ]
         },
         {
-            "manufacturer": "Cameo",
+            "manufacturer": "cameo",
             "name": "Thunderwash 600 RGB",
             "shortName": "CLTW600RGB",
             "type": "Strobe",

--- a/fixtures/futurelight.json
+++ b/fixtures/futurelight.json
@@ -1,0 +1,309 @@
+{
+    "manufacturers": {
+        "Futurelight": {
+            "name": "Futurelight",
+            "website": "http://eshop.steinigke.de/futurelight/"
+        }
+    },
+    "fixtures": [
+        {
+            "manufacturer": "Futurelight",
+            "name": "PRO Slim PAR-12 HCL",
+            "shortName": "PROSlim12HCL",
+            "type": "Color Changer",
+            "physical": {
+                "dimensions": [298, 112, 323],
+                "weight": 5,
+                "power": 95,
+                "DMXconnector": "3-pin and 5-pin",
+                "bulb": {
+                    "type": "LED"
+                },
+                "lens": {
+                    "degreesMinMax": [23, 23]
+                },
+                "focus": {
+                    "type": "Fixed"
+                }
+            },
+            "availableChannels": {
+                "Dimmer": {
+                    "type": "Intensity",
+                    "crossfade": true
+                },
+                "Red": {
+                    "type": "SingleColor",
+                    "color": "Red",
+                    "crossfade": true
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "color": "Green",
+                    "crossfade": true
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "color": "Blue",
+                    "crossfade": true
+                },
+                "Amber": {
+                    "type": "SingleColor",
+                    "color": "Amber",
+                    "crossfade": true
+                },
+                "White": {
+                    "type": "SingleColor",
+                    "color": "White",
+                    "crossfade": true
+                },
+                "UV": {
+                    "type": "SingleColor",
+                    "color": "UV",
+                    "crossfade": true
+                },
+                "Strobe": {
+                    "type": "Strobe",
+                    "capabilities": [
+                        {
+                            "range": [0, 10],
+                            "name": "No function"
+                        },
+                        {
+                            "range": [11, 255],
+                            "name": "Strobe 0-100%"
+                        }
+                    ]
+                },
+                "Color Presets": {
+                    "type": "MultiColor",
+                    "capabilities": [
+                        {
+                            "range": [0, 10],
+                            "name": "No function"
+                        },
+                        {
+                            "range": [11, 30],
+                            "name": "Red 100% / Green increasing / Blue 0%"
+                        },
+                        {
+                            "range": [31, 50],
+                            "name": "Red decreasing / Green 100% / Blue 0%"
+                        },
+                        {
+                            "range": [51, 70],
+                            "name": "Red 0% / Green 100% / Blue increasing"
+                        },
+                        {
+                            "range": [71, 90],
+                            "name": "Red 0% / Green decreasing / Blue 100%"
+                        },
+                        {
+                            "range": [91, 110],
+                            "name": "Red increasing / Green 0% / Blue 100%"
+                        },
+                        {
+                            "range": [111, 130],
+                            "name": "Red 100% / Green 0% / Blue decreasing"
+                        },
+                        {
+                            "range": [131, 150],
+                            "name": "Red 100% / Green increasing / Blue increasing"
+                        },
+                        {
+                            "range": [151, 170],
+                            "name": "Red decreasing / Green decreasing / Blue 100%"
+                        },
+                        {
+                            "range": [171, 200],
+                            "name": "Red 100% / Green 100% / Blue 100% / White 100%"
+                        },
+                        {
+                            "range": [201, 205],
+                            "name": "White 1: 3200 K"
+                        },
+                        {
+                            "range": [206, 210],
+                            "name": "White 2: 3400 K"
+                        },
+                        {
+                            "range": [211, 215],
+                            "name": "White 3: 4200 K"
+                        },
+                        {
+                            "range": [216, 220],
+                            "name": "White 4: 4900 K"
+                        },
+                        {
+                            "range": [221, 225],
+                            "name": "White 5: 5600 K"
+                        },
+                        {
+                            "range": [226, 230],
+                            "name": "White 6: 5900 K"
+                        },
+                        {
+                            "range": [231, 235],
+                            "name": "White 7: 6500 K"
+                        },
+                        {
+                            "range": [236, 240],
+                            "name": "White 8: 7200 K"
+                        },
+                        {
+                            "range": [241, 245],
+                            "name": "White 9: 8000 K"
+                        },
+                        {
+                            "range": [246, 250],
+                            "name": "White 10: 8500 K"
+                        },
+                        {
+                            "range": [251, 255],
+                            "name": "White 11: 10000 K"
+                        }
+                    ]
+                },
+                "Internal Programs": {
+                    "type": "Effect",
+                    "capabilities": [
+                        {
+                            "range": [0, 10],
+                            "name": "No function"
+                        },
+                        {
+                            "range": [11, 60],
+                            "name": "Internal Program 1"
+                        },
+                        {
+                            "range": [61, 120],
+                            "name": "Internal Program 2"
+                        },
+                        {
+                            "range": [121, 180],
+                            "name": "Internal Program 3"
+                        },
+                        {
+                            "range": [181, 240],
+                            "name": "Internal Program 4"
+                        },
+                        {
+                            "range": [241, 250],
+                            "name": "Internal Program 5"
+                        },
+                        {
+                            "range": [251, 255],
+                            "name": "Music Control"
+                        }
+                    ]
+                },
+                "Program Speed / Mic Sensitivity": {
+                    "type": "Speed"
+                },
+                "Dimmer Speed": {
+                    "type": "Speed",
+                    "capabilities": [
+                        {
+                            "range": [0, 51],
+                            "name": "Control Board setting dimmer speed"
+                        },
+                        {
+                            "range": [52, 101],
+                            "name": "Neutral"
+                        },
+                        {
+                            "range": [102, 152],
+                            "name": "Dimmer Speed 1"
+                        },
+                        {
+                            "range": [153, 203],
+                            "name": "Dimmer Speed 2"
+                        },
+                        {
+                            "range": [204, 255],
+                            "name": "Dimmer Speed 3"
+                        }
+                    ]
+                },
+                "Hue": {
+                    "type": "SingleColor"
+                },
+                "Saturation": {
+                    "type": "Intensity",
+                    "crossfade": true
+                },
+                "Value / Brightness": {
+                    "type": "Intensity",
+                    "crossfade": true
+                },
+                "Intensity": {
+                    "type": "Intensity",
+                    "crossfade": true
+                }
+            },
+            "modes": [
+                {
+                    "name": "6-channel Mode",
+                    "shortName": "6ch",
+                    "channels": [
+                        "Red",
+                        "Green",
+                        "Blue",
+                        "Amber",
+                        "White",
+                        "UV"
+                    ]
+                },
+                {
+                    "name": "8-channel Mode",
+                    "shortName": "8ch",
+                    "channels": [
+                        "Red",
+                        "Green",
+                        "Blue",
+                        "Amber",
+                        "White",
+                        "UV",
+                        "Dimmer",
+                        "Strobe"
+                    ]
+                },
+                {
+                    "name": "12-channel Mode",
+                    "shortName": "12ch",
+                    "channels": [
+                        "Dimmer",
+                        "Red",
+                        "Green",
+                        "Blue",
+                        "Amber",
+                        "White",
+                        "UV",
+                        "Strobe",
+                        "Color Presets",
+                        "Internal Programs",
+                        "Program Speed / Mic Sensitivity",
+                        "Dimmer Speed"
+                    ]
+                },
+                {
+                    "name": "HSV Mode",
+                    "shortName": "HSV",
+                    "channels": [
+                        "Hue",
+                        "Saturation",
+                        "Value / Brightness"
+                    ]
+                },
+                {
+                    "name": "HSI Mode",
+                    "shortName": "HSI",
+                    "channels": [
+                        "Hue",
+                        "Saturation",
+                        "Intensity"
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/fixtures/showtec.json
+++ b/fixtures/showtec.json
@@ -258,6 +258,378 @@
         },
         {
             "manufacturer": "Showtec",
+            "name": "Light Bar RGB",
+            "shortName": "LightBar",
+            "type": "Color Changer",
+            "physical": {
+                "dimensions": [1070, 65, 88],
+                "weight": 1.68,
+                "power": 70,
+                "DMXconnector": "3-pin",
+                "bulb": {
+                    "type": "LED"
+                },
+                "lens": {
+                    "name": "Other",
+                    "degreesMinMax": [40, 40]
+                },
+                "focus": {
+                    "type": "Fixed"
+                }
+            },
+            "availableChannels": {
+                "Red": {
+                    "type": "SingleColor",
+                    "crossfade": true,
+                    "color": "Red"
+                },
+                "Green": {
+                    "type": "SingleColor",
+                    "crossfade": true,
+                    "color": "Green"
+                },
+                "Blue": {
+                    "type": "SingleColor",
+                    "crossfade": true,
+                    "color": "Blue"
+                },
+                "Dimmer": {
+                    "type": "Intensity",
+                    "crossfade": true
+                },
+                "Red 1/2": {
+                    "type": "SingleColor",
+                    "crossfade": true,
+                    "color": "Red"
+                },
+                "Green 1/2": {
+                    "type": "SingleColor",
+                    "crossfade": true,
+                    "color": "Green"
+                },
+                "Blue 1/2": {
+                    "type": "SingleColor",
+                    "crossfade": true,
+                    "color": "Blue"
+                },
+                "Red 2/2": {
+                    "type": "SingleColor",
+                    "crossfade": true,
+                    "color": "Red"
+                },
+                "Green 2/2": {
+                    "type": "SingleColor",
+                    "crossfade": true,
+                    "color": "Green"
+                },
+                "Blue 2/2": {
+                    "type": "SingleColor",
+                    "crossfade": true,
+                    "color": "Blue"
+                },
+                "Strobe": {
+                    "type": "Strobe",
+                    "capabilities": [
+                        {
+                            "range": [0, 255],
+                            "name": "0-20Hz"
+                        }
+                    ]
+                },
+                "Red 1/4": {
+                    "type": "SingleColor",
+                    "crossfade": true,
+                    "color": "Red"
+                },
+                "Green 1/4": {
+                    "type": "SingleColor",
+                    "crossfade": true,
+                    "color": "Green"
+                },
+                "Blue 1/4": {
+                    "type": "SingleColor",
+                    "crossfade": true,
+                    "color": "Blue"
+                },
+                "Red 2/4": {
+                    "type": "SingleColor",
+                    "crossfade": true,
+                    "color": "Red"
+                },
+                "Green 2/4": {
+                    "type": "SingleColor",
+                    "crossfade": true,
+                    "color": "Green"
+                },
+                "Blue 2/4": {
+                    "type": "SingleColor",
+                    "crossfade": true,
+                    "color": "Blue"
+                },
+                "Red 3/4": {
+                    "type": "SingleColor",
+                    "crossfade": true,
+                    "color": "Red"
+                },
+                "Green 3/4": {
+                    "type": "SingleColor",
+                    "crossfade": true,
+                    "color": "Green"
+                },
+                "Blue 3/4": {
+                    "type": "SingleColor",
+                    "crossfade": true,
+                    "color": "Blue"
+                },
+                "Red 4/4": {
+                    "type": "SingleColor",
+                    "crossfade": true,
+                    "color": "Red"
+                },
+                "Green 4/4": {
+                    "type": "SingleColor",
+                    "crossfade": true,
+                    "color": "Green"
+                },
+                "Blue 4/4": {
+                    "type": "SingleColor",
+                    "crossfade": true,
+                    "color": "Blue"
+                },
+                "Color Programs": {
+                    "type": "MultiColor",
+                    "capabilities": [
+                        {
+                            "range": [0, 9],
+                            "name": "No function",
+                            "color": "#000000"
+                        },
+                        {
+                            "range": [10, 19],
+                            "name": "Red",
+                            "color": "#ff0000"
+                        },
+                        {
+                            "range": [20, 29],
+                            "name": "Yellow",
+                            "color": "#ffff00"
+                        },
+                        {
+                            "range": [30, 39],
+                            "name": "Green",
+                            "color": "#00ff00"
+                        },
+                        {
+                            "range": [40, 49],
+                            "name": "Cyan",
+                            "color": "#00ffff"
+                        },
+                        {
+                            "range": [50, 59],
+                            "name": "Blue",
+                            "color": "#5500ff"
+                        },
+                        {
+                            "range": [60, 69],
+                            "name": "Purple",
+                            "color": "#aa00ff"
+                        },
+                        {
+                            "range": [70, 79],
+                            "name": "White",
+                            "color": "#ffffff"
+                        },
+                        {
+                            "range": [80, 89],
+                            "name": "Program 1"
+                        },
+                        {
+                            "range": [90, 99],
+                            "name": "Program 2"
+                        },
+                        {
+                            "range": [100, 109],
+                            "name": "Program 3"
+                        },
+                        {
+                            "range": [110, 119],
+                            "name": "Program 4"
+                        },
+                        {
+                            "range": [120, 129],
+                            "name": "Program 5"
+                        },
+                        {
+                            "range": [130, 139],
+                            "name": "Program 6"
+                        },
+                        {
+                            "range": [140, 149],
+                            "name": "Program 7"
+                        },
+                        {
+                            "range": [150, 159],
+                            "name": "Program 8"
+                        },
+                        {
+                            "range": [160, 169],
+                            "name": "Program 9"
+                        },
+                        {
+                            "range": [170, 179],
+                            "name": "Program 10"
+                        },
+                        {
+                            "range": [180, 189],
+                            "name": "Program 11"
+                        },
+                        {
+                            "range": [190, 199],
+                            "name": "Program 12"
+                        },
+                        {
+                            "range": [200, 209],
+                            "name": "Program 13"
+                        },
+                        {
+                            "range": [210, 219],
+                            "name": "Program 14"
+                        },
+                        {
+                            "range": [220, 229],
+                            "name": "Program 15"
+                        },
+                        {
+                            "range": [230, 239],
+                            "name": "Program 16"
+                        },
+                        {
+                            "range": [240, 249],
+                            "name": "Sound control "
+                        }
+                    ]
+                },
+                "Program Speed / Mic Sensitivity": {
+                    "type": "Speed"
+                },
+                "Operation Mode": {
+                    "type": "Effect",
+                    "capabilities": [
+                        {
+                            "range": [0, 9],
+                            "name": "RGB Mode"
+                        },
+                        {
+                            "range": [10, 249],
+                            "name": "Auto Program"
+                        },
+                        {
+                            "range": [250, 255],
+                            "name": "Sound control"
+                        }
+                    ]
+                }
+            },
+            "modes": [
+                {
+                    "name": "3-channel Mode",
+                    "shortName": "3ch",
+                    "channels": [
+                        "Red",
+                        "Green",
+                        "Blue"
+                    ]
+                },
+                {
+                    "name": "4-channel Mode",
+                    "shortName": "4ch",
+                    "channels": [
+                        "Red",
+                        "Green",
+                        "Blue",
+                        "Dimmer"
+                    ]
+                },
+                {
+                    "name": "8-channel Mode",
+                    "shortName": "8ch",
+                    "channels": [
+                        "Red 1/2",
+                        "Green 1/2",
+                        "Blue 1/2",
+                        "Red 2/2",
+                        "Green 2/2",
+                        "Blue 2/2",
+                        "Strobe",
+                        "Dimmer"
+                    ]
+                },
+                {
+                    "name": "14-channel Mode",
+                    "shortName": "14ch",
+                    "channels": [
+                        "Red 1/4",
+                        "Green 1/4",
+                        "Blue 1/4",
+                        "Red 2/4",
+                        "Green 2/4",
+                        "Blue 2/4",
+                        "Red 3/4",
+                        "Green 3/4",
+                        "Blue 3/4",
+                        "Red 4/4",
+                        "Green 4/4",
+                        "Blue 4/4",
+                        "Strobe",
+                        "Dimmer"
+                    ]
+                },
+                {
+                    "name": "2-channel Mode",
+                    "shortName": "2ch",
+                    "channels": [
+                        "Color Programs",
+                        "Program Speed / Mic Sensitivity"
+                    ]
+                },
+                {
+                    "name": "15-channel Mode",
+                    "shortName": "15ch",
+                    "channels": [
+                        "Operation Mode",
+                        "Dimmer",
+                        "Strobe",
+                        "Red 1/4",
+                        "Green 1/4",
+                        "Blue 1/4",
+                        "Red 2/4",
+                        "Green 2/4",
+                        "Blue 2/4",
+                        "Red 3/4",
+                        "Green 3/4",
+                        "Blue 3/4",
+                        "Red 4/4",
+                        "Green 4/4",
+                        "Blue 4/4"
+                    ]
+                },
+                {
+                    "name": "7-channel Mode",
+                    "shortName": "7ch",
+                    "channels": [
+                        "Red",
+                        "Green",
+                        "Blue",
+                        "Color Programs",
+                        "Program Speed / Mic Sensitivity",
+                        "Strobe",
+                        "Dimmer"
+                    ]
+                }
+            ]
+        },
+        {
+            "manufacturer": "Showtec",
             "name": "Phantom 50 LED Spot",
             "shortName": "Phant50",
             "type": "Moving Head",

--- a/formats/ecue.js
+++ b/formats/ecue.js
@@ -123,9 +123,12 @@ module.exports.export = function formatEcue(manufacturers, fixtures, optionsOutp
                     mode.channels[Math.max(dmxByteHigh, dmxByteLow)] = null;
                 }
 
-                const hasCapabilities = (channel.capabilities !== undefined);
+                dmxByteLow++;
+                dmxByteHigh++;
 
-                str += `                    <Channel${chType} Name="${chData.name}" DefaultValue="${chData.defaultValue}" Highlight="${chData.highlightValue}" Deflection="0" DmxByte0="${dmxByteHigh+1}" DmxByte1="${dmxByteLow+1}" Constant="${chData.constant ? 1 : 0}" Crossfade="${chData.crossfade ? 1 : 0}" Invert="${chData.invert ? 1 : 0}" Precedence="${chData.precendence}" ClassicPos="${viewPosCount++}"` + (hasCapabilities ? '' : ' /') + '>\n';
+                const hasCapabilities = (channel.capabilities && true);
+
+                str += `                    <Channel${chType} Name="${chData.name}" DefaultValue="${chData.defaultValue}" Highlight="${chData.highlightValue}" Deflection="0" DmxByte0="${dmxByteLow}" DmxByte1="${dmxByteHigh}" Constant="${chData.constant ? 1 : 0}" Crossfade="${chData.crossfade ? 1 : 0}" Invert="${chData.invert ? 1 : 0}" Precedence="${chData.precendence}" ClassicPos="${viewPosCount++}"` + (hasCapabilities ? '' : ' /') + '>\n';
 
                 if (hasCapabilities) {
                     for (const cap of channel.capabilities) {

--- a/formats/qlcplus.js
+++ b/formats/qlcplus.js
@@ -204,18 +204,20 @@ module.exports.import = function importQLCplus(str, filename) {
                         "type": channel.Group[0]._
                     };
 
+                    if (ch.type == "Intensity") {
+                        ch.crossfade = true;
+                    }
+
                     if (ch.type == "Colour") {
-                        ch.type = (channel.Capability && channel.Capability.length > 1) ? "MultiColor" : "SingleColor";
+                        ch.type = "MultiColor";
+                    }
+                    else if (channel.Colour) {
+                        ch.type = "SingleColor";
+                        ch.color = channel.Colour[0];
                     }
                     else if (channel.$.Name.toLowerCase().includes("strob")) {
                         ch.type = "Strobe";
                     }
-
-                    if (channel.Colour)
-                        ch.color = channel.Colour[0];
-
-                    if (ch.type == "Intensity")
-                        ch.crossfade = true;
 
                     if (channel.Group[0].$.Byte == "1")
                         doubleByteChannels.push([channel.$.Name]);

--- a/tests/desired_out/ecue/Eurolite-LED-KLS-801.xml
+++ b/tests/desired_out/ecue/Eurolite-LED-KLS-801.xml
@@ -4,7 +4,7 @@
         <Fixtures>
             <Manufacturer _CreationDate="2016-09-20#21:59:16" _ModifiedDate="2016-09-20#21:59:16" Header="" Name="Eurolite" Comment="" Web="http://eshop.steinigke.de/Eurolite/">
                 <Fixture _CreationDate="2016-09-20#21:59:16" _ModifiedDate="2016-09-20#21:59:16" Header="" Name="LED KLS-801 (control)" NameShort="KLS801" Comment="Compact Light Set. When Program is active, Red 1 (ch4) controls running speed, Green 1 (ch5) controls fade time. (Control Only 3-channel Mode)" AllocateDmxChannels="3" Weight="9" Power="130" DimWidth="1200" DimHeight="315" DimDepth="65">
-                    <ChannelBeam Name="Program" DefaultValue="0" Highlight="0" Deflection="0" DmxByte0="0" DmxByte1="01" Constant="0" Crossfade="0" Invert="0" Precedence="LTP" ClassicPos="1">
+                    <ChannelBeam Name="Program" DefaultValue="0" Highlight="0" Deflection="0" DmxByte0="1" DmxByte1="0" Constant="0" Crossfade="0" Invert="0" Precedence="LTP" ClassicPos="1">
                         <Range Name="Off" Start="0" End="9" AutoMenu="1" Centre="0" />
                         <Range Name="Program 1" Start="10" End="29" AutoMenu="1" Centre="0" />
                         <Range Name="Program 2" Start="30" End="49" AutoMenu="1" Centre="0" />
@@ -20,14 +20,14 @@
                         <Range Name="Automatic mode" Start="230" End="249" AutoMenu="1" Centre="0" />
                         <Range Name="Sound control" Start="250" End="255" AutoMenu="1" Centre="0" />
                     </ChannelBeam>
-                    <ChannelIntensity Name="Master" DefaultValue="0" Highlight="255" Deflection="0" DmxByte0="0" DmxByte1="11" Constant="0" Crossfade="1" Invert="0" Precedence="LTP" ClassicPos="2" />
-                    <ChannelBeam Name="Strobe" DefaultValue="0" Highlight="220" Deflection="0" DmxByte0="0" DmxByte1="21" Constant="0" Crossfade="0" Invert="0" Precedence="LTP" ClassicPos="3">
+                    <ChannelIntensity Name="Master" DefaultValue="0" Highlight="255" Deflection="0" DmxByte0="2" DmxByte1="0" Constant="0" Crossfade="1" Invert="0" Precedence="LTP" ClassicPos="2" />
+                    <ChannelBeam Name="Strobe" DefaultValue="0" Highlight="220" Deflection="0" DmxByte0="3" DmxByte1="0" Constant="0" Crossfade="0" Invert="0" Precedence="LTP" ClassicPos="3">
                         <Range Name="Strobe off" Start="0" End="9" AutoMenu="1" Centre="0" />
                         <Range Name="Strobe slow-fast" Start="10" End="255" AutoMenu="1" Centre="1" />
                     </ChannelBeam>
                 </Fixture>
                 <Fixture _CreationDate="2016-09-20#21:59:16" _ModifiedDate="2016-09-20#21:59:16" Header="" Name="LED KLS-801 (program)" NameShort="KLS801" Comment="Compact Light Set. When Program is active, Red 1 (ch4) controls running speed, Green 1 (ch5) controls fade time. (Program 5-channel Mode)" AllocateDmxChannels="5" Weight="9" Power="130" DimWidth="1200" DimHeight="315" DimDepth="65">
-                    <ChannelBeam Name="Program" DefaultValue="0" Highlight="0" Deflection="0" DmxByte0="0" DmxByte1="01" Constant="0" Crossfade="0" Invert="0" Precedence="LTP" ClassicPos="1">
+                    <ChannelBeam Name="Program" DefaultValue="0" Highlight="0" Deflection="0" DmxByte0="1" DmxByte1="0" Constant="0" Crossfade="0" Invert="0" Precedence="LTP" ClassicPos="1">
                         <Range Name="Off" Start="0" End="9" AutoMenu="1" Centre="0" />
                         <Range Name="Program 1" Start="10" End="29" AutoMenu="1" Centre="0" />
                         <Range Name="Program 2" Start="30" End="49" AutoMenu="1" Centre="0" />
@@ -43,16 +43,16 @@
                         <Range Name="Automatic mode" Start="230" End="249" AutoMenu="1" Centre="0" />
                         <Range Name="Sound control" Start="250" End="255" AutoMenu="1" Centre="0" />
                     </ChannelBeam>
-                    <ChannelIntensity Name="Master" DefaultValue="0" Highlight="255" Deflection="0" DmxByte0="0" DmxByte1="11" Constant="0" Crossfade="1" Invert="0" Precedence="LTP" ClassicPos="2" />
-                    <ChannelBeam Name="Strobe" DefaultValue="0" Highlight="220" Deflection="0" DmxByte0="0" DmxByte1="21" Constant="0" Crossfade="0" Invert="0" Precedence="LTP" ClassicPos="3">
+                    <ChannelIntensity Name="Master" DefaultValue="0" Highlight="255" Deflection="0" DmxByte0="2" DmxByte1="0" Constant="0" Crossfade="1" Invert="0" Precedence="LTP" ClassicPos="2" />
+                    <ChannelBeam Name="Strobe" DefaultValue="0" Highlight="220" Deflection="0" DmxByte0="3" DmxByte1="0" Constant="0" Crossfade="0" Invert="0" Precedence="LTP" ClassicPos="3">
                         <Range Name="Strobe off" Start="0" End="9" AutoMenu="1" Centre="0" />
                         <Range Name="Strobe slow-fast" Start="10" End="255" AutoMenu="1" Centre="1" />
                     </ChannelBeam>
-                    <ChannelBeam Name="Running Speed" DefaultValue="0" Highlight="255" Deflection="0" DmxByte0="0" DmxByte1="31" Constant="0" Crossfade="1" Invert="0" Precedence="LTP" ClassicPos="4" />
-                    <ChannelBeam Name="Fade time" DefaultValue="0" Highlight="255" Deflection="0" DmxByte0="0" DmxByte1="41" Constant="0" Crossfade="1" Invert="0" Precedence="LTP" ClassicPos="5" />
+                    <ChannelBeam Name="Running Speed" DefaultValue="0" Highlight="255" Deflection="0" DmxByte0="4" DmxByte1="0" Constant="0" Crossfade="1" Invert="0" Precedence="LTP" ClassicPos="4" />
+                    <ChannelBeam Name="Fade time" DefaultValue="0" Highlight="255" Deflection="0" DmxByte0="5" DmxByte1="0" Constant="0" Crossfade="1" Invert="0" Precedence="LTP" ClassicPos="5" />
                 </Fixture>
                 <Fixture _CreationDate="2016-09-20#21:59:16" _ModifiedDate="2016-09-20#21:59:16" Header="" Name="LED KLS-801 (combined)" NameShort="KLS801" Comment="Compact Light Set. When Program is active, Red 1 (ch4) controls running speed, Green 1 (ch5) controls fade time. (Combined 15-channel Mode)" AllocateDmxChannels="15" Weight="9" Power="130" DimWidth="1200" DimHeight="315" DimDepth="65">
-                    <ChannelBeam Name="Program" DefaultValue="0" Highlight="0" Deflection="0" DmxByte0="0" DmxByte1="01" Constant="0" Crossfade="0" Invert="0" Precedence="LTP" ClassicPos="1">
+                    <ChannelBeam Name="Program" DefaultValue="0" Highlight="0" Deflection="0" DmxByte0="1" DmxByte1="0" Constant="0" Crossfade="0" Invert="0" Precedence="LTP" ClassicPos="1">
                         <Range Name="Off" Start="0" End="9" AutoMenu="1" Centre="0" />
                         <Range Name="Program 1" Start="10" End="29" AutoMenu="1" Centre="0" />
                         <Range Name="Program 2" Start="30" End="49" AutoMenu="1" Centre="0" />
@@ -68,26 +68,26 @@
                         <Range Name="Automatic mode" Start="230" End="249" AutoMenu="1" Centre="0" />
                         <Range Name="Sound control" Start="250" End="255" AutoMenu="1" Centre="0" />
                     </ChannelBeam>
-                    <ChannelIntensity Name="Master" DefaultValue="0" Highlight="255" Deflection="0" DmxByte0="0" DmxByte1="11" Constant="0" Crossfade="1" Invert="0" Precedence="LTP" ClassicPos="2" />
-                    <ChannelBeam Name="Strobe" DefaultValue="0" Highlight="220" Deflection="0" DmxByte0="0" DmxByte1="21" Constant="0" Crossfade="0" Invert="0" Precedence="LTP" ClassicPos="3">
+                    <ChannelIntensity Name="Master" DefaultValue="0" Highlight="255" Deflection="0" DmxByte0="2" DmxByte1="0" Constant="0" Crossfade="1" Invert="0" Precedence="LTP" ClassicPos="2" />
+                    <ChannelBeam Name="Strobe" DefaultValue="0" Highlight="220" Deflection="0" DmxByte0="3" DmxByte1="0" Constant="0" Crossfade="0" Invert="0" Precedence="LTP" ClassicPos="3">
                         <Range Name="Strobe off" Start="0" End="9" AutoMenu="1" Centre="0" />
                         <Range Name="Strobe slow-fast" Start="10" End="255" AutoMenu="1" Centre="1" />
                     </ChannelBeam>
-                    <ChannelBeam Name="Red 1 / Running Speed" DefaultValue="0" Highlight="255" Deflection="0" DmxByte0="0" DmxByte1="31" Constant="0" Crossfade="1" Invert="0" Precedence="LTP" ClassicPos="4" />
-                    <ChannelBeam Name="Green 1 / Fade time" DefaultValue="0" Highlight="255" Deflection="0" DmxByte0="0" DmxByte1="41" Constant="0" Crossfade="1" Invert="0" Precedence="LTP" ClassicPos="5" />
-                    <ChannelColor Name="Blue 1" DefaultValue="0" Highlight="255" Deflection="0" DmxByte0="0" DmxByte1="51" Constant="0" Crossfade="1" Invert="0" Precedence="LTP" ClassicPos="6" />
-                    <ChannelColor Name="Red 2" DefaultValue="0" Highlight="255" Deflection="0" DmxByte0="0" DmxByte1="61" Constant="0" Crossfade="1" Invert="0" Precedence="LTP" ClassicPos="7" />
-                    <ChannelColor Name="Green 2" DefaultValue="0" Highlight="255" Deflection="0" DmxByte0="0" DmxByte1="71" Constant="0" Crossfade="1" Invert="0" Precedence="LTP" ClassicPos="8" />
-                    <ChannelColor Name="Blue 2" DefaultValue="0" Highlight="255" Deflection="0" DmxByte0="0" DmxByte1="81" Constant="0" Crossfade="1" Invert="0" Precedence="LTP" ClassicPos="9" />
-                    <ChannelColor Name="Red 3" DefaultValue="0" Highlight="255" Deflection="0" DmxByte0="0" DmxByte1="91" Constant="0" Crossfade="1" Invert="0" Precedence="LTP" ClassicPos="10" />
-                    <ChannelColor Name="Green 3" DefaultValue="0" Highlight="255" Deflection="0" DmxByte0="0" DmxByte1="101" Constant="0" Crossfade="1" Invert="0" Precedence="LTP" ClassicPos="11" />
-                    <ChannelColor Name="Blue 3" DefaultValue="0" Highlight="255" Deflection="0" DmxByte0="0" DmxByte1="111" Constant="0" Crossfade="1" Invert="0" Precedence="LTP" ClassicPos="12" />
-                    <ChannelColor Name="Red 4" DefaultValue="0" Highlight="255" Deflection="0" DmxByte0="0" DmxByte1="121" Constant="0" Crossfade="1" Invert="0" Precedence="LTP" ClassicPos="13" />
-                    <ChannelColor Name="Green 4" DefaultValue="0" Highlight="255" Deflection="0" DmxByte0="0" DmxByte1="131" Constant="0" Crossfade="1" Invert="0" Precedence="LTP" ClassicPos="14" />
-                    <ChannelColor Name="Blue 4" DefaultValue="0" Highlight="255" Deflection="0" DmxByte0="0" DmxByte1="141" Constant="0" Crossfade="1" Invert="0" Precedence="LTP" ClassicPos="15" />
+                    <ChannelBeam Name="Red 1 / Running Speed" DefaultValue="0" Highlight="255" Deflection="0" DmxByte0="4" DmxByte1="0" Constant="0" Crossfade="1" Invert="0" Precedence="LTP" ClassicPos="4" />
+                    <ChannelBeam Name="Green 1 / Fade time" DefaultValue="0" Highlight="255" Deflection="0" DmxByte0="5" DmxByte1="0" Constant="0" Crossfade="1" Invert="0" Precedence="LTP" ClassicPos="5" />
+                    <ChannelColor Name="Blue 1" DefaultValue="0" Highlight="255" Deflection="0" DmxByte0="6" DmxByte1="0" Constant="0" Crossfade="1" Invert="0" Precedence="LTP" ClassicPos="6" />
+                    <ChannelColor Name="Red 2" DefaultValue="0" Highlight="255" Deflection="0" DmxByte0="7" DmxByte1="0" Constant="0" Crossfade="1" Invert="0" Precedence="LTP" ClassicPos="7" />
+                    <ChannelColor Name="Green 2" DefaultValue="0" Highlight="255" Deflection="0" DmxByte0="8" DmxByte1="0" Constant="0" Crossfade="1" Invert="0" Precedence="LTP" ClassicPos="8" />
+                    <ChannelColor Name="Blue 2" DefaultValue="0" Highlight="255" Deflection="0" DmxByte0="9" DmxByte1="0" Constant="0" Crossfade="1" Invert="0" Precedence="LTP" ClassicPos="9" />
+                    <ChannelColor Name="Red 3" DefaultValue="0" Highlight="255" Deflection="0" DmxByte0="10" DmxByte1="0" Constant="0" Crossfade="1" Invert="0" Precedence="LTP" ClassicPos="10" />
+                    <ChannelColor Name="Green 3" DefaultValue="0" Highlight="255" Deflection="0" DmxByte0="11" DmxByte1="0" Constant="0" Crossfade="1" Invert="0" Precedence="LTP" ClassicPos="11" />
+                    <ChannelColor Name="Blue 3" DefaultValue="0" Highlight="255" Deflection="0" DmxByte0="12" DmxByte1="0" Constant="0" Crossfade="1" Invert="0" Precedence="LTP" ClassicPos="12" />
+                    <ChannelColor Name="Red 4" DefaultValue="0" Highlight="255" Deflection="0" DmxByte0="13" DmxByte1="0" Constant="0" Crossfade="1" Invert="0" Precedence="LTP" ClassicPos="13" />
+                    <ChannelColor Name="Green 4" DefaultValue="0" Highlight="255" Deflection="0" DmxByte0="14" DmxByte1="0" Constant="0" Crossfade="1" Invert="0" Precedence="LTP" ClassicPos="14" />
+                    <ChannelColor Name="Blue 4" DefaultValue="0" Highlight="255" Deflection="0" DmxByte0="15" DmxByte1="0" Constant="0" Crossfade="1" Invert="0" Precedence="LTP" ClassicPos="15" />
                 </Fixture>
                 <Fixture _CreationDate="2016-09-20#21:59:16" _ModifiedDate="2016-09-20#21:59:16" Header="" Name="LED KLS-801 (color)" NameShort="KLS801" Comment="Compact Light Set. When Program is active, Red 1 (ch4) controls running speed, Green 1 (ch5) controls fade time. (Color 15-channel Mode)" AllocateDmxChannels="15" Weight="9" Power="130" DimWidth="1200" DimHeight="315" DimDepth="65">
-                    <ChannelBeam Name="Program" DefaultValue="0" Highlight="0" Deflection="0" DmxByte0="0" DmxByte1="01" Constant="0" Crossfade="0" Invert="0" Precedence="LTP" ClassicPos="1">
+                    <ChannelBeam Name="Program" DefaultValue="0" Highlight="0" Deflection="0" DmxByte0="1" DmxByte1="0" Constant="0" Crossfade="0" Invert="0" Precedence="LTP" ClassicPos="1">
                         <Range Name="Off" Start="0" End="9" AutoMenu="1" Centre="0" />
                         <Range Name="Program 1" Start="10" End="29" AutoMenu="1" Centre="0" />
                         <Range Name="Program 2" Start="30" End="49" AutoMenu="1" Centre="0" />
@@ -103,23 +103,23 @@
                         <Range Name="Automatic mode" Start="230" End="249" AutoMenu="1" Centre="0" />
                         <Range Name="Sound control" Start="250" End="255" AutoMenu="1" Centre="0" />
                     </ChannelBeam>
-                    <ChannelIntensity Name="Master" DefaultValue="0" Highlight="255" Deflection="0" DmxByte0="0" DmxByte1="11" Constant="0" Crossfade="1" Invert="0" Precedence="LTP" ClassicPos="2" />
-                    <ChannelBeam Name="Strobe" DefaultValue="0" Highlight="220" Deflection="0" DmxByte0="0" DmxByte1="21" Constant="0" Crossfade="0" Invert="0" Precedence="LTP" ClassicPos="3">
+                    <ChannelIntensity Name="Master" DefaultValue="0" Highlight="255" Deflection="0" DmxByte0="2" DmxByte1="0" Constant="0" Crossfade="1" Invert="0" Precedence="LTP" ClassicPos="2" />
+                    <ChannelBeam Name="Strobe" DefaultValue="0" Highlight="220" Deflection="0" DmxByte0="3" DmxByte1="0" Constant="0" Crossfade="0" Invert="0" Precedence="LTP" ClassicPos="3">
                         <Range Name="Strobe off" Start="0" End="9" AutoMenu="1" Centre="0" />
                         <Range Name="Strobe slow-fast" Start="10" End="255" AutoMenu="1" Centre="1" />
                     </ChannelBeam>
-                    <ChannelColor Name="Red 1" DefaultValue="0" Highlight="255" Deflection="0" DmxByte0="0" DmxByte1="31" Constant="0" Crossfade="1" Invert="0" Precedence="LTP" ClassicPos="4" />
-                    <ChannelColor Name="Green 1" DefaultValue="0" Highlight="255" Deflection="0" DmxByte0="0" DmxByte1="41" Constant="0" Crossfade="1" Invert="0" Precedence="LTP" ClassicPos="5" />
-                    <ChannelColor Name="Blue 1" DefaultValue="0" Highlight="255" Deflection="0" DmxByte0="0" DmxByte1="51" Constant="0" Crossfade="1" Invert="0" Precedence="LTP" ClassicPos="6" />
-                    <ChannelColor Name="Red 2" DefaultValue="0" Highlight="255" Deflection="0" DmxByte0="0" DmxByte1="61" Constant="0" Crossfade="1" Invert="0" Precedence="LTP" ClassicPos="7" />
-                    <ChannelColor Name="Green 2" DefaultValue="0" Highlight="255" Deflection="0" DmxByte0="0" DmxByte1="71" Constant="0" Crossfade="1" Invert="0" Precedence="LTP" ClassicPos="8" />
-                    <ChannelColor Name="Blue 2" DefaultValue="0" Highlight="255" Deflection="0" DmxByte0="0" DmxByte1="81" Constant="0" Crossfade="1" Invert="0" Precedence="LTP" ClassicPos="9" />
-                    <ChannelColor Name="Red 3" DefaultValue="0" Highlight="255" Deflection="0" DmxByte0="0" DmxByte1="91" Constant="0" Crossfade="1" Invert="0" Precedence="LTP" ClassicPos="10" />
-                    <ChannelColor Name="Green 3" DefaultValue="0" Highlight="255" Deflection="0" DmxByte0="0" DmxByte1="101" Constant="0" Crossfade="1" Invert="0" Precedence="LTP" ClassicPos="11" />
-                    <ChannelColor Name="Blue 3" DefaultValue="0" Highlight="255" Deflection="0" DmxByte0="0" DmxByte1="111" Constant="0" Crossfade="1" Invert="0" Precedence="LTP" ClassicPos="12" />
-                    <ChannelColor Name="Red 4" DefaultValue="0" Highlight="255" Deflection="0" DmxByte0="0" DmxByte1="121" Constant="0" Crossfade="1" Invert="0" Precedence="LTP" ClassicPos="13" />
-                    <ChannelColor Name="Green 4" DefaultValue="0" Highlight="255" Deflection="0" DmxByte0="0" DmxByte1="131" Constant="0" Crossfade="1" Invert="0" Precedence="LTP" ClassicPos="14" />
-                    <ChannelColor Name="Blue 4" DefaultValue="0" Highlight="255" Deflection="0" DmxByte0="0" DmxByte1="141" Constant="0" Crossfade="1" Invert="0" Precedence="LTP" ClassicPos="15" />
+                    <ChannelColor Name="Red 1" DefaultValue="0" Highlight="255" Deflection="0" DmxByte0="4" DmxByte1="0" Constant="0" Crossfade="1" Invert="0" Precedence="LTP" ClassicPos="4" />
+                    <ChannelColor Name="Green 1" DefaultValue="0" Highlight="255" Deflection="0" DmxByte0="5" DmxByte1="0" Constant="0" Crossfade="1" Invert="0" Precedence="LTP" ClassicPos="5" />
+                    <ChannelColor Name="Blue 1" DefaultValue="0" Highlight="255" Deflection="0" DmxByte0="6" DmxByte1="0" Constant="0" Crossfade="1" Invert="0" Precedence="LTP" ClassicPos="6" />
+                    <ChannelColor Name="Red 2" DefaultValue="0" Highlight="255" Deflection="0" DmxByte0="7" DmxByte1="0" Constant="0" Crossfade="1" Invert="0" Precedence="LTP" ClassicPos="7" />
+                    <ChannelColor Name="Green 2" DefaultValue="0" Highlight="255" Deflection="0" DmxByte0="8" DmxByte1="0" Constant="0" Crossfade="1" Invert="0" Precedence="LTP" ClassicPos="8" />
+                    <ChannelColor Name="Blue 2" DefaultValue="0" Highlight="255" Deflection="0" DmxByte0="9" DmxByte1="0" Constant="0" Crossfade="1" Invert="0" Precedence="LTP" ClassicPos="9" />
+                    <ChannelColor Name="Red 3" DefaultValue="0" Highlight="255" Deflection="0" DmxByte0="10" DmxByte1="0" Constant="0" Crossfade="1" Invert="0" Precedence="LTP" ClassicPos="10" />
+                    <ChannelColor Name="Green 3" DefaultValue="0" Highlight="255" Deflection="0" DmxByte0="11" DmxByte1="0" Constant="0" Crossfade="1" Invert="0" Precedence="LTP" ClassicPos="11" />
+                    <ChannelColor Name="Blue 3" DefaultValue="0" Highlight="255" Deflection="0" DmxByte0="12" DmxByte1="0" Constant="0" Crossfade="1" Invert="0" Precedence="LTP" ClassicPos="12" />
+                    <ChannelColor Name="Red 4" DefaultValue="0" Highlight="255" Deflection="0" DmxByte0="13" DmxByte1="0" Constant="0" Crossfade="1" Invert="0" Precedence="LTP" ClassicPos="13" />
+                    <ChannelColor Name="Green 4" DefaultValue="0" Highlight="255" Deflection="0" DmxByte0="14" DmxByte1="0" Constant="0" Crossfade="1" Invert="0" Precedence="LTP" ClassicPos="14" />
+                    <ChannelColor Name="Blue 4" DefaultValue="0" Highlight="255" Deflection="0" DmxByte0="15" DmxByte1="0" Constant="0" Crossfade="1" Invert="0" Precedence="LTP" ClassicPos="15" />
                 </Fixture>
             </Manufacturer>
         </Fixtures>


### PR DESCRIPTION
New fixtures:
- cameo Outdoor PAR Tri 12
- Futurelight PRO Slim PAR-12 HCL
- Showtec Light Bar RGB

Fixed e:cue export:
- DMX channels
- Not-unique short names

Fixed QLC+ import:
- Recognize single/multi color channels correctly
